### PR TITLE
fix(server): user metadata migration

### DIFF
--- a/server/internal/infrastructure/mongo/migration/250603145155_add_metadata_user.go
+++ b/server/internal/infrastructure/mongo/migration/250603145155_add_metadata_user.go
@@ -47,7 +47,24 @@ func AddMetadataUser(ctx context.Context, c DBClient) error {
 					metadata.Website = doc.Metadata.Website
 					doc.Metadata = metadata
 				} else {
-					doc.Metadata = metadata
+					var lang, theme string
+					if doc.Lang != "" {
+						lang = doc.Lang
+						doc.Lang = ""
+					}
+
+					if doc.Theme != "" {
+						theme = doc.Theme
+						doc.Theme = ""
+					}
+
+					doc.Metadata = &mongodoc.UserMetadataDocument{
+						Description: "",
+						Lang:        lang,
+						PhotoURL:    "",
+						Theme:       theme,
+						Website:     "",
+					}
 				}
 
 				ids = append(ids, doc.ID)

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -11,5 +11,5 @@ import "github.com/reearth/reearthx/usecasex/migration"
 // Set the batch size to as large a value as possible without using up the RAM of the deployment destination.
 var migrations = migration.Migrations[DBClient]{
 	250530152219: AddMetadataWorkspace,
-	250530170708: AddMetadataUser,
+	250603145155: AddMetadataUser,
 }


### PR DESCRIPTION
# Overview
This pull request updates a MongoDB migration script to handle additional user metadata fields (`Lang` and `Theme`) and reflects the changes in the migration registration. The migration file was also renamed to reflect the updated timestamp.

### Migration Script Updates:

* [`server/internal/infrastructure/mongo/migration/250603145155_add_metadata_user.go`](diffhunk://#diff-84ed599fb793d2d0046d57ce7f367a2e2da7a703a8b9d7d01e8636af398ad328L50-R67): Modified the `AddMetadataUser` function to migrate `Lang` and `Theme` fields into the `Metadata` structure. These fields are now cleared from their original location after being moved.

### Migration Registration:

* [`server/internal/infrastructure/mongo/migration/migrations.go`](diffhunk://#diff-61fb2deaea2572553db03217eb8d46fb6664efa65b138547cfbce215e30e617fL14-R14): Updated the migration ID for `AddMetadataUser` to reflect the new timestamp (`250603145155`) and ensure the migration is registered correctly.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo