### PR TITLE
ci: grant id-token and packages write at workflow level for reusable workflow calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -110,6 +115,10 @@ jobs:
       - ci
       - ci-server
       - ci-collect-info
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     if: |
       !failure() &&
       needs.ci-server.result == 'success' &&
@@ -128,5 +137,9 @@ jobs:
 
   deploy-server-oss:
     needs: build-server
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: ./.github/workflows/deploy_server_nightly.yml
     secrets: inherit


### PR DESCRIPTION
## Why

The `deploy-server-oss` job calls the reusable workflow `deploy_server_nightly.yml`, which requests `id-token: write` in its nested job. However, GitHub Actions enforces that reusable workflows can only use permissions up to the ceiling set by the **calling workflow's top-level permissions block**.

The top-level `permissions: contents: read` in `ci.yml` implicitly set `id-token: none`, causing the workflow validation error:
> The nested job 'deploy-to-cloud-run' is requesting 'id-token: write', but is only allowed 'id-token: none'.

Adding `id-token: write` and `packages: write` to the workflow-level permissions block allows the reusable workflow to use those permissions as intended.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values