### PR TITLE
feat(server): add findbyids to auth bypass list

### DIFF
--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -63,6 +63,7 @@ func isBypassed(req *http.Request) bool {
 		"signup(",
 		"signupoidc(",
 		"findbyid(",
+		"findbyids(",
 		"findbyalias(",
 		"createverification(",
 		"authconfig",


### PR DESCRIPTION
# Overview

## What I've done
- Added `findbyids(` to the authentication bypass list in `internal/app/auth.go`
- This allows unauthenticated access to the `findbyids` GraphQL query for batch user lookups

## What I haven't done
- N/A

## How I tested
- Verified the change is consistent with the existing `findbyid(` bypass pattern

## Which point I want you to review particularly
- Confirm that `findbyids` should be publicly accessible without authentication

## Memo
🤖 Generated with [Claude Code](https://claude.com/claude-code)