### PR TITLE
feat(server): add unique index migrations scripts for workspace and user collections [VIZ-2227]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/server/internal/infrastructure/mongo/migration/250909092221_add_case_insensitive_workspace_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/250909092221_add_case_insensitive_workspace_indexes.go
@@ -1,0 +1,29 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func AddCaseInsensitiveWorkspaceIndexes(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("workspace")
+
+	aliasIndexModel := mongo.IndexModel{
+		Keys: map[string]interface{}{
+			"alias": 1,
+		},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}).SetUnique(true).SetName("alias_case_insensitive_unique"),
+	}
+
+	_, err := col.Indexes().CreateOne(ctx, aliasIndexModel)
+		if err != nil {
+		return fmt.Errorf("failed to create unique index on workspace.alias: %w", err)
+	}
+	fmt.Println("Created unique case-insensitive index on workspace.alias")
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250909092221_add_case_insensitive_workspace_indexes_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909092221_add_case_insensitive_workspace_indexes_test.go
@@ -1,0 +1,78 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddCaseInsensitiveWorkspaceIndexes_CaseInsensitiveUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the index
+	err = AddCaseInsensitiveWorkspaceIndexes(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("workspace")
+
+	// Insert first workspace with lowercase alias
+	workspace1 := mongodoc.WorkspaceDocument{
+		ID:    "workspace1",
+		Name:  "Test Workspace 1",
+		Alias: "myworkspace",
+		Email: "test1@example.com",
+	}
+	
+	_, err = col.InsertOne(ctx, workspace1)
+	assert.NoError(t, err, "First workspace should insert successfully")
+
+	// Try to insert second workspace with uppercase alias - should fail
+	workspace2 := mongodoc.WorkspaceDocument{
+		ID:    "workspace2", 
+		Name:  "Test Workspace 2",
+		Alias: "MYWORKSPACE", // Same as first but uppercase
+		Email: "test2@example.com",
+	}
+
+	_, err = col.InsertOne(ctx, workspace2)
+	assert.Error(t, err, "Second workspace with case-different alias should fail")
+	
+	// Verify it's a duplicate key error
+	if mongo.IsDuplicateKeyError(err) {
+		t.Logf("Correctly got duplicate key error: %v", err)
+	} else {
+		t.Errorf("Expected duplicate key error, got: %v", err)
+	}
+
+	// Try with mixed case - should also fail
+	workspace3 := mongodoc.WorkspaceDocument{
+		ID:    "workspace3",
+		Name:  "Test Workspace 3", 
+		Alias: "MyWorkSpace", // Mixed case version
+		Email: "test3@example.com",
+	}
+
+	_, err = col.InsertOne(ctx, workspace3)
+	assert.Error(t, err, "Third workspace with mixed case alias should also fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error")
+}

--- a/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index.go
@@ -1,0 +1,33 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func AddWorkspaceAliasMembersCompositeUniqueIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("workspace")
+
+	// Create composite unique index for alias and members
+	compositeIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "alias", Value: 1},
+			{Key: "members", Value: 1},
+		},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}).SetUnique(true).SetName("alias_members_case_insensitive_unique"),
+	}
+
+	_, err := col.Indexes().CreateOne(ctx, compositeIndexModel)
+	if err != nil {
+		return fmt.Errorf("failed to create composite unique index on workspace.alias+members: %w", err)
+	}
+	fmt.Println("Created composite unique case-insensitive index on workspace.alias+members")
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index.go
@@ -12,7 +12,6 @@ import (
 func AddWorkspaceAliasMembersCompositeUniqueIndex(ctx context.Context, c DBClient) error {
 	col := c.Database().Collection("workspace")
 
-	// Create composite unique index for alias and members
 	compositeIndexModel := mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "alias", Value: 1},

--- a/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909103955_add_composite_workspace_index_test.go
@@ -1,0 +1,87 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddWorkspaceAliasMembersCompositeUniqueIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_composite_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the composite index
+	err = AddWorkspaceAliasMembersCompositeUniqueIndex(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("workspace")
+
+	// Create sample members map
+	members1 := map[string]mongodoc.WorkspaceMemberDocument{
+		"user1": {Role: "owner", InvitedBy: "user1", Disabled: false},
+		"user2": {Role: "maintainer", InvitedBy: "user1", Disabled: false},
+	}
+
+	members2 := map[string]mongodoc.WorkspaceMemberDocument{
+		"user3": {Role: "owner", InvitedBy: "user3", Disabled: false},
+		"user4": {Role: "maintainer", InvitedBy: "user3", Disabled: false},
+	}
+
+	// Insert first workspace with lowercase alias and specific members
+	workspace1 := mongodoc.WorkspaceDocument{
+		ID:      "workspace1",
+		Name:    "Test Workspace 1",
+		Alias:   "myworkspace",
+		Email:   "test1@example.com",
+		Members: members1,
+	}
+	
+	_, err = col.InsertOne(ctx, workspace1)
+	assert.NoError(t, err, "First workspace should insert successfully")
+
+	// Try to insert workspace with same alias (different case) but different members - should succeed
+	workspace2 := mongodoc.WorkspaceDocument{
+		ID:      "workspace2",
+		Name:    "Test Workspace 2", 
+		Alias:   "MYWORKSPACE", // Same alias but different case
+		Email:   "test2@example.com",
+		Members: members2, // Different members
+	}
+
+	_, err = col.InsertOne(ctx, workspace2)
+	assert.NoError(t, err, "Workspace with same alias but different members should succeed")
+
+	// Try to insert workspace with same alias and same members - should fail
+	workspace3 := mongodoc.WorkspaceDocument{
+		ID:      "workspace3",
+		Name:    "Test Workspace 3",
+		Alias:   "MyWorkSpace", // Mixed case version
+		Email:   "test3@example.com", 
+		Members: members1, // Same members as workspace1
+	}
+
+	_, err = col.InsertOne(ctx, workspace3)
+	assert.Error(t, err, "Workspace with same alias and same members should fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error for composite index")
+
+	t.Logf("Composite index correctly prevented duplicate: %v", err)
+}

--- a/server/internal/infrastructure/mongo/migration/250909133755_add_case_insensitive_user_alias_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909133755_add_case_insensitive_user_alias_index.go
@@ -8,23 +8,22 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func AddCaseInsensitiveWorkspaceIndexes(ctx context.Context, c DBClient) error {
-	col := c.Database().Collection("workspace")
+func AddCaseInsensitiveUserAliasIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("user")
 
 	aliasIndexModel := mongo.IndexModel{
 		Keys: map[string]interface{}{
 			"alias": 1,
 		},
 		Options: options.Index().SetCollation(&options.Collation{
-			Locale:   "en",
-			Strength: 2, // Case-insensitive comparison
+			Locale: "en",
+			Strength: 2,
 		}).SetUnique(true).SetName("alias_case_insensitive_unique"),
 	}
-
 	_, err := col.Indexes().CreateOne(ctx, aliasIndexModel)
-		if err != nil {
-		return fmt.Errorf("failed to create unique index on workspace.alias: %w", err)
+	if err != nil {
+		return fmt.Errorf("failed to create unique index on user.alias: %w", err)
 	}
-	fmt.Println("Created unique case-insensitive index on workspace.alias")
+	fmt.Println("Created unique case-insensitive index on user.alias")
 	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/250909133755_add_case_insensitive_user_alias_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909133755_add_case_insensitive_user_alias_index_test.go
@@ -1,0 +1,78 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddCaseInsensitiveUserAliasIndex_CaseInsensitiveUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_user_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the index
+	err = AddCaseInsensitiveUserAliasIndex(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("user")
+
+	// Insert first user with lowercase alias
+	user1 := mongodoc.UserDocument{
+		ID:    "user1",
+		Name:  "Test User 1",
+		Alias: "testuser",
+		Email: "test1@example.com",
+	}
+	
+	_, err = col.InsertOne(ctx, user1)
+	assert.NoError(t, err, "First user should insert successfully")
+
+	// Try to insert second user with uppercase alias - should fail
+	user2 := mongodoc.UserDocument{
+		ID:    "user2", 
+		Name:  "Test User 2",
+		Alias: "TESTUSER", // Same as first but uppercase
+		Email: "test2@example.com",
+	}
+
+	_, err = col.InsertOne(ctx, user2)
+	assert.Error(t, err, "Second user with case-different alias should fail")
+	
+	// Verify it's a duplicate key error
+	if mongo.IsDuplicateKeyError(err) {
+		t.Logf("Correctly got duplicate key error: %v", err)
+	} else {
+		t.Errorf("Expected duplicate key error, got: %v", err)
+	}
+
+	// Try with mixed case - should also fail
+	user3 := mongodoc.UserDocument{
+		ID:    "user3",
+		Name:  "Test User 3", 
+		Alias: "TestUser", // Mixed case version
+		Email: "test3@example.com",
+	}
+
+	_, err = col.InsertOne(ctx, user3)
+	assert.Error(t, err, "Third user with mixed case alias should also fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error")
+}

--- a/server/internal/infrastructure/mongo/migration/250909142051_add_case_insensitive_user_email_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909142051_add_case_insensitive_user_email_index.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func AddCaseInsensitiveUserEmailIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("user")
+
+	emailIndexModel := mongo.IndexModel{
+		Keys: map[string]interface{}{
+			"email": 1,
+		},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}).SetUnique(true).SetName("email_case_insensitive_unique"),
+	}
+
+	_, err := col.Indexes().CreateOne(ctx, emailIndexModel)
+	if err != nil {
+		return fmt.Errorf("failed to create unique index on user.email: %w", err)
+	}
+	fmt.Println("Created unique case-insensitive index on user.email")
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250909142051_add_case_insensitive_user_email_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909142051_add_case_insensitive_user_email_index_test.go
@@ -1,0 +1,60 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddCaseInsensitiveUserEmailIndex_CaseInsensitiveUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_user_email_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the index
+	err = AddCaseInsensitiveUserEmailIndex(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("user")
+
+	// Insert first user with lowercase email
+	user1 := mongodoc.UserDocument{
+		ID:    "user1",
+		Name:  "Test User 1",
+		Alias: "testuser1",
+		Email: "test@example.com",
+	}
+	
+	_, err = col.InsertOne(ctx, user1)
+	assert.NoError(t, err, "First user should insert successfully")
+
+	// Try to insert second user with uppercase email - should fail
+	user2 := mongodoc.UserDocument{
+		ID:    "user2", 
+		Name:  "Test User 2",
+		Alias: "testuser2",
+		Email: "TEST@EXAMPLE.COM", // Same as first but uppercase
+	}
+
+	_, err = col.InsertOne(ctx, user2)
+	assert.Error(t, err, "Second user with case-different email should fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error")
+}

--- a/server/internal/infrastructure/mongo/migration/250909142052_add_case_insensitive_user_workspace_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909142052_add_case_insensitive_user_workspace_index.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func AddCaseInsensitiveUserWorkspaceIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("user")
+
+	indexModel := mongo.IndexModel{
+		Keys: map[string]interface{}{
+			"workspace": 1,
+		},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}).SetUnique(true).SetName("workspace_case_insensitive_unique"),
+	}
+
+	_, err := col.Indexes().CreateOne(ctx, indexModel)
+	if err != nil {
+		return fmt.Errorf("failed to create unique index on user.workspace: %w", err)
+	}
+	fmt.Println("Created unique case-insensitive index on user.workspace")
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250909142052_add_case_insensitive_user_workspace_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909142052_add_case_insensitive_user_workspace_index_test.go
@@ -1,0 +1,62 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddCaseInsensitiveUserWorkspaceIndex_CaseInsensitiveUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_user_workspace_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the index
+	err = AddCaseInsensitiveUserWorkspaceIndex(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("user")
+
+	// Insert first user with lowercase workspace
+	user1 := mongodoc.UserDocument{
+		ID:        "user1",
+		Name:      "Test User 1",
+		Alias:     "testuser1",
+		Email:     "test1@example.com",
+		Workspace: "workspace123",
+	}
+	
+	_, err = col.InsertOne(ctx, user1)
+	assert.NoError(t, err, "First user should insert successfully")
+
+	// Try to insert second user with uppercase workspace - should fail
+	user2 := mongodoc.UserDocument{
+		ID:        "user2", 
+		Name:      "Test User 2",
+		Alias:     "testuser2",
+		Email:     "test2@example.com",
+		Workspace: "WORKSPACE123", // Same as first but uppercase
+	}
+
+	_, err = col.InsertOne(ctx, user2)
+	assert.Error(t, err, "Second user with case-different workspace should fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error")
+}

--- a/server/internal/infrastructure/mongo/migration/250909142053_add_case_insensitive_user_subs_index.go
+++ b/server/internal/infrastructure/mongo/migration/250909142053_add_case_insensitive_user_subs_index.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func AddCaseInsensitiveUserSubsIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("user")
+
+	subsIndexModel := mongo.IndexModel{
+		Keys: map[string]interface{}{
+			"subs": 1,
+		},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}).SetUnique(true).SetName("subs_case_insensitive_unique"),
+	}
+
+	_, err := col.Indexes().CreateOne(ctx, subsIndexModel)
+	if err != nil {
+		return fmt.Errorf("failed to create unique index on user.subs: %w", err)
+	}
+	fmt.Println("Created unique case-insensitive index on user.subs")
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250909142053_add_case_insensitive_user_subs_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/250909142053_add_case_insensitive_user_subs_index_test.go
@@ -1,0 +1,62 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestAddCaseInsensitiveUserSubsIndex_CaseInsensitiveUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	
+	// Connect to test database
+	client, err := mongo.Connect(ctx, nil) 
+	if err != nil {
+		t.Skipf("Could not connect to MongoDB: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	testDB := client.Database("test_user_subs_migration")
+	defer testDB.Drop(ctx)
+
+	mongoxClient := mongox.NewClientWithDatabase(testDB)
+
+	// Run the migration to create the index
+	err = AddCaseInsensitiveUserSubsIndex(ctx, mongoxClient)
+	assert.NoError(t, err)
+
+	col := testDB.Collection("user")
+
+	// Insert first user with lowercase sub
+	user1 := mongodoc.UserDocument{
+		ID:    "user1",
+		Name:  "Test User 1",
+		Alias: "testuser1",
+		Email: "test1@example.com",
+		Subs:  []string{"auth0|abc123"},
+	}
+	
+	_, err = col.InsertOne(ctx, user1)
+	assert.NoError(t, err, "First user should insert successfully")
+
+	// Try to insert second user with uppercase sub - should fail
+	user2 := mongodoc.UserDocument{
+		ID:    "user2", 
+		Name:  "Test User 2",
+		Alias: "testuser2",
+		Email: "test2@example.com",
+		Subs:  []string{"AUTH0|ABC123"}, // Same as first but uppercase
+	}
+
+	_, err = col.InsertOne(ctx, user2)
+	assert.Error(t, err, "Second user with case-different sub should fail")
+	assert.True(t, mongo.IsDuplicateKeyError(err), "Should be duplicate key error")
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -10,13 +10,17 @@ import "github.com/reearth/reearthx/usecasex/migration"
 // If the migration takes too long, the deployment may fail in a serverless environment.
 // Set the batch size to as large a value as possible without using up the RAM of the deployment destination.
 var migrations = migration.Migrations[DBClient]{
-	250617171055: AddMetadataWorkspace,
-	250617171056: AddMetadataUser,
-	250617171057: AddMetadataWorkspaceV2,
-	250617171058: AddMetadataUserV2,
-	250724212700: AddMetadataUserV3,
-	250725020842: ConvertNonValidUserAlias,
-	250725020843: ConvertNonValidWorkspaceAlias,
-	250909092221: AddCaseInsensitiveWorkspaceIndexes,
-	250909103955: AddWorkspaceAliasMembersCompositeUniqueIndex,
+  250617171055: AddMetadataWorkspace,
+  250617171056: AddMetadataUser,
+  250617171057: AddMetadataWorkspaceV2,
+  250617171058: AddMetadataUserV2,
+  250724212700: AddMetadataUserV3,
+  250725020842: ConvertNonValidUserAlias,
+  250725020843: ConvertNonValidWorkspaceAlias,
+  250909092221: AddCaseInsensitiveWorkspaceIndexes,
+  250909103955: AddWorkspaceAliasMembersCompositeUniqueIndex,
+  250909133755: AddCaseInsensitiveUserAliasIndex,
+  250909142051: AddCaseInsensitiveUserEmailIndex,
+  250909142052: AddCaseInsensitiveUserWorkspaceIndex,
+  250909142053: AddCaseInsensitiveUserSubsIndex,
 }

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -18,4 +18,5 @@ var migrations = migration.Migrations[DBClient]{
 	250725020842: ConvertNonValidUserAlias,
 	250725020843: ConvertNonValidWorkspaceAlias,
 	250909092221: AddCaseInsensitiveWorkspaceIndexes,
+	250909103955: AddWorkspaceAliasMembersCompositeUniqueIndex,
 }

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -17,4 +17,5 @@ var migrations = migration.Migrations[DBClient]{
 	250724212700: AddMetadataUserV3,
 	250725020842: ConvertNonValidUserAlias,
 	250725020843: ConvertNonValidWorkspaceAlias,
+	250909092221: AddCaseInsensitiveWorkspaceIndexes,
 }


### PR DESCRIPTION
 Adds migration scripts and tests for the following indices with case insensitivity applied:
 - unique index for `alias` and composite unique index for `alias` and `members` in `workspace` collection
 - unique index for `alias`, `email`, `workspace` and `subs` fields in `user` collection
 