### PR TITLE
revert: remove findbyids from auth bypass list

### DIFF
--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -63,7 +63,6 @@ func isBypassed(req *http.Request) bool {
 		"signup(",
 		"signupoidc(",
 		"findbyid(",
-		"findbyids(",
 		"findbyalias(",
 		"createverification(",
 		"authconfig",


### PR DESCRIPTION
## What
Reverts commit 79eb5b6 (`feat(server): add findbyids to auth bypass list (#218)`).

## Why
Removes `findbyids(` from the authentication bypass list in `server/internal/app/auth.go`.

## Changed
- `server/internal/app/auth.go` — removed `findbyids(` from bypass list