### PR TITLE
fix(server): delete userId from checkpermission schema

### DIFF
--- a/server/e2e/gql_cerbos_test.go
+++ b/server/e2e/gql_cerbos_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/reearth/reearth-accounts/internal/app"
 )
 
-func checkPermission(e *httpexpect.Expect, userId string, service string, resource string, action string) (GraphQLRequest, *httpexpect.Value) {
+func checkPermission(e *httpexpect.Expect, service string, resource string, action string) (GraphQLRequest, *httpexpect.Value) {
 	checkPermissionRequestBody := GraphQLRequest{
 		OperationName: "CheckPermission",
 		Query: `query CheckPermission($input: CheckPermissionInput!) {
@@ -18,7 +18,6 @@ func checkPermission(e *httpexpect.Expect, userId string, service string, resour
 		}`,
 		Variables: map[string]any{
 			"input": map[string]any{
-				"userId":   userId,
 				"service":  service,
 				"resource": resource,
 				"action":   action,
@@ -57,7 +56,7 @@ func TestCheckPermission(t *testing.T) {
 	}, true, baseSeederOneUser)
 
 	// check permission with no permittable
-	_, res1 := checkPermission(e, uId.String(), "service", "resource", "read")
+	_, res1 := checkPermission(e, "service", "resource", "read")
 	res1.Object().
 		Value("data").Object().
 		Value("checkPermission").Object().
@@ -68,14 +67,14 @@ func TestCheckPermission(t *testing.T) {
 	_, _, _ = updatePermittable(e, uId.String(), []string{roleId1})
 
 	// check permission with permittable
-	_, res2 := checkPermission(e, uId.String(), "service", "resource", "read")
+	_, res2 := checkPermission(e, "service", "resource", "read")
 	res2.Object().
 		Value("data").Object().
 		Value("checkPermission").Object().
 		Value("allowed").Boolean().IsTrue()
 
 	// check permission with permittable but allowed is false
-	_, res3 := checkPermission(e, uId.String(), "service", "resource", "edit")
+	_, res3 := checkPermission(e, "service", "resource", "edit")
 	res3.Object().
 		Value("data").Object().
 		Value("checkPermission").Object().

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -1392,7 +1392,6 @@ schema {
   mutation: Mutation
 }`, BuiltIn: false},
 	{Name: "../../../schemas/cerbos.graphql", Input: `input CheckPermissionInput {
-  userId: String!
   service: String!
   resource: String!
   action: String!
@@ -10563,20 +10562,13 @@ func (ec *executionContext) unmarshalInputCheckPermissionInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "service", "resource", "action"}
+	fieldsInOrder := [...]string{"service", "resource", "action"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "userId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.UserID = data
 		case "service":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
 			data, err := ec.unmarshalNString2string(ctx, v)

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -41,7 +41,6 @@ type AddUsersToWorkspacePayload struct {
 }
 
 type CheckPermissionInput struct {
-	UserID   string `json:"userId"`
 	Service  string `json:"service"`
 	Resource string `json:"resource"`
 	Action   string `json:"action"`

--- a/server/internal/adapter/gql/resolver_cerbos.go
+++ b/server/internal/adapter/gql/resolver_cerbos.go
@@ -5,16 +5,16 @@ import (
 
 	"github.com/reearth/reearth-accounts/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-accounts/internal/usecase/interfaces"
-	"github.com/reearth/reearth-accounts/pkg/user"
+	"github.com/reearth/reearthx/rerror"
 )
 
 func (r *queryResolver) CheckPermission(ctx context.Context, input gqlmodel.CheckPermissionInput) (*gqlmodel.CheckPermissionPayload, error) {
-	userId, err := user.IDFrom(input.UserID)
-	if err != nil {
-		return nil, err
+	u := getUser(ctx)
+	if u == nil {
+		return nil, rerror.ErrNotFound
 	}
 
-	res, err := usecases(ctx).Cerbos.CheckPermission(ctx, userId, interfaces.CheckPermissionParam{
+	res, err := usecases(ctx).Cerbos.CheckPermission(ctx, u.ID(), interfaces.CheckPermissionParam{
 		Service:  input.Service,
 		Resource: input.Resource,
 		Action:   input.Action,

--- a/server/schemas/cerbos.graphql
+++ b/server/schemas/cerbos.graphql
@@ -1,5 +1,4 @@
 input CheckPermissionInput {
-  userId: String!
   service: String!
   resource: String!
   action: String!


### PR DESCRIPTION
# Overview

## WHY

We no longer need to receive the user ID as input, as the middleware now handles user information retrieval.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo