### PR TITLE
fix(server): prevent auth bypass via GraphQL query injection

### DIFF
--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -39,6 +39,13 @@ const (
 	maxBypassBodySize = 100 * 1024 // 100 KB
 )
 
+// readCloser combines an io.Reader and an io.Closer so that
+// Close() is delegated to the original request body.
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 type graphqlRequest struct {
 	Query         string         `json:"query"`
 	OperationName string         `json:"operationName"`
@@ -65,14 +72,18 @@ func isBypassed(req *http.Request) bool {
 
 	// Read up to maxBypassBodySize+1 bytes to detect oversized bodies
 	// without allocating unbounded memory.
-	lr := io.LimitReader(req.Body, maxBypassBodySize+1)
+	origBody := req.Body
+	lr := io.LimitReader(origBody, maxBypassBodySize+1)
 	body, err := io.ReadAll(lr)
 	if err != nil {
 		return false
 	}
 	// Restore full body for downstream handlers: concatenate what we read
-	// with any remaining unread portion of the original body.
-	req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), req.Body))
+	// with any remaining unread portion, preserving the original Close().
+	req.Body = readCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), origBody),
+		Closer: origBody,
+	}
 
 	if len(body) > maxBypassBodySize {
 		return false

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -18,6 +18,8 @@ import (
 	"github.com/reearth/reearthx/appx"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
 )
 
 const (
@@ -37,6 +39,20 @@ type graphqlRequest struct {
 	Variables     map[string]any `json:"variables"`
 }
 
+// bypassedFields is the set of top-level GraphQL field names that are
+// allowed without authentication. Field names must be lowercase.
+var bypassedFields = map[string]struct{}{
+	"signup":                        {},
+	"signupoidc":                    {},
+	"createverification":            {},
+	"findbyid":                      {},
+	"findbyids":                     {},
+	"findbyalias":                   {},
+	"finduserbyalias":               {},
+	"findusersbyidswithpagination":  {},
+	"authconfig":                    {},
+}
+
 func isBypassed(req *http.Request) bool {
 	if req.Method != http.MethodPost {
 		return false
@@ -53,30 +69,30 @@ func isBypassed(req *http.Request) bool {
 		return false
 	}
 
-	query := strings.ToLower(gqlReq.Query)
-	query = strings.ReplaceAll(query, " ", "")
-	query = strings.ReplaceAll(query, "\n", "")
-	query = strings.ReplaceAll(query, "\t", "")
-	query = strings.ReplaceAll(query, "\r", "")
-
-	list := []string{
-		"signup(",
-		"signupoidc(",
-		"findbyid(",
-		"findbyids(",
-		"findbyalias(",
-		"createverification(",
-		"authconfig",
-		"findusersbyidswithpagination(",
+	if gqlReq.Query == "" {
+		return false
 	}
 
-	for _, q := range list {
-		if strings.Contains(query, q) {
-			return true
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: gqlReq.Query})
+	if gqlErr != nil {
+		return false
+	}
+
+	fieldCount := 0
+	for _, op := range doc.Operations {
+		for _, sel := range op.SelectionSet {
+			field, ok := sel.(*ast.Field)
+			if !ok {
+				return false
+			}
+			if _, allowed := bypassedFields[strings.ToLower(field.Name)]; !allowed {
+				return false
+			}
+			fieldCount++
 		}
 	}
 
-	return false
+	return fieldCount > 0
 }
 
 func canUseDebugHeaders(req *http.Request, cfg *ServerConfig) bool {

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -31,6 +31,12 @@ const (
 	debugAuthEmailHeader = "X-Reearth-Debug-Auth-Email"
 	FIXED_MOCK_USERNAME  = "Demo User"
 	FIXED_MOCK_USERMAILE = "demo@example.com"
+
+	// maxBypassBodySize is the maximum request body size (in bytes) that
+	// isBypassed will read. Bypass-eligible operations (signup, findByID, etc.)
+	// are small by nature; rejecting oversized bodies before parsing prevents
+	// unauthenticated callers from forcing large allocations.
+	maxBypassBodySize = 100 * 1024 // 100 KB
 )
 
 type graphqlRequest struct {
@@ -57,11 +63,20 @@ func isBypassed(req *http.Request) bool {
 		return false
 	}
 
-	body, err := io.ReadAll(req.Body)
+	// Read up to maxBypassBodySize+1 bytes to detect oversized bodies
+	// without allocating unbounded memory.
+	lr := io.LimitReader(req.Body, maxBypassBodySize+1)
+	body, err := io.ReadAll(lr)
 	if err != nil {
 		return false
 	}
-	req.Body = io.NopCloser(bytes.NewReader(body))
+	// Restore full body for downstream handlers: concatenate what we read
+	// with any remaining unread portion of the original body.
+	req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), req.Body))
+
+	if len(body) > maxBypassBodySize {
+		return false
+	}
 
 	var gqlReq graphqlRequest
 	if err := json.Unmarshal(body, &gqlReq); err != nil {

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -118,26 +118,43 @@ func isBypassed(req *http.Request) bool {
 		return false
 	}
 
-	// A GraphQL document can contain multiple named operations (e.g. query A {...} mutation B {...}).
-	// Only one is executed per request, selected by the operationName field. We iterate all
-	// operations and require every top-level field across all of them to be in the bypass list.
-	// This is intentionally conservative: even though only one operation runs, we reject the
-	// request if any operation contains a non-bypassed field.
-	fieldCount := 0
-	for _, op := range doc.Operations {
-		for _, sel := range op.SelectionSet {
-			field, ok := sel.(*ast.Field)
-			if !ok {
-				return false
+	// Select the operation to inspect. In GraphQL, when multiple operations
+	// are present, only the one matching operationName is executed.
+	var targetOp *ast.OperationDefinition
+	if gqlReq.OperationName != "" {
+		for _, op := range doc.Operations {
+			if op.Name == gqlReq.OperationName {
+				targetOp = op
+				break
 			}
-			if _, allowed := bypassedFields[strings.ToLower(field.Name)]; !allowed {
-				return false
-			}
-			fieldCount++
+		}
+		if targetOp == nil {
+			return false
+		}
+	} else {
+		// When operationName is not set, GraphQL only allows a single operation.
+		if len(doc.Operations) != 1 {
+			return false
+		}
+		targetOp = doc.Operations[0]
+	}
+
+	// Require every top-level field in the selected operation to be in the
+	// bypass allowlist.
+	if len(targetOp.SelectionSet) == 0 {
+		return false
+	}
+	for _, sel := range targetOp.SelectionSet {
+		field, ok := sel.(*ast.Field)
+		if !ok {
+			return false
+		}
+		if _, allowed := bypassedFields[strings.ToLower(field.Name)]; !allowed {
+			return false
 		}
 	}
 
-	return fieldCount > 0
+	return true
 }
 
 func canUseDebugHeaders(req *http.Request, cfg *ServerConfig) bool {

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -78,6 +78,11 @@ func isBypassed(req *http.Request) bool {
 		return false
 	}
 
+	// A GraphQL document can contain multiple named operations (e.g. query A {...} mutation B {...}).
+	// Only one is executed per request, selected by the operationName field. We iterate all
+	// operations and require every top-level field across all of them to be in the bypass list.
+	// This is intentionally conservative: even though only one operation runs, we reject the
+	// request if any operation contains a non-bypassed field.
 	fieldCount := 0
 	for _, op := range doc.Operations {
 		for _, sel := range op.SelectionSet {

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -42,15 +42,14 @@ type graphqlRequest struct {
 // bypassedFields is the set of top-level GraphQL field names that are
 // allowed without authentication. Field names must be lowercase.
 var bypassedFields = map[string]struct{}{
-	"signup":                        {},
-	"signupoidc":                    {},
-	"createverification":            {},
-	"findbyid":                      {},
-	"findbyids":                     {},
-	"findbyalias":                   {},
-	"finduserbyalias":               {},
-	"findusersbyidswithpagination":  {},
-	"authconfig":                    {},
+	"authconfig":                   {},
+	"createverification":           {},
+	"findbyalias":                  {},
+	"findbyid":                     {},
+	"findbyids":                    {},
+	"findusersbyidswithpagination": {},
+	"signup":                       {},
+	"signupoidc":                   {},
 }
 
 func isBypassed(req *http.Request) bool {
@@ -70,6 +69,21 @@ func isBypassed(req *http.Request) bool {
 	}
 
 	if gqlReq.Query == "" {
+		return false
+	}
+
+	// Cheap prefilter: skip AST parsing if the raw query doesn't contain
+	// any of the bypassed field names. This avoids parsing overhead for
+	// the majority of authenticated requests.
+	queryLower := strings.ToLower(gqlReq.Query)
+	hasCandidate := false
+	for field := range bypassedFields {
+		if strings.Contains(queryLower, field) {
+			hasCandidate = true
+			break
+		}
+	}
+	if !hasCandidate {
 		return false
 	}
 

--- a/server/internal/app/auth_signup_test.go
+++ b/server/internal/app/auth_signup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,5 +183,16 @@ func TestIsBypassed(t *testing.T) {
 			result := isBypassed(req)
 			assert.False(t, result)
 		})
+	})
+
+	t.Run("should reject oversized request body", func(t *testing.T) {
+		// Build a body that exceeds maxBypassBodySize (100 KB)
+		padding := strings.Repeat("x", maxBypassBodySize+1)
+		body := `{"query":"mutation { signup(input: {}) { user { id } } }", "extra":"` + padding + `"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.False(t, result)
 	})
 }

--- a/server/internal/app/auth_signup_test.go
+++ b/server/internal/app/auth_signup_test.go
@@ -185,6 +185,44 @@ func TestIsBypassed(t *testing.T) {
 		})
 	})
 
+	t.Run("should bypass only the selected operation via operationName", func(t *testing.T) {
+		t.Run("operationName selects bypassed operation", func(t *testing.T) {
+			body := `{"query":"query Allowed { signup(input: {}) { user { id } } } query Protected { me { id } }", "operationName":"Allowed"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			result := isBypassed(req)
+			assert.True(t, result)
+		})
+
+		t.Run("operationName selects protected operation", func(t *testing.T) {
+			body := `{"query":"query Allowed { signup(input: {}) { user { id } } } query Protected { me { id } }", "operationName":"Protected"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			result := isBypassed(req)
+			assert.False(t, result)
+		})
+
+		t.Run("operationName not found in document", func(t *testing.T) {
+			body := `{"query":"query A { signup(input: {}) { user { id } } }", "operationName":"NonExistent"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			result := isBypassed(req)
+			assert.False(t, result)
+		})
+
+		t.Run("multiple operations without operationName is rejected", func(t *testing.T) {
+			body := `{"query":"query A { signup(input: {}) { user { id } } } query B { findByID(id: \"x\") { id } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			result := isBypassed(req)
+			assert.False(t, result)
+		})
+	})
+
 	t.Run("should reject oversized request body", func(t *testing.T) {
 		// Build a body that exceeds maxBypassBodySize (100 KB)
 		padding := strings.Repeat("x", maxBypassBodySize+1)

--- a/server/internal/app/auth_signup_test.go
+++ b/server/internal/app/auth_signup_test.go
@@ -93,6 +93,51 @@ func TestIsBypassed(t *testing.T) {
 		})
 	})
 
+	t.Run("should reject bypass keyword injection via comment", func(t *testing.T) {
+		body := `{"query":"# signup(\nmutation { updatePermittable(input: {}) { permittable { id } } }"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.False(t, result)
+	})
+
+	t.Run("should reject bypass keyword in operation name", func(t *testing.T) {
+		body := `{"query":"mutation signup { updatePermittable(input: {}) { permittable { id } } }"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.False(t, result)
+	})
+
+	t.Run("should reject bypass keyword as field alias", func(t *testing.T) {
+		body := `{"query":"mutation { signup: updatePermittable(input: {}) { permittable { id } } }"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.False(t, result)
+	})
+
+	t.Run("should reject mixed bypassed and protected fields", func(t *testing.T) {
+		body := `{"query":"mutation { signup(input: {}) { user { id } } updatePermittable(input: {}) { permittable { id } } }"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.False(t, result)
+	})
+
+	t.Run("should allow multiple bypassed fields", func(t *testing.T) {
+		body := `{"query":"query { authConfig { clientId } findByID(id: \"abc\") { id } }"}`
+		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+		assert.NoError(t, err)
+
+		result := isBypassed(req)
+		assert.True(t, result)
+	})
+
 	t.Run("should not detect non-signup operations", func(t *testing.T) {
 		t.Run("other mutation", func(t *testing.T) {
 			body := `{"query":"mutation { updateMe(input: $input) { me { id } } }"}`

--- a/server/internal/app/auth_signup_test.go
+++ b/server/internal/app/auth_signup_test.go
@@ -66,7 +66,7 @@ func TestIsBypassed(t *testing.T) {
 		})
 
 		t.Run("authConfig query", func(t *testing.T) {
-			body := `{"query":"query { authConfig { provider } }"}`
+			body := `{"query":"query { authConfig { auth0ClientId authProvider } }"}`
 			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
 			assert.NoError(t, err)
 
@@ -130,7 +130,7 @@ func TestIsBypassed(t *testing.T) {
 	})
 
 	t.Run("should allow multiple bypassed fields", func(t *testing.T) {
-		body := `{"query":"query { authConfig { clientId } findByID(id: \"abc\") { id } }"}`
+		body := `{"query":"query { authConfig { auth0ClientId } findByID(id: \"abc\") { id } }"}`
 		req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
 		assert.NoError(t, err)
 

--- a/server/internal/app/auth_test.go
+++ b/server/internal/app/auth_test.go
@@ -315,7 +315,7 @@ func TestMockAuthMiddleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		body := `{"query":"mutation { signup(input: {}) { id } }","operationName":"signup"}`
+		body := `{"query":"mutation { signup(input: {}) { id } }"}`
 		req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
## Why

`isBypassed` used naive `strings.Contains` matching on raw GraphQL query text to determine which requests should skip authentication. An attacker could embed bypass keywords (e.g., `signup(`) in comments (`# signup(`), operation names (`mutation signup { ... }`), or aliases (`signup: updatePermittable(...)`) to bypass authentication for **any** GraphQL operation.

This was a critical authentication bypass vulnerability affecting the entire GraphQL API surface.

### Fix

Replaced substring matching with AST-based parsing using `gqlparser`. The new implementation:
- Parses the query into an AST, ignoring comments and syntactic noise
- Inspects only the actual top-level **field names** in the selection set
- Requires **all** fields in a request to be in the bypass allowlist (prevents mixing a bypassed field with a protected one)

### Test coverage

Added tests verifying:
- Bypass keyword in comment is rejected
- Bypass keyword in operation name is rejected
- Bypass keyword as field alias is rejected
- Mixed bypassed + protected fields are rejected
- Multiple allowed fields are accepted

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values