### PR TITLE
perf(server): replace O(N·M) nested loop in filterUsers with O(N+M) map lookup

### DIFF
--- a/server/e2e/gql_user_test.go
+++ b/server/e2e/gql_user_test.go
@@ -592,6 +592,30 @@ func TestNodes(t *testing.T) {
 	o.Array().ConsistsOf(map[string]string{"id": uId.String()})
 }
 
+func TestNodes_MultipleUsersOrderPreserved(t *testing.T) {
+	e, _ := StartServer(t, &app.Config{}, true, baseSeederUser)
+	// Request IDs in reverse insertion order to verify filterUsers preserves the requested order.
+	query := fmt.Sprintf(
+		`{ nodes(id: ["%s", "%s", "%s"], type: USER){ id } }`,
+		uId3.String(), uId2.String(), uId.String(),
+	)
+	request := GraphQLRequest{Query: query}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	arr := e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", uId.String()).
+		WithBytes(jsonData).Expect().Status(http.StatusOK).
+		JSON().Object().Value("data").Object().Value("nodes").Array()
+
+	arr.Length().IsEqual(3)
+	arr.Value(0).Object().Value("id").String().IsEqual(uId3.String())
+	arr.Value(1).Object().Value("id").String().IsEqual(uId2.String())
+	arr.Value(2).Object().Value("id").String().IsEqual(uId.String())
+}
+
 func TestSignup(t *testing.T) {
 	e, _ := StartServer(t, &app.Config{}, true, seedRoles)
 	email := "newuser@example.com"

--- a/server/internal/infrastructure/mongo/user.go
+++ b/server/internal/infrastructure/mongo/user.go
@@ -224,16 +224,13 @@ func (r *User) findOne(ctx context.Context, filter any) (*user.User, error) {
 }
 
 func filterUsers(ids []user.ID, rows []*user.User) []*user.User {
+	m := make(map[user.ID]*user.User, len(rows))
+	for _, r := range rows {
+		m[r.ID()] = r
+	}
 	res := make([]*user.User, 0, len(ids))
 	for _, id := range ids {
-		var r2 *user.User
-		for _, r := range rows {
-			if r.ID() == id {
-				r2 = r
-				break
-			}
-		}
-		res = append(res, r2)
+		res = append(res, m[id])
 	}
 	return res
 }

--- a/server/internal/infrastructure/mongo/user_test.go
+++ b/server/internal/infrastructure/mongo/user_test.go
@@ -614,6 +614,22 @@ func TestUserRepo_FindBySub(t *testing.T) {
 	}
 }
 
+func BenchmarkFilterUsers(b *testing.B) {
+	wsid := user.NewWorkspaceID()
+	const n = 10000
+	rows := make([]*user.User, n)
+	ids := make([]user.ID, n)
+	for i := range rows {
+		u := user.New().NewID().Email("u@example.com").Workspace(wsid).Name("u").MustBuild()
+		rows[i] = u
+		ids[i] = u.ID()
+	}
+	b.ResetTimer()
+	for range b.N {
+		filterUsers(ids, rows)
+	}
+}
+
 func TestUserRepo_Remove(t *testing.T) {
 	wsid := user.NewWorkspaceID()
 	user1 := user.New().


### PR DESCRIPTION
## Why

`filterUsers` used a nested linear scan to re-order query results to match the input ID order, resulting in O(N·M) comparisons per call. `FindByIDs` is on hot paths including the dataloader and `buildExistingUserSetFromWorkspaces`, so on workspaces with large member counts this became a CPU hotspot and prolonged Mongo connection-pool checkout times.

The fix builds a `map[user.ID]*user.User` once from the query results (O(N)), then looks up each requested ID in O(1), producing the ordered output in O(N+M) total. A benchmark (`BenchmarkFilterUsers`, N=10,000) is added to prevent regressions.

Resolves [SCA-04](https://github.com/eukarya-inc/compliance/issues/12).

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values