### PR TITLE
chore: Change env name from REEARTH_DB to REEARTH_ACCOUNTS_DB [FLOW-BE-49]

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
-REEARTH_DB=mongodb://localhost
+REEARTH_ACCOUNTS_DB=mongodb://localhost
 REEARTH_ACCOUNTS_ORIGINS=http://localhost:3000,https://accounts.test.reearth.dev,https://*.netlify.app
 
 # cerbos

--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -19,7 +19,7 @@ const configPrefix = "reearth"
 type Config struct {
 	Port    string `default:"8090" envconfig:"PORT"`
 	Dev     bool
-	DB      string   `default:"mongodb://localhost" envconfig:"REEARTH_DB" `
+	DB      string   `default:"mongodb://localhost" envconfig:"REEARTH_ACCOUNTS_DB"`
 	Origins []string `envconfig:"REEARTH_ACCOUNTS_ORIGINS"`
 	Host    string
 


### PR DESCRIPTION
# Overview

We use reearth-accounts-db instead of reearth-db.
I thought it would be more appropriate to change the naming of the environment variables.

ref: https://github.com/eukarya-inc/infrastructure/pull/787

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings to clarify database connection references related to account management, ensuring consistent connectivity without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->