### PR TITLE
fix(server): allow non-owner users to change their own workspace role

### DIFF
--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -433,7 +433,7 @@ func (i *Workspace) RemoveIntegrations(ctx context.Context, wId workspace.ID, iI
 	})
 }
 
-func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u workspace.UserID, role role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
+func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u workspace.UserID, r role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
 	if operator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
 	}
@@ -448,16 +448,16 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		if u == *operator.User {
+		if u == *operator.User && ws.Members().UserRole(u) == role.RoleOwner {
 			return nil, interfaces.ErrCannotChangeOwnerRole
 		}
 
-		err = ws.Members().UpdateUserRole(u, role)
+		err = ws.Members().UpdateUserRole(u, r)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := i.updatePermittable(ctx, u, ws.ID(), role); err != nil {
+		if err := i.updatePermittable(ctx, u, ws.ID(), r); err != nil {
 			return nil, err
 		}
 

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -433,7 +433,7 @@ func (i *Workspace) RemoveIntegrations(ctx context.Context, wId workspace.ID, iI
 	})
 }
 
-func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u workspace.UserID, r role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
+func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u workspace.UserID, newRole role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
 	if operator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
 	}
@@ -448,16 +448,16 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		if u == *operator.User && ws.Members().UserRole(u) == role.RoleOwner {
+		if u == *operator.User && ws.Members().UserRole(u) == role.RoleOwner && newRole != role.RoleOwner {
 			return nil, interfaces.ErrCannotChangeOwnerRole
 		}
 
-		err = ws.Members().UpdateUserRole(u, r)
+		err = ws.Members().UpdateUserRole(u, newRole)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := i.updatePermittable(ctx, u, ws.ID(), r); err != nil {
+		if err := i.updatePermittable(ctx, u, ws.ID(), newRole); err != nil {
 			return nil, err
 		}
 

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -1521,11 +1521,13 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 	w4 := workspace.New().ID(id4).Name("W4").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
 	id5 := id.NewWorkspaceID()
 	w5 := workspace.New().ID(id5).Name("W5").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
+	id6 := id.NewWorkspaceID()
+	w6 := workspace.New().ID(id6).Name("W6").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
 
 	op := &workspace.Operator{
 		User:               &userID,
 		ReadableWorkspaces: []workspace.ID{id1, id2},
-		OwningWorkspaces:   []workspace.ID{id1, id2, id3, id4, id5},
+		OwningWorkspaces:   []workspace.ID{id1, id2, id3, id4, id5, id6},
 	}
 
 	tests := []struct {
@@ -1634,7 +1636,7 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 		},
 		{
 			name:       "Non-owner can change own role",
-			seeds:      workspace.List{w2},
+			seeds:      workspace.List{w6},
 			usersSeeds: []*user.User{u},
 			args: struct {
 				wId      workspace.ID
@@ -1642,13 +1644,13 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 				role     role.RoleType
 				operator *workspace.Operator
 			}{
-				wId:  id2,
+				wId:  id6,
 				uId:  u.ID(),
 				role: role.RoleWriter,
 				operator: &workspace.Operator{
 					User:               lo.ToPtr(u.ID()),
-					ReadableWorkspaces: []workspace.ID{id2},
-					WritableWorkspaces: []workspace.ID{id2},
+					ReadableWorkspaces: []workspace.ID{id6},
+					WritableWorkspaces: []workspace.ID{id6},
 				},
 			},
 			wantErr: nil,

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -1517,11 +1517,15 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 	w2 := workspace.New().ID(id2).Name("W2").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
 	id3 := id.NewWorkspaceID()
 	w3 := workspace.New().ID(id3).Name("W3").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}}).Personal(true).MustBuild()
+	id4 := id.NewWorkspaceID()
+	w4 := workspace.New().ID(id4).Name("W4").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
+	id5 := id.NewWorkspaceID()
+	w5 := workspace.New().ID(id5).Name("W5").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
 
 	op := &workspace.Operator{
 		User:               &userID,
 		ReadableWorkspaces: []workspace.ID{id1, id2},
-		OwningWorkspaces:   []workspace.ID{id1, id2, id3},
+		OwningWorkspaces:   []workspace.ID{id1, id2, id3, id4, id5},
 	}
 
 	tests := []struct {
@@ -1591,6 +1595,64 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 			},
 			wantErr: workspace.ErrCannotModifyPersonalWorkspace,
 			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}}, map[id.IntegrationID]workspace.Member{}, true),
+		},
+		{
+			name:       "Owner cannot change own role",
+			seeds:      workspace.List{w4},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				uId      user.ID
+				role     role.RoleType
+				operator *workspace.Operator
+			}{
+				wId:      id4,
+				uId:      userID,
+				role:     role.RoleReader,
+				operator: op,
+			},
+			wantErr: interfaces.ErrCannotChangeOwnerRole,
+			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}, nil, false),
+		},
+		{
+			name:       "Owner can set own role to owner",
+			seeds:      workspace.List{w5},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				uId      user.ID
+				role     role.RoleType
+				operator *workspace.Operator
+			}{
+				wId:      id5,
+				uId:      userID,
+				role:     role.RoleOwner,
+				operator: op,
+			},
+			wantErr: nil,
+			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}, nil, false),
+		},
+		{
+			name:       "Non-owner can change own role",
+			seeds:      workspace.List{w2},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				uId      user.ID
+				role     role.RoleType
+				operator *workspace.Operator
+			}{
+				wId:  id2,
+				uId:  u.ID(),
+				role: role.RoleWriter,
+				operator: &workspace.Operator{
+					User:               lo.ToPtr(u.ID()),
+					ReadableWorkspaces: []workspace.ID{id2},
+					WritableWorkspaces: []workspace.ID{id2},
+				},
+			},
+			wantErr: nil,
+			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleWriter}}, nil, false),
 		},
 		{
 			name: "mock error",


### PR DESCRIPTION
## Why

`UpdateUserMember` was blocking **all** users from changing their own workspace role, not just owners. The condition `u == *operator.User` returned `ErrCannotChangeOwnerRole` regardless of the user's current role.

This meant admin/writer/reader users could not change their own role in a workspace, which is overly restrictive. Only owners should be prevented from downgrading themselves to avoid losing workspace ownership.

### Fix

Changed the condition to also check that the user's current role is `owner`:

```go
// Before
if u == *operator.User {

// After
if u == *operator.User && ws.Members().UserRole(u) == role.RoleOwner {
```

Also renamed the `role` parameter to `r` to avoid shadowing the `role` package import.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values