### PR TITLE
fix(server): prevent non-owner users from self-promoting workspace role

### DIFF
--- a/server/e2e/gql_user_test.go
+++ b/server/e2e/gql_user_test.go
@@ -115,6 +115,82 @@ func baseSeederOneUser(ctx context.Context, r *repo.Container) error {
 	return nil
 }
 
+func baseSeederSelfRoleChange(ctx context.Context, r *repo.Container) error {
+	for _, roleName := range []string{"maintainer", "owner", "reader", "self", "writer"} {
+		_ = r.Role.Save(ctx, *role.New().NewID().Name(roleName).MustBuild())
+	}
+
+	u := user.New().ID(uId).Name("e2e").Email("e2e@e2e.com").Workspace(wId).MustBuild()
+	if err := r.User.Save(ctx, u); err != nil {
+		return err
+	}
+	u3 := user.New().ID(uId3).Name("e2e3").Email("e2e3@e2e.com").Workspace(wId2).MustBuild()
+	if err := r.User.Save(ctx, u3); err != nil {
+		return err
+	}
+
+	ownerMember := workspace.Member{Role: role.RoleOwner, InvitedBy: uId}
+	writerMember := workspace.Member{Role: role.RoleWriter, InvitedBy: uId}
+	maintainerMember := workspace.Member{Role: role.RoleMaintainer, InvitedBy: uId}
+
+	// wId: uId=owner, uId3=writer (used for self-promotion test)
+	w := workspace.New().ID(wId).Name("e2e").
+		Members(map[idx.ID[id.User]]workspace.Member{
+			uId:  ownerMember,
+			uId3: writerMember,
+		}).
+		MustBuild()
+	if err := r.Workspace.Save(ctx, w); err != nil {
+		return err
+	}
+
+	// wId2: uId=owner, uId3=maintainer (used for self-demotion test)
+	w2 := workspace.New().ID(wId2).Name("e2e2").
+		Members(map[idx.ID[id.User]]workspace.Member{
+			uId:  ownerMember,
+			uId3: maintainerMember,
+		}).
+		MustBuild()
+	if err := r.Workspace.Save(ctx, w2); err != nil {
+		return err
+	}
+
+	ownerRole, err := r.Role.FindByName(ctx, "owner")
+	if err != nil {
+		return err
+	}
+	writerRole, err := r.Role.FindByName(ctx, "writer")
+	if err != nil {
+		return err
+	}
+	maintainerRole, err := r.Role.FindByName(ctx, "maintainer")
+	if err != nil {
+		return err
+	}
+
+	p1, err := permittable.New().NewID().UserID(uId).Build()
+	if err != nil {
+		return err
+	}
+	p1.UpdateWorkspaceRole(wId, ownerRole.ID())
+	p1.UpdateWorkspaceRole(wId2, ownerRole.ID())
+	if err := r.Permittable.Save(ctx, *p1); err != nil {
+		return err
+	}
+
+	p3, err := permittable.New().NewID().UserID(uId3).Build()
+	if err != nil {
+		return err
+	}
+	p3.UpdateWorkspaceRole(wId, writerRole.ID())
+	p3.UpdateWorkspaceRole(wId2, maintainerRole.ID())
+	if err := r.Permittable.Save(ctx, *p3); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func baseSeederUser(ctx context.Context, r *repo.Container) error {
 	// Seed roles first
 	if err := seedRoles(ctx, r); err != nil {
@@ -661,6 +737,59 @@ func TestSignupOIDC(t *testing.T) {
 	o.Value("id").String().NotEmpty()
 	o.Value("name").String().IsEqual("new user")
 	o.Value("email").String().IsEqual(email)
+}
+
+func TestUpdateUserOfWorkspace_MaintainerCanSelfDemoteToWriter(t *testing.T) {
+	e, r := StartServer(t, &app.Config{}, true, baseSeederSelfRoleChange)
+
+	w, err := r.Workspace.FindByID(context.Background(), wId2)
+	assert.NoError(t, err)
+	assert.Equal(t, role.RoleMaintainer, w.Members().User(uId3).Role)
+
+	query := fmt.Sprintf(`mutation { updateUserOfWorkspace(input: {workspaceId: "%s", userId: "%s", role: writer}){ workspace{ id } }}`, wId2, uId3)
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", uId3.String()).
+		WithBytes(jsonData).Expect().Status(http.StatusOK).
+		JSON().Object().
+		Value("data").Object().
+		Value("updateUserOfWorkspace").Object().
+		Value("workspace").Object().
+		Value("id").String().IsEqual(wId2.String())
+
+	w, err = r.Workspace.FindByID(context.Background(), wId2)
+	assert.NoError(t, err)
+	assert.Equal(t, role.RoleWriter, w.Members().User(uId3).Role)
+}
+
+func TestUpdateUserOfWorkspace_WriterCannotSelfPromoteToOwner(t *testing.T) {
+	e, r := StartServer(t, &app.Config{}, true, baseSeederSelfRoleChange)
+
+	w, err := r.Workspace.FindByID(context.Background(), wId)
+	assert.NoError(t, err)
+	assert.Equal(t, role.RoleWriter, w.Members().User(uId3).Role)
+
+	query := fmt.Sprintf(`mutation { updateUserOfWorkspace(input: {workspaceId: "%s", userId: "%s", role: owner}){ workspace{ id } }}`, wId, uId3)
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	resp := e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", uId3.String()).
+		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+
+	resp.Value("errors").Array().NotEmpty()
+
+	w, err = r.Workspace.FindByID(context.Background(), wId)
+	assert.NoError(t, err)
+	assert.Equal(t, role.RoleWriter, w.Members().User(uId3).Role)
 }
 
 func TestVerifyUser(t *testing.T) {

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -455,8 +455,14 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		if u == *operator.User && ws.Members().UserRole(u) == role.RoleOwner && newRole != role.RoleOwner {
-			return nil, interfaces.ErrCannotChangeOwnerRole
+		if u == *operator.User {
+			currentRole := ws.Members().UserRole(u)
+			if !currentRole.Includes(newRole) {
+				return nil, interfaces.ErrCannotSelfPromote
+			}
+			if currentRole == role.RoleOwner && newRole != role.RoleOwner {
+				return nil, interfaces.ErrCannotChangeOwnerRole
+			}
 		}
 
 		err = ws.Members().UpdateUserRole(u, newRole)

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -1523,6 +1523,8 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 	w5 := workspace.New().ID(id5).Name("W5").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
 	id6 := id.NewWorkspaceID()
 	w6 := workspace.New().ID(id6).Name("W6").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}).Personal(false).MustBuild()
+	id7 := id.NewWorkspaceID()
+	w7 := workspace.New().ID(id7).Name("W7").Members(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleMaintainer}}).Personal(false).MustBuild()
 
 	op := &workspace.Operator{
 		User:               &userID,
@@ -1635,7 +1637,7 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}, nil, false),
 		},
 		{
-			name:       "Non-owner can change own role",
+			name:       "Non-owner cannot self-promote to higher role",
 			seeds:      workspace.List{w6},
 			usersSeeds: []*user.User{u},
 			args: struct {
@@ -1651,6 +1653,27 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 					User:               lo.ToPtr(u.ID()),
 					ReadableWorkspaces: []workspace.ID{id6},
 					WritableWorkspaces: []workspace.ID{id6},
+				},
+			},
+			wantErr: interfaces.ErrCannotSelfPromote,
+		},
+		{
+			name:       "Non-owner can self-demote to lower role",
+			seeds:      workspace.List{w7},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				uId      user.ID
+				role     role.RoleType
+				operator *workspace.Operator
+			}{
+				wId:  id7,
+				uId:  u.ID(),
+				role: role.RoleWriter,
+				operator: &workspace.Operator{
+					User:               lo.ToPtr(u.ID()),
+					ReadableWorkspaces: []workspace.ID{id7},
+					WritableWorkspaces: []workspace.ID{id7},
 				},
 			},
 			wantErr: nil,

