### PR TITLE
fix(server): improve OIDC signup logic by handling nil auth info and using input values

### DIFF
--- a/server/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/internal/adapter/gql/resolver_mutation_user.go
@@ -78,9 +78,6 @@ func (r *mutationResolver) Signup(ctx context.Context, input gqlmodel.SignupInpu
 
 func (r *mutationResolver) SignupOidc(ctx context.Context, input gqlmodel.SignupOIDCInput) (*gqlmodel.UserPayload, error) {
 	au := adapter.GetAuthInfo(ctx)
-	if au == nil {
-		return nil, interfaces.ErrOperationDenied
-	}
 
 	name := ""
 	if input.Name != nil {
@@ -90,14 +87,27 @@ func (r *mutationResolver) SignupOidc(ctx context.Context, input gqlmodel.Signup
 	if input.Email != nil {
 		email = *input.Email
 	}
+	sub := ""
+	if input.Sub != nil {
+		sub = *input.Sub
+	}
+	accessToken := ""
+	if au != nil && au.Token != "" {
+		accessToken = au.Token
+	}
+	iss := ""
+	if au != nil && au.Iss != "" {
+		iss = au.Iss
+	}
+
 	var lang language.Tag
 	if input.Lang != nil {
 		lang = language.Make(*input.Lang)
 	}
 	u, err := usecases(ctx).User.SignupOIDC(ctx, interfaces.SignupOIDCParam{
-		Sub:         au.Sub,
-		AccessToken: au.Token,
-		Issuer:      au.Iss,
+		Sub:         sub,
+		AccessToken: accessToken,
+		Issuer:      iss,
 		Email:       email,
 		Name:        name,
 		Secret:      input.Secret,


### PR DESCRIPTION
# Overview
This pull request updates the OIDC signup mutation resolver to improve how user authentication information is handled, particularly when some fields may be missing from the context or input. The main change is to make the resolver more robust by safely extracting OIDC parameters from both the input and the authentication context.

**Improvements to OIDC signup mutation:**

* Removed the requirement for authentication info (`au`) to be present in the context at the start of the `SignupOidc` resolver, allowing the function to proceed even if `au` is `nil`.
* Added logic to extract `sub` from the input if provided, and to safely retrieve `accessToken` and `iss` from the authentication context only if they are present, defaulting to empty strings otherwise. This makes the resolver more flexible and prevents potential panics or errors when fields are missing.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo