### PR TITLE
ci: fix GC secrets

### DIFF
--- a/.github/workflows/build_deploy_server.yml
+++ b/.github/workflows/build_deploy_server.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Configure docker for GCP
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/.github/workflows/run_migration.yml
+++ b/.github/workflows/run_migration.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Update Migration Job
         run: |


### PR DESCRIPTION
# Overview
This pull request updates Google Cloud authentication configuration in two GitHub Actions workflows to use new secret names for the service account and workload identity provider.

Google Cloud authentication updates:

* [`.github/workflows/build_deploy_server.yml`](diffhunk://#diff-dcc08b4108442bef22575ff750df2af6f33f847240657d33d7524eba6947607aL103-R104): Updated `service_account` and `workload_identity_provider` to use `${{ secrets.GC_SA_EMAIL }}` and `${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}` respectively.
* [`.github/workflows/run_migration.yml`](diffhunk://#diff-5dde83ed9fd857609bc998d2d6e81899438d4354460e3d46c949b12dc7c54c94L23-R24): Updated `service_account` and `workload_identity_provider` to use `${{ secrets.GC_SA_EMAIL }}` and `${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}` respectively.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo