### PR TITLE
fix(server): remove X-Internal-Service auth bypass in canUseDebugHeaders

### DIFF
--- a/server/e2e/common_test.go
+++ b/server/e2e/common_test.go
@@ -77,6 +77,40 @@ func StartServerWithRepos(
 	cfg *app.Config,
 	repos *repo.Container,
 ) *httpexpect.Expect {
+	return startServerWithReposAndDebug(t, cfg, repos, true)
+}
+
+func StartServerNoDebug(t *testing.T, cfg *app.Config, useMongo bool, seeder Seeder) (*httpexpect.Expect, *repo.Container) {
+	t.Helper()
+	ctx := context.Background()
+	var repos *repo.Container
+
+	if useMongo {
+		db := mongorepo.Connect(t)(t)
+		var err error
+		repos, err = mongorepo.New(ctx, db, false, false, nil)
+		if err != nil {
+			log.Fatalf("Failed to init mongo: %+v\n", err)
+		}
+	} else {
+		repos = memory.New()
+	}
+
+	if seeder != nil {
+		if err := seeder(ctx, repos); err != nil {
+			t.Fatalf("failed to seed the db: %s", err)
+		}
+	}
+
+	return startServerWithReposAndDebug(t, cfg, repos, false), repos
+}
+
+func startServerWithReposAndDebug(
+	t *testing.T,
+	cfg *app.Config,
+	repos *repo.Container,
+	debug bool,
+) *httpexpect.Expect {
 	t.Helper()
 
 	if testing.Short() {
@@ -105,7 +139,7 @@ func StartServerWithRepos(
 		Gateways: &gateway.Container{
 			Mailer: mailer.New(ctx, &mailer.Config{}),
 		},
-		Debug:         true,
+		Debug:         debug,
 		CerbosAdapter: cerbosAdapter,
 	})
 

--- a/server/e2e/gql_auth_bypass_test.go
+++ b/server/e2e/gql_auth_bypass_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/app"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/idx"
+	"github.com/stretchr/testify/assert"
+)
+
+func baseSeederAuthBypass(ctx context.Context, r *repo.Container) error {
+	auth := user.ReearthSub(uId.String())
+
+	u := user.New().ID(uId).
+		Name("target-user").
+		Email("target@example.com").
+		Auths([]user.Auth{*auth}).
+		Workspace(wId).
+		MustBuild()
+	if err := r.User.Save(ctx, u); err != nil {
+		return err
+	}
+
+	w := workspace.New().ID(wId).
+		Name("target-workspace").
+		Personal(true).
+		Members(map[idx.ID[id.User]]workspace.Member{
+			uId: {Role: role.RoleOwner, InvitedBy: uId},
+		}).
+		MustBuild()
+	return r.Workspace.Save(ctx, w)
+}
+
+// TestSEC04_XInternalServiceHeaderDoesNotBypassAuth verifies that
+// X-Internal-Service: visualizer-api cannot be used to authenticate
+// without a valid JWT when the server runs in production mode (Debug: false).
+func TestSEC04_XInternalServiceHeaderDoesNotBypassAuth(t *testing.T) {
+	e, _ := StartServerNoDebug(t, &app.Config{}, false, baseSeederAuthBypass)
+
+	query := `{ me { id name email } }`
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	// Sending X-Internal-Service + X-Reearth-Debug-User without a valid JWT.
+	// Before the fix this would have authenticated as the target user.
+	// After the fix the server must reject with 401.
+	e.POST("/api/graphql").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Internal-Service", "visualizer-api").
+		WithHeader("X-Reearth-Debug-User", uId.String()).
+		WithBytes(jsonData).
+		Expect().Status(http.StatusUnauthorized)
+}
+
+// TestSEC04_XInternalServiceWithDebugAuthSubDoesNotBypassAuth verifies that
+// X-Internal-Service: visualizer-api + X-Reearth-Debug-Auth-Sub cannot inject
+// arbitrary auth info without a valid JWT in production mode.
+func TestSEC04_XInternalServiceWithDebugAuthSubDoesNotBypassAuth(t *testing.T) {
+	e, _ := StartServerNoDebug(t, &app.Config{}, false, baseSeederAuthBypass)
+
+	query := `{ me { id name email } }`
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	e.POST("/api/graphql").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Internal-Service", "visualizer-api").
+		WithHeader("X-Reearth-Debug-Auth-Sub", uId.String()).
+		WithBytes(jsonData).
+		Expect().Status(http.StatusUnauthorized)
+}
+
+// TestSEC04_DebugHeadersWorkInDebugMode confirms that debug authentication
+// still functions correctly when the server is explicitly started with Debug: true.
+func TestSEC04_DebugHeadersWorkInDebugMode(t *testing.T) {
+	e, _ := StartServer(t, &app.Config{}, false, baseSeederAuthBypass)
+
+	query := `{ me { id name email } }`
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	o := e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", uId.String()).
+		WithBytes(jsonData).
+		Expect().Status(http.StatusOK).
+		JSON().Object().
+		Value("data").Object().
+		Value("me").Object()
+
+	o.Value("id").String().IsEqual(uId.String())
+	o.Value("name").String().IsEqual("target-user")
+	o.Value("email").String().IsEqual("target@example.com")
+}

--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -157,14 +157,8 @@ func isBypassed(req *http.Request) bool {
 	return true
 }
 
-func canUseDebugHeaders(req *http.Request, cfg *ServerConfig) bool {
-	if cfg.Debug || cfg.Config.Dev || os.Getenv("REEARTH_ACCOUNTS_DEV") == "true" {
-		return true
-	}
-	if req.Header.Get("X-Internal-Service") == "visualizer-api" {
-		return true
-	}
-	return false
+func canUseDebugHeaders(cfg *ServerConfig) bool {
+	return cfg.Debug || cfg.Config.Dev || os.Getenv("REEARTH_ACCOUNTS_DEV") == "true"
 }
 
 func authMiddleware(cfg *ServerConfig) func(http.Handler) http.Handler {
@@ -251,7 +245,7 @@ func identityProviderAuthMiddleware(cfg *ServerConfig) func(http.Handler) http.H
 				ai = a
 			}
 
-			if canUseDebugHeaders(req, cfg) {
+			if canUseDebugHeaders(cfg) {
 				if newCtx, dai := injectDebugAuthInfo(ctx, req); dai != nil {
 					ctx = newCtx
 					ai = *dai

--- a/server/internal/app/auth_test.go
+++ b/server/internal/app/auth_test.go
@@ -727,9 +727,8 @@ func TestCanUseDebugHeaders(t *testing.T) {
 			},
 			Debug: true,
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		result := canUseDebugHeaders(req, cfg)
+		result := canUseDebugHeaders(cfg)
 
 		assert.True(t, result)
 	})
@@ -741,26 +740,23 @@ func TestCanUseDebugHeaders(t *testing.T) {
 			},
 			Debug: false,
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		result := canUseDebugHeaders(req, cfg)
+		result := canUseDebugHeaders(cfg)
 
 		assert.True(t, result)
 	})
 
-	t.Run("should allow debug headers with visualizer-api service header", func(t *testing.T) {
+	t.Run("X-Internal-Service header must not enable debug headers in production", func(t *testing.T) {
 		cfg := &ServerConfig{
 			Config: &Config{
 				Dev: false,
 			},
 			Debug: false,
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.Header.Set("X-Internal-Service", "visualizer-api")
 
-		result := canUseDebugHeaders(req, cfg)
+		result := canUseDebugHeaders(cfg)
 
-		assert.True(t, result)
+		assert.False(t, result)
 	})
 
 	t.Run("should not allow debug headers in production mode", func(t *testing.T) {
@@ -770,9 +766,8 @@ func TestCanUseDebugHeaders(t *testing.T) {
 			},
 			Debug: false,
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		result := canUseDebugHeaders(req, cfg)
+		result := canUseDebugHeaders(cfg)
 
 		assert.False(t, result)
 	})

--- a/server/internal/app/auth_test.go
+++ b/server/internal/app/auth_test.go
@@ -747,16 +747,45 @@ func TestCanUseDebugHeaders(t *testing.T) {
 	})
 
 	t.Run("X-Internal-Service header must not enable debug headers in production", func(t *testing.T) {
+		uid := user.NewID()
+		u := user.New().
+			ID(uid).
+			Name("target-user").
+			Email("target@example.com").
+			MustBuild()
+
+		wid := workspace.NewID()
+		w := workspace.New().
+			ID(wid).
+			Name("target-workspace").
+			Members(map[id.UserID]workspace.Member{
+				uid: {Role: role.RoleOwner, InvitedBy: uid},
+			}).
+			MustBuild()
+
+		repos := memory.New()
+		repos.User = memory.NewUserWith(u)
+		repos.Workspace = memory.NewWorkspaceWith(w)
+
 		cfg := &ServerConfig{
-			Config: &Config{
-				Dev: false,
-			},
-			Debug: false,
+			Config: &Config{Dev: false, Mock_Auth: false},
+			Debug:  false,
+			Repos:  repos,
 		}
+		middleware := identityProviderAuthMiddleware(cfg)
 
-		result := canUseDebugHeaders(cfg)
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 
-		assert.False(t, result)
+		req := httptest.NewRequest(http.MethodPost, "/api/graphql", nil)
+		req.Header.Set("X-Internal-Service", "visualizer-api")
+		req.Header.Set(debugUserHeader, uid.String())
+		rr := httptest.NewRecorder()
+
+		middleware(nextHandler).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	})
 
 	t.Run("should not allow debug headers in production mode", func(t *testing.T) {


### PR DESCRIPTION
## Why

`canUseDebugHeaders` returned `true` whenever a request carried `X-Internal-Service: visualizer-api`, independent of any debug/dev flag. This allowed any client that could reach `/api/graphql` to inject `X-Reearth-Debug-Auth-Sub` or `X-Reearth-Debug-User` and authenticate as an arbitrary user — no JWT, no signature, no issuer check required.

The fix gates debug header usage exclusively on server-side configuration (`cfg.Debug`, `cfg.Config.Dev`, `REEARTH_ACCOUNTS_DEV`), which external callers cannot influence. The `X-Internal-Service` header is retained for its legitimate logging purpose only.

Resolves SEC-04 (AI Scan Issue #12).

## Checklist

- [x] Verified backward compatibility related to feature modifications (debug headers remain available in dev/debug mode as before)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values