### PR TITLE
perf(server): batch permittable writes in AddUserMember

### DIFF
--- a/server/e2e/gql_workspace_permittable_test.go
+++ b/server/e2e/gql_workspace_permittable_test.go
@@ -1,0 +1,242 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/app"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/permittable"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seederBulkPermittable seeds a workspace owned by a single user plus a set of additional users
+// that are not yet members, returning their IDs for use in tests.
+func seederBulkPermittable(ownerID user.ID, wsID workspace.ID, extraUsers []user.ID) Seeder {
+	return func(ctx context.Context, r *repo.Container) error {
+		for _, roleName := range []string{"owner", "maintainer", "writer", "reader", "self"} {
+			if err := r.Role.Save(ctx, *role.New().NewID().Name(roleName).MustBuild()); err != nil {
+				return err
+			}
+		}
+
+		owner := user.New().ID(ownerID).Name("owner").Email("owner@bulk.test").MustBuild()
+		if err := r.User.Save(ctx, owner); err != nil {
+			return err
+		}
+
+		for i, uid := range extraUsers {
+			u := user.New().ID(uid).
+				Name(fmt.Sprintf("extra%d", i)).
+				Email(fmt.Sprintf("extra%d@bulk.test", i)).
+				MustBuild()
+			if err := r.User.Save(ctx, u); err != nil {
+				return err
+			}
+		}
+
+		ownerRole, err := r.Role.FindByName(ctx, "owner")
+		if err != nil {
+			return err
+		}
+
+		ws := workspace.New().ID(wsID).Name("bulk-ws").
+			Members(map[user.ID]workspace.Member{
+				ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+			}).
+			Personal(false).MustBuild()
+		if err := r.Workspace.Save(ctx, ws); err != nil {
+			return err
+		}
+
+		p, err := permittable.New().NewID().UserID(ownerID).Build()
+		if err != nil {
+			return err
+		}
+		p.UpdateWorkspaceRole(wsID, ownerRole.ID())
+		return r.Permittable.Save(ctx, *p)
+	}
+}
+
+// TestAddUsersToWorkspace_BulkCreatesPermittables verifies that adding multiple users in a
+// single addUsersToWorkspace call creates a permittable for every invited user.
+func TestAddUsersToWorkspace_BulkCreatesPermittables(t *testing.T) {
+	ownerID := id.NewUserID()
+	wsID := id.NewWorkspaceID()
+	extraIDs := []user.ID{id.NewUserID(), id.NewUserID(), id.NewUserID()}
+
+	e, r := StartServer(t, &app.Config{}, false,
+		seederBulkPermittable(ownerID, wsID, extraIDs))
+
+	ctx := context.Background()
+
+	users := fmt.Sprintf(
+		`{userId: "%s", role: writer}, {userId: "%s", role: reader}, {userId: "%s", role: maintainer}`,
+		extraIDs[0], extraIDs[1], extraIDs[2],
+	)
+	query := fmt.Sprintf(
+		`mutation { addUsersToWorkspace(input: {workspaceId: "%s", users: [%s]}){ workspace{ id } }}`,
+		wsID, users,
+	)
+	body, err := json.Marshal(GraphQLRequest{Query: query})
+	require.NoError(t, err)
+
+	e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", ownerID.String()).
+		WithBytes(body).
+		Expect().Status(http.StatusOK)
+
+	writerRole, err := r.Role.FindByName(ctx, "writer")
+	require.NoError(t, err)
+	readerRole, err := r.Role.FindByName(ctx, "reader")
+	require.NoError(t, err)
+	maintainerRole, err := r.Role.FindByName(ctx, "maintainer")
+	require.NoError(t, err)
+
+	expected := map[user.ID]id.RoleID{
+		extraIDs[0]: writerRole.ID(),
+		extraIDs[1]: readerRole.ID(),
+		extraIDs[2]: maintainerRole.ID(),
+	}
+
+	for uid, wantRoleID := range expected {
+		p, err := r.Permittable.FindByUserID(ctx, uid)
+		require.NoError(t, err, "permittable missing for user %s", uid)
+		require.NotNil(t, p)
+
+		wrs := p.WorkspaceRoles()
+		require.Len(t, wrs, 1, "expected exactly one workspace role for user %s", uid)
+		assert.Equal(t, wsID, wrs[0].ID())
+		assert.Equal(t, wantRoleID, wrs[0].RoleID())
+	}
+}
+
+// TestAddUsersToWorkspace_BulkPreservesExistingPermittables verifies that adding a user who
+// already has permittables for other workspaces does not remove those existing workspace roles.
+func TestAddUsersToWorkspace_BulkPreservesExistingPermittables(t *testing.T) {
+	ownerID := id.NewUserID()
+	wsID := id.NewWorkspaceID()
+	otherWsID := id.NewWorkspaceID()
+	inviteeID := id.NewUserID()
+
+	e, r := StartServer(t, &app.Config{}, false,
+		func(ctx context.Context, repos *repo.Container) error {
+			if err := seederBulkPermittable(ownerID, wsID, []user.ID{inviteeID})(ctx, repos); err != nil {
+				return err
+			}
+
+			// Give the invitee a pre-existing role on a different workspace.
+			maintainerRole, err := repos.Role.FindByName(ctx, "maintainer")
+			if err != nil {
+				return err
+			}
+			existing, err := permittable.New().NewID().UserID(inviteeID).
+				WorkspaceRoles([]permittable.WorkspaceRole{
+					permittable.NewWorkspaceRole(otherWsID, maintainerRole.ID()),
+				}).Build()
+			if err != nil {
+				return err
+			}
+			return repos.Permittable.Save(ctx, *existing)
+		},
+	)
+
+	ctx := context.Background()
+
+	query := fmt.Sprintf(
+		`mutation { addUsersToWorkspace(input: {workspaceId: "%s", users: [{userId: "%s", role: writer}]}){ workspace{ id } }}`,
+		wsID, inviteeID,
+	)
+	body, err := json.Marshal(GraphQLRequest{Query: query})
+	require.NoError(t, err)
+
+	e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", ownerID.String()).
+		WithBytes(body).
+		Expect().Status(http.StatusOK)
+
+	maintainerRole, err := r.Role.FindByName(ctx, "maintainer")
+	require.NoError(t, err)
+	writerRole, err := r.Role.FindByName(ctx, "writer")
+	require.NoError(t, err)
+
+	p, err := r.Permittable.FindByUserID(ctx, inviteeID)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	wrs := p.WorkspaceRoles()
+	assert.Len(t, wrs, 2, "both workspace roles should be present")
+
+	roleByWS := make(map[workspace.ID]id.RoleID, len(wrs))
+	for _, wr := range wrs {
+		roleByWS[wr.ID()] = wr.RoleID()
+	}
+	assert.Equal(t, maintainerRole.ID(), roleByWS[otherWsID], "pre-existing workspace role must not be removed")
+	assert.Equal(t, writerRole.ID(), roleByWS[wsID], "new workspace role must be set")
+}
+
+// TestAddUsersToWorkspace_BulkLargeBatch verifies correctness when many users are added in one call.
+func TestAddUsersToWorkspace_BulkLargeBatch(t *testing.T) {
+	const batchSize = 20
+
+	ownerID := id.NewUserID()
+	wsID := id.NewWorkspaceID()
+	extraIDs := make([]user.ID, batchSize)
+	for i := range extraIDs {
+		extraIDs[i] = id.NewUserID()
+	}
+
+	e, r := StartServer(t, &app.Config{}, false,
+		seederBulkPermittable(ownerID, wsID, extraIDs))
+
+	ctx := context.Background()
+
+	memberInputs := ""
+	for i, uid := range extraIDs {
+		if i > 0 {
+			memberInputs += ", "
+		}
+		memberInputs += fmt.Sprintf(`{userId: "%s", role: reader}`, uid)
+	}
+	query := fmt.Sprintf(
+		`mutation { addUsersToWorkspace(input: {workspaceId: "%s", users: [%s]}){ workspace{ id } }}`,
+		wsID, memberInputs,
+	)
+	body, err := json.Marshal(GraphQLRequest{Query: query})
+	require.NoError(t, err)
+
+	e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", ownerID.String()).
+		WithBytes(body).
+		Expect().Status(http.StatusOK)
+
+	readerRole, err := r.Role.FindByName(ctx, "reader")
+	require.NoError(t, err)
+
+	ws, err := r.Workspace.FindByID(ctx, wsID)
+	require.NoError(t, err)
+	assert.Len(t, ws.Members().Users(), batchSize+1, "workspace should have all invited users plus the owner")
+
+	for _, uid := range extraIDs {
+		p, err := r.Permittable.FindByUserID(ctx, uid)
+		require.NoError(t, err, "permittable missing for user %s", uid)
+		wrs := p.WorkspaceRoles()
+		require.Len(t, wrs, 1)
+		assert.Equal(t, wsID, wrs[0].ID())
+		assert.Equal(t, readerRole.ID(), wrs[0].RoleID())
+	}
+}

--- a/server/internal/infrastructure/memory/permittable.go
+++ b/server/internal/infrastructure/memory/permittable.go
@@ -89,3 +89,14 @@ func (r *Permittable) Save(ctx context.Context, p permittable.Permittable) error
 	r.data[p.ID()] = &p
 	return nil
 }
+
+func (r *Permittable) SaveMany(ctx context.Context, ps permittable.List) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, p := range ps {
+		copied := *p
+		r.data[p.ID()] = &copied
+	}
+	return nil
+}

--- a/server/internal/infrastructure/mongo/permittable.go
+++ b/server/internal/infrastructure/mongo/permittable.go
@@ -49,6 +49,21 @@ func (r *Permittable) Save(ctx context.Context, permittable permittable.Permitta
 	return r.client.SaveOne(ctx, gId, doc)
 }
 
+func (r *Permittable) SaveMany(ctx context.Context, ps permittable.List) error {
+	if len(ps) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(ps))
+	docs := make([]any, 0, len(ps))
+	for _, p := range ps {
+		doc, id := mongodoc.NewPermittable(*p)
+		ids = append(ids, id)
+		docs = append(docs, doc)
+	}
+	return r.client.SaveAll(ctx, ids, docs)
+}
+
 func (r *Permittable) find(ctx context.Context, filter any) (permittable.List, error) {
 	c := mongodoc.NewPermittableConsumer()
 	if err := r.client.Find(ctx, filter, c); err != nil {

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -287,6 +287,7 @@ func (i *Workspace) AddUserMember(ctx context.Context, workspaceID workspace.ID,
 			}
 		}
 
+		joined := make(map[user.ID]role.RoleType, len(ul))
 		for _, m := range ul {
 			if m == nil {
 				continue
@@ -297,9 +298,11 @@ func (i *Workspace) AddUserMember(ctx context.Context, workspaceID workspace.ID,
 				return nil, applog.ErrorWithCallerLogging(ctx, "failed to join user to workspace", err)
 			}
 
-			if err := i.updatePermittable(ctx, m.ID(), ws.ID(), users[m.ID()]); err != nil {
-				return nil, applog.ErrorWithCallerLogging(ctx, "failed to update permittable", err)
-			}
+			joined[m.ID()] = users[m.ID()]
+		}
+
+		if err := i.bulkUpdatePermittable(ctx, ws.ID(), joined); err != nil {
+			return nil, applog.ErrorWithCallerLogging(ctx, "failed to update permittable", err)
 		}
 
 		err = i.repos.Workspace.Save(ctx, ws)
@@ -668,6 +671,65 @@ func (i *Workspace) updatePermittable(ctx context.Context, userID user.ID, works
 	p.UpdateWorkspaceRole(workspaceID, r.ID())
 
 	return i.permittableRepo.Save(ctx, *p)
+}
+
+func (i *Workspace) bulkUpdatePermittable(ctx context.Context, workspaceID workspace.ID, userRoles map[user.ID]role.RoleType) error {
+	if len(userRoles) == 0 {
+		return nil
+	}
+
+	// Deduplicate role lookups: fetch each unique role name once.
+	roleIDByName := make(map[role.RoleType]role.ID, len(userRoles))
+	for _, roleName := range userRoles {
+		if _, seen := roleIDByName[roleName]; seen {
+			continue
+		}
+		r, err := i.roleRepo.FindByName(ctx, string(roleName))
+		if err != nil {
+			if errors.Is(err, rerror.ErrNotFound) && os.Getenv("REEARTH_MOCK_AUTH") == "true" {
+				log.Infof("[MockAuth] Auto-creating role for workspace: %s", roleName)
+				newRole := role.New().NewID().Name(string(roleName)).MustBuild()
+				if saveErr := i.roleRepo.Save(ctx, *newRole); saveErr != nil {
+					return applog.ErrorWithCallerLogging(ctx, "failed to auto-create role", saveErr)
+				}
+				r = newRole
+			} else {
+				return err
+			}
+		}
+		roleIDByName[roleName] = r.ID()
+	}
+
+	// Batch fetch existing permittables for all users in one round-trip.
+	userIDs := make(user.IDList, 0, len(userRoles))
+	for uid := range userRoles {
+		userIDs = append(userIDs, uid)
+	}
+	existing, err := i.permittableRepo.FindByUserIDs(ctx, userIDs)
+	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+		return applog.ErrorWithCallerLogging(ctx, "failed to fetch permittables", err)
+	}
+
+	permByUserID := make(map[user.ID]*permittable.Permittable, len(existing))
+	for _, p := range existing {
+		permByUserID[p.UserID()] = p
+	}
+
+	// Build updated/new permittables and save them in one round-trip.
+	toSave := make(permittable.List, 0, len(userRoles))
+	for uid, roleName := range userRoles {
+		p, ok := permByUserID[uid]
+		if !ok {
+			p, err = permittable.New().NewID().UserID(uid).Build()
+			if err != nil {
+				return err
+			}
+		}
+		p.UpdateWorkspaceRole(workspaceID, roleIDByName[roleName])
+		toSave = append(toSave, p)
+	}
+
+	return i.permittableRepo.SaveMany(ctx, toSave)
 }
 
 func (i *Workspace) removePermittable(ctx context.Context, userID user.ID, workspaceID workspace.ID) error {

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
 	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/permittable"
 	"github.com/reearth/reearth-accounts/server/pkg/role"
 	"github.com/reearth/reearth-accounts/server/pkg/user"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
@@ -1854,4 +1855,275 @@ func TestWorkspace_RemoveIntegrations(t *testing.T) {
 			assert.NotZero(t, got.UpdatedAt(), "updatedAt should be set")
 		})
 	}
+}
+
+func TestWorkspace_AddUserMember_PermittableSync(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	seedDB := func() *repo.Container {
+		db := memory.New()
+		for _, r := range []string{"owner", "maintainer", "writer", "reader"} {
+			_ = db.Role.Save(ctx, *role.New().NewID().Name(r).MustBuild())
+		}
+		return db
+	}
+
+	findRole := func(db *repo.Container, name role.RoleType) *role.Role {
+		r, err := db.Role.FindByName(ctx, string(name))
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+
+	t.Run("creates permittables for added users", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+
+		ownerID := id.NewUserID()
+		wsID := id.NewWorkspaceID()
+		ws := workspace.New().ID(wsID).Name("ws").
+			Members(map[user.ID]workspace.Member{ownerID: {Role: role.RoleOwner}}).
+			Personal(false).MustBuild()
+		_ = db.Workspace.Save(ctx, ws)
+
+		u1 := user.New().NewID().Name("u1").Email("u1@test.com").MustBuild()
+		u2 := user.New().NewID().Name("u2").Email("u2@test.com").MustBuild()
+		_ = db.User.Save(ctx, u1)
+		_ = db.User.Save(ctx, u2)
+
+		op := &workspace.Operator{
+			User:             &ownerID,
+			OwningWorkspaces: workspace.IDList{wsID},
+		}
+
+		_, err := NewWorkspace(db, nil, nil).AddUserMember(ctx, wsID, map[user.ID]role.RoleType{
+			u1.ID(): role.RoleWriter,
+			u2.ID(): role.RoleReader,
+		}, op)
+		assert.NoError(t, err)
+
+		readerRoleID := findRole(db, role.RoleReader).ID()
+		writerRoleID := findRole(db, role.RoleWriter).ID()
+
+		p1, err := db.Permittable.FindByUserID(ctx, u1.ID())
+		assert.NoError(t, err)
+		assert.NotNil(t, p1)
+		assert.Equal(t, u1.ID(), p1.UserID())
+		wrs1 := p1.WorkspaceRoles()
+		assert.Len(t, wrs1, 1)
+		assert.Equal(t, wsID, wrs1[0].ID())
+		assert.Equal(t, writerRoleID, wrs1[0].RoleID())
+
+		p2, err := db.Permittable.FindByUserID(ctx, u2.ID())
+		assert.NoError(t, err)
+		assert.NotNil(t, p2)
+		assert.Equal(t, u2.ID(), p2.UserID())
+		wrs2 := p2.WorkspaceRoles()
+		assert.Len(t, wrs2, 1)
+		assert.Equal(t, wsID, wrs2[0].ID())
+		assert.Equal(t, readerRoleID, wrs2[0].RoleID())
+	})
+
+	t.Run("updates existing permittable without losing other workspace roles", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+
+		ownerID := id.NewUserID()
+		ws1ID := id.NewWorkspaceID()
+		ws2ID := id.NewWorkspaceID()
+		ws1 := workspace.New().ID(ws1ID).Name("ws1").
+			Members(map[user.ID]workspace.Member{ownerID: {Role: role.RoleOwner}}).
+			Personal(false).MustBuild()
+		_ = db.Workspace.Save(ctx, ws1)
+
+		otherRoleID := findRole(db, role.RoleMaintainer).ID()
+		u := user.New().NewID().Name("u").Email("u@test.com").MustBuild()
+		_ = db.User.Save(ctx, u)
+
+		// Pre-existing permittable with a role on a different workspace.
+		existing, _ := permittable.New().NewID().UserID(u.ID()).
+			WorkspaceRoles([]permittable.WorkspaceRole{
+				permittable.NewWorkspaceRole(ws2ID, otherRoleID),
+			}).Build()
+		_ = db.Permittable.Save(ctx, *existing)
+
+		op := &workspace.Operator{
+			User:             &ownerID,
+			OwningWorkspaces: workspace.IDList{ws1ID},
+		}
+
+		_, err := NewWorkspace(db, nil, nil).AddUserMember(ctx, ws1ID, map[user.ID]role.RoleType{
+			u.ID(): role.RoleWriter,
+		}, op)
+		assert.NoError(t, err)
+
+		writerRoleID := findRole(db, role.RoleWriter).ID()
+		p, err := db.Permittable.FindByUserID(ctx, u.ID())
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+
+		wrs := p.WorkspaceRoles()
+		assert.Len(t, wrs, 2)
+
+		roleByWS := make(map[workspace.ID]id.RoleID, len(wrs))
+		for _, wr := range wrs {
+			roleByWS[wr.ID()] = wr.RoleID()
+		}
+		assert.Equal(t, otherRoleID, roleByWS[ws2ID], "existing workspace role should be preserved")
+		assert.Equal(t, writerRoleID, roleByWS[ws1ID], "new workspace role should be set")
+	})
+}
+
+func TestWorkspace_BulkUpdatePermittable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	seedDB := func() *repo.Container {
+		db := memory.New()
+		for _, r := range []string{"owner", "maintainer", "writer", "reader"} {
+			_ = db.Role.Save(ctx, *role.New().NewID().Name(r).MustBuild())
+		}
+		return db
+	}
+
+	findRole := func(db *repo.Container, name role.RoleType) *role.Role {
+		r, err := db.Role.FindByName(ctx, string(name))
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+
+	makeInteractor := func(db *repo.Container) *Workspace {
+		return &Workspace{
+			repos:           db,
+			permittableRepo: db.Permittable,
+			roleRepo:        db.Role,
+		}
+	}
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		err := i.bulkUpdatePermittable(ctx, wsID, map[user.ID]role.RoleType{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("creates new permittable for unknown user", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		uID := id.NewUserID()
+
+		err := i.bulkUpdatePermittable(ctx, wsID, map[user.ID]role.RoleType{
+			uID: role.RoleReader,
+		})
+		assert.NoError(t, err)
+
+		p, err := db.Permittable.FindByUserID(ctx, uID)
+		assert.NoError(t, err)
+		assert.Equal(t, uID, p.UserID())
+		wrs := p.WorkspaceRoles()
+		assert.Len(t, wrs, 1)
+		assert.Equal(t, wsID, wrs[0].ID())
+		assert.Equal(t, findRole(db, role.RoleReader).ID(), wrs[0].RoleID())
+	})
+
+	t.Run("updates existing permittable workspace role", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		uID := id.NewUserID()
+
+		oldRoleID := findRole(db, role.RoleReader).ID()
+		existing, _ := permittable.New().NewID().UserID(uID).
+			WorkspaceRoles([]permittable.WorkspaceRole{
+				permittable.NewWorkspaceRole(wsID, oldRoleID),
+			}).Build()
+		_ = db.Permittable.Save(ctx, *existing)
+
+		err := i.bulkUpdatePermittable(ctx, wsID, map[user.ID]role.RoleType{
+			uID: role.RoleOwner,
+		})
+		assert.NoError(t, err)
+
+		p, err := db.Permittable.FindByUserID(ctx, uID)
+		assert.NoError(t, err)
+		wrs := p.WorkspaceRoles()
+		assert.Len(t, wrs, 1)
+		assert.Equal(t, findRole(db, role.RoleOwner).ID(), wrs[0].RoleID())
+	})
+
+	t.Run("handles mix of new and existing users in one batch", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+
+		existingUID := id.NewUserID()
+		newUID := id.NewUserID()
+
+		ep, _ := permittable.New().NewID().UserID(existingUID).Build()
+		_ = db.Permittable.Save(ctx, *ep)
+
+		err := i.bulkUpdatePermittable(ctx, wsID, map[user.ID]role.RoleType{
+			existingUID: role.RoleWriter,
+			newUID:      role.RoleReader,
+		})
+		assert.NoError(t, err)
+
+		writerRoleID := findRole(db, role.RoleWriter).ID()
+		readerRoleID := findRole(db, role.RoleReader).ID()
+
+		pe, err := db.Permittable.FindByUserID(ctx, existingUID)
+		assert.NoError(t, err)
+		assert.Equal(t, writerRoleID, pe.WorkspaceRoles()[0].RoleID())
+
+		pn, err := db.Permittable.FindByUserID(ctx, newUID)
+		assert.NoError(t, err)
+		assert.Equal(t, readerRoleID, pn.WorkspaceRoles()[0].RoleID())
+	})
+
+	t.Run("deduplicates role lookups for users sharing the same role", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+
+		ids := make([]user.ID, 5)
+		userRoles := make(map[user.ID]role.RoleType, 5)
+		for j := range ids {
+			ids[j] = id.NewUserID()
+			userRoles[ids[j]] = role.RoleReader
+		}
+
+		err := i.bulkUpdatePermittable(ctx, wsID, userRoles)
+		assert.NoError(t, err)
+
+		readerRoleID := findRole(db, role.RoleReader).ID()
+		for _, uID := range ids {
+			p, err := db.Permittable.FindByUserID(ctx, uID)
+			assert.NoError(t, err)
+			assert.Equal(t, readerRoleID, p.WorkspaceRoles()[0].RoleID())
+		}
+	})
+
+	t.Run("returns error when role does not exist", func(t *testing.T) {
+		t.Parallel()
+		db := seedDB()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		uID := id.NewUserID()
+
+		err := i.bulkUpdatePermittable(ctx, wsID, map[user.ID]role.RoleType{
+			uID: role.RoleType("nonexistent-role"),
+		})
+		assert.Error(t, err)
+	})
 }

--- a/server/pkg/permittable/mock_permittable.go
+++ b/server/pkg/permittable/mock_permittable.go
@@ -100,3 +100,17 @@ func (mr *MockRepoMockRecorder) Save(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockRepo)(nil).Save), arg0, arg1)
 }
+
+// SaveMany mocks base method.
+func (m *MockRepo) SaveMany(arg0 context.Context, arg1 List) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveMany", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveMany indicates an expected call of SaveMany.
+func (mr *MockRepoMockRecorder) SaveMany(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveMany", reflect.TypeOf((*MockRepo)(nil).SaveMany), arg0, arg1)
+}

--- a/server/pkg/permittable/repo.go
+++ b/server/pkg/permittable/repo.go
@@ -13,4 +13,5 @@ type Repo interface {
 	FindByUserIDs(context.Context, user.IDList) (List, error)
 	FindByRoleID(context.Context, id.RoleID) (List, error)
 	Save(context.Context, Permittable) error
+	SaveMany(context.Context, List) error
 }


### PR DESCRIPTION
## Why

`AddUserMember` called `updatePermittable` inside a loop, issuing two serial MongoDB round-trips per user (one `FindByUserID` + one `Save`) while holding the workspace write lock. For a 100-member bulk invite this means ~200 round-trips under the lock, starving concurrent workspace writes and exhausting the Mongo client pool.

This PR replaces the per-user loop with a single `bulkUpdatePermittable` call that:
1. Deduplicates role lookups — one `FindByName` per distinct `RoleType` instead of per user
2. Batch-fetches all existing permittables with a single `FindByUserIDs` call
3. Batch-upserts all updated permittables with a single `SaveMany` call (backed by `mongox.SaveAll`)

Round-trips inside the lock drop from **2·K + K_roles → K_unique_roles + 2**.

Fixes SCA-03.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values