--- a/server/internal/usecase/interfaces/workspace.go
+++ b/server/internal/usecase/interfaces/workspace.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	ErrOwnerCannotLeaveTheWorkspace = rerror.NewE(i18n.T("owner user cannot leave from the workspace"))
 	ErrCannotChangeOwnerRole        = rerror.NewE(i18n.T("cannot change the role of the workspace owner"))
 	ErrCannotDeleteWorkspace        = rerror.NewE(i18n.T("cannot delete workspace because at least one project is left"))
+	ErrCannotSelfPromote            = rerror.NewE(i18n.T("cannot promote own role to a higher level"))
+	ErrOwnerCannotLeaveTheWorkspace = rerror.NewE(i18n.T("owner user cannot leave from the workspace"))
 	ErrWorkspaceWithProjects        = rerror.NewE(i18n.T("target workspace still has some project"))
 	ErrPermissionDenied             = rerror.NewE(i18n.T("permission denied"))
 )


### PR DESCRIPTION
## Why

A privilege escalation vulnerability (SEC-05) existed in `UpdateUserMember`: the self-change guard only blocked `Owner → non-Owner` demotions. Because the check `ws.Members().UserRole(u) == RoleOwner` is `false` for non-owners, any `Writer` or `Maintainer` could call `mutation updateUserOfWorkspace` with their own user ID and `role: OWNER`, granting themselves full workspace ownership with no restriction.

The fix adds a rank-comparison check using the existing `RoleType.Includes` method: when the caller targets their own user ID, the requested new role must be at the same privilege level or lower than their current role. A new `ErrCannotSelfPromote` error is returned on violation. The existing `ErrCannotChangeOwnerRole` path (preventing owners from demoting themselves) is preserved.

## Checklist

- [x] Verified backward compatibility related to feature modifications (mutation returns a new error type for previously-permitted but insecure calls — intentional breaking fix)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed