### PR TITLE
feat(server): add findByIDs to auth bypass and simplify workspace fetch

### DIFF
--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -1977,6 +1977,7 @@ type DeleteWorkspacePayload {
     workspaceId: ID!
 }
 
+# TODO: rename it to findWorkspace** as a prefix to avoid conflict with other entities
 extend type Query {
     findByID(id: ID!): Workspace!
     findByIDs(ids: [ID!]!): [Workspace!]!

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -63,6 +63,7 @@ func isBypassed(req *http.Request) bool {
 		"signup(",
 		"signupoidc(",
 		"findbyid(",
+		"findbyids(",
 		"findbyalias(",
 		"createverification(",
 		"authconfig",

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -47,8 +47,7 @@ func NewWorkspace(r *repo.Container, enforceMemberCount WorkspaceMemberCountEnfo
 }
 
 func (i *Workspace) Fetch(ctx context.Context, ids workspace.IDList, operator *workspace.Operator) (workspace.List, error) {
-	res, err := i.repos.Workspace.FindByIDs(ctx, ids)
-	return filterWorkspaces(res, operator, err, false, true)
+	return i.repos.Workspace.FindByIDs(ctx, ids)
 }
 
 func (i *Workspace) FetchByID(ctx context.Context, id workspace.ID) (*workspace.Workspace, error) {

--- a/server/schemas/workspace.graphql
+++ b/server/schemas/workspace.graphql
@@ -159,6 +159,7 @@ type DeleteWorkspacePayload {
     workspaceId: ID!
 }
 
+# TODO: rename it to findWorkspace** as a prefix to avoid conflict with other entities
 extend type Query {
     findByID(id: ID!): Workspace!
     findByIDs(ids: [ID!]!): [Workspace!]!


### PR DESCRIPTION
## Why

Other services need to fetch workspace information via GraphQL without requiring authentication. This change enables the `findByIDs` query to work without auth tokens, similar to other public queries like `findByID` and `findByAlias`.

Additionally, the workspace fetch logic was simplified by removing unnecessary filtering, as callers should receive all requested workspaces directly.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)