### PR TITLE
ci: inherit secrets on reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,12 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.server == 'true'
     uses: ./.github/workflows/ci_server.yml
+    secrets: inherit
   ci-cerbos:
     needs: prepare
     if: needs.prepare.outputs.cerbos == 'true'
     uses: ./.github/workflows/ci_cerbos.yml
+    secrets: inherit
   ci:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
# Why

Because to use secrets in reusable workflows (type `workflow_call`), you'll need to explicitly pass the secrets or inherit it from the parent workflow.

## Ref

* [Creating a reusable workflow, GitHub Docs](https://docs.github.com/en/enterprise-cloud@latest/actions/sharing-automations/reusing-workflows#creating-a-reusable-workflow)