### PR TITLE
ci: added build & deploy for dev env

### DIFF
--- a/.github/workflows/build_deploy_server_dev.yml
+++ b/.github/workflows/build_deploy_server_dev.yml
@@ -1,0 +1,124 @@
+name: build-deploy-server-dev
+on:
+  workflow_call:
+    inputs:
+      sha_short:
+        required: true
+        type: string
+      new_tag:
+        required: true
+        type: string
+      new_tag_short:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-docker-image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
+    env:
+      IMAGE_NAME: reearth/reearth-accounts-api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Determine Build Options
+        id: options
+        run: |
+          TAG="${{ inputs.new_tag_short != 'blank' && inputs.new_tag_short || '' }}"
+          NAME="${{ inputs.name }}"
+          SHA="${{ inputs.sha_short }}"
+
+          if [[ -n "$TAG" ]]; then
+            PLATFORMS="linux/amd64,linux/arm64"
+            VERSION="$TAG"
+            TAGS="$IMAGE_NAME:$TAG"
+
+            if [[ ! "$TAG" =~ '-' ]]; then
+              TAGS+=",${IMAGE_NAME}:${TAG%.*}"
+              TAGS+=",${IMAGE_NAME}:${TAG%%.*}"
+              TAGS+=",${IMAGE_NAME}:latest"
+            fi
+          else
+            PLATFORMS="linux/amd64"
+            VERSION="$SHA"
+            TAGS="$IMAGE_NAME:$NAME"
+          fi
+
+          echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image for accounts api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          platforms: ${{ steps.options.outputs.platforms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          build-args: VERSION=${{ steps.options.outputs.version }}
+          tags: ${{ steps.options.outputs.tags }}
+
+  deploy-to-cloud-run:
+    name: Deploy to Cloud Run (Nightly)
+    needs:  build-and-push-docker-image
+    runs-on: ubuntu-latest
+    if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: reearth/reearth-accounts-api:nightly
+      IMAGE_GCP: us-central1-docker.pkg.dev/reearth-dev/reearth/reearth-accounts-api:nightly
+      GCP_REGION: us-central1
+      CLOUD_RUN_SERVICE: reearth-accounts-api
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Configure docker for GCP
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Pull docker image from DockerHub
+        run: docker pull $IMAGE
+
+      - name: Tag docker image for Google Cloud Artifact Registry
+        run: docker tag $IMAGE $IMAGE_GCP
+
+      - name: Push docker image to Google Cloud Artifact Registry
+        run: docker push $IMAGE_GCP
+
+      - name: Deploy to Cloud Run for accounts api (Nightly)
+        run: |
+          gcloud run deploy $CLOUD_RUN_SERVICE \
+            --image $IMAGE_GCP \
+            --region $GCP_REGION \
+            --platform managed \
+            --quiet


### PR DESCRIPTION
# Overview
This pull request introduces a new GitHub Actions workflow to automate the build, push, and deployment process for the `reearth-accounts-api` Docker image. The workflow includes steps for building Docker images, pushing them to DockerHub and Google Cloud Artifact Registry, and deploying to Google Cloud Run for nightly builds.

### New GitHub Actions Workflow:

* Added a workflow file `.github/workflows/build_deploy_server_dev.yml` to handle the following:
  - **Build and Push Docker Image**: Builds Docker images for the `reearth-accounts-api` service, supports multi-platform builds, and pushes the images to DockerHub.
  - **Deploy to Cloud Run**: Deploys the nightly Docker image to Google Cloud Run, using Google Cloud Artifact Registry for image storage.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo