### PR TITLE
fix(server): add OIDC HTTP timeout, ISS allowlist, and fix duplicate-check bug

### DIFF
--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -72,14 +72,22 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		log.Printf("gql: GraphQL Playground is available")
 	}
 
+	allowedISS := make([]string, 0)
+	for _, a := range cfg.Config.Auths() {
+		if a.ISS != "" {
+			allowedISS = append(allowedISS, a.ISS)
+		}
+	}
+
 	usecaseMiddleware := UsecaseMiddleware(
 		cfg.Repos,
 		cfg.Gateways,
 		nil,
 		cfg.CerbosAdapter,
 		interactor.ContainerConfig{
-			SignupSecret:    cfg.Config.SignupSecret,
+			AllowedISS:      allowedISS,
 			AuthSrvUIDomain: cfg.Config.HostWeb,
+			SignupSecret:    cfg.Config.SignupSecret,
 		})
 
 	// API

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ContainerConfig struct {
-	SignupSecret    string
+	AllowedISS      []string
 	AuthSrvUIDomain string
+	SignupSecret    string
 }
 
 func NewContainer(
@@ -24,7 +25,7 @@ func NewContainer(
 	cerbos := NewCerbos(r, cerbosAdapter)
 	return interfaces.Container{
 		Cerbos:    cerbos,
-		User:      NewUser(r, acg, config.SignupSecret, config.AuthSrvUIDomain),
+		User:      NewUser(r, acg, config.SignupSecret, config.AuthSrvUIDomain, config.AllowedISS...),
 		Workspace: NewWorkspace(r, enforcer, cerbos),
 	}
 }

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -24,6 +24,7 @@ type User struct {
 	gateways        *gateway.Container
 	signupSecret    string
 	authSrvUIDomain string
+	allowedISS      []string
 	query           interfaces.UserQuery
 }
 
@@ -35,7 +36,7 @@ var (
 	}
 )
 
-func NewUser(r *repo.Container, g *gateway.Container, signupSecret, authSrcUIDomain string) interfaces.User {
+func NewUser(r *repo.Container, g *gateway.Container, signupSecret, authSrcUIDomain string, allowedISS ...string) interfaces.User {
 	var repos []user.Repo
 	if r != nil {
 		repos = []user.Repo{r.User}
@@ -45,18 +46,20 @@ func NewUser(r *repo.Container, g *gateway.Container, signupSecret, authSrcUIDom
 		gateways:        g,
 		signupSecret:    signupSecret,
 		authSrvUIDomain: authSrcUIDomain,
+		allowedISS:      allowedISS,
 		query: &UserQuery{
 			repos: repos,
 		},
 	}
 }
 
-func NewMultiUser(r *repo.Container, g *gateway.Container, signupSecret, authSrcUIDomain string, users []user.Repo) interfaces.User {
+func NewMultiUser(r *repo.Container, g *gateway.Container, signupSecret, authSrcUIDomain string, users []user.Repo, allowedISS ...string) interfaces.User {
 	return &User{
 		repos:           r,
 		gateways:        g,
 		signupSecret:    signupSecret,
 		authSrvUIDomain: authSrcUIDomain,
+		allowedISS:      allowedISS,
 		query: &UserQuery{
 			repos: append([]user.Repo{r.User}, users...),
 		},

--- a/server/internal/usecase/interactor/user_signup.go
+++ b/server/internal/usecase/interactor/user_signup.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strings"
 	textTmpl "text/template"
+	"time"
 
 	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-accounts/server/pkg/id"
@@ -55,6 +56,8 @@ var (
 
 	authTextTMPL *textTmpl.Template
 	authHTMLTMPL *htmlTmpl.Template
+
+	oidcHTTPClient = &http.Client{Timeout: 10 * time.Second}
 )
 
 func init() {
@@ -155,7 +158,7 @@ func (i *User) SignupOIDC(ctx context.Context, param interfaces.SignupOIDCParam)
 	name := param.Name
 	email := param.Email
 	if sub == "" || email == "" {
-		ui, err := getUserInfoFromISS(ctx, param.Issuer, param.AccessToken)
+		ui, err := i.getUserInfoFromISS(ctx, param.Issuer, param.AccessToken)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +167,7 @@ func (i *User) SignupOIDC(ctx context.Context, param interfaces.SignupOIDCParam)
 	}
 
 	return Run1(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) (*user.User, error) {
-		eu, err := i.repos.User.FindByEmail(ctx, param.Email)
+		eu, err := i.repos.User.FindByEmail(ctx, email)
 		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
 			return nil, err
 		}
@@ -172,7 +175,7 @@ func (i *User) SignupOIDC(ctx context.Context, param interfaces.SignupOIDCParam)
 			return nil, user.ErrDuplicatedUser
 		}
 
-		eu, err = i.repos.User.FindBySub(ctx, param.Sub)
+		eu, err = i.repos.User.FindBySub(ctx, sub)
 		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
 			return nil, err
 		}
@@ -238,7 +241,7 @@ func (i *User) FindOrCreate(ctx context.Context, param interfaces.UserFindOrCrea
 			return existedUser, nil
 		}
 
-		ui, err := getUserInfoFromISS(ctx, param.ISS, param.Token)
+		ui, err := i.getUserInfoFromISS(ctx, param.ISS, param.Token)
 		if err != nil {
 			return nil, err
 		}
@@ -300,12 +303,25 @@ func (i *User) sendVerificationMail(ctx context.Context, u *user.User, vr *user.
 	return nil
 }
 
-func getUserInfoFromISS(ctx context.Context, iss, accessToken string) (UserInfo, error) {
+func (i *User) getUserInfoFromISS(ctx context.Context, iss, accessToken string) (UserInfo, error) {
 	if accessToken == "" {
 		return UserInfo{}, rerror.NewE(i18n.T("invalid access token"))
 	}
 	if iss == "" {
 		return UserInfo{}, rerror.NewE(i18n.T("invalid issuer"))
+	}
+
+	if len(i.allowedISS) > 0 {
+		allowed := false
+		for _, a := range i.allowedISS {
+			if a == iss {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return UserInfo{}, rerror.NewE(i18n.T("invalid issuer"))
+		}
 	}
 
 	var u string
@@ -339,7 +355,7 @@ func getOpenIDConfiguration(ctx context.Context, iss string) (c OpenIDConfigurat
 		return
 	}
 
-	res, err2 := http.DefaultClient.Do(req)
+	res, err2 := oidcHTTPClient.Do(req)
 	if err2 != nil {
 		err = err2
 		return
@@ -370,7 +386,7 @@ func getUserInfo(ctx context.Context, url, accessToken string) (ui UserInfo, err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
-	res, err2 := http.DefaultClient.Do(req)
+	res, err2 := oidcHTTPClient.Do(req)
 	if err2 != nil {
 		err = err2
 		return

--- a/server/internal/usecase/interactor/user_signup_test.go
+++ b/server/internal/usecase/interactor/user_signup_test.go
@@ -2,6 +2,9 @@ package interactor
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -385,6 +388,215 @@ func TestIssToURL(t *testing.T) {
 	assert.Equal(t, &url.URL{Scheme: "https", Host: "iss.com", Path: ""}, issToURL("https://iss.com/", ""))
 	assert.Equal(t, &url.URL{Scheme: "https", Host: "iss.com", Path: "/hoge"}, issToURL("https://iss.com/hoge", ""))
 	assert.Equal(t, &url.URL{Scheme: "https", Host: "iss.com", Path: "/hoge/foobar"}, issToURL("https://iss.com/hoge", "foobar"))
+}
+
+func TestUser_getUserInfoFromISS_AllowlistValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedISS  []string
+		iss         string
+		accessToken string
+		wantErrMsg  string
+	}{
+		{
+			name:        "empty access token",
+			allowedISS:  nil,
+			iss:         "https://example.com",
+			accessToken: "",
+			wantErrMsg:  "invalid access token",
+		},
+		{
+			name:        "empty iss",
+			allowedISS:  nil,
+			iss:         "",
+			accessToken: "token",
+			wantErrMsg:  "invalid issuer",
+		},
+		{
+			name:        "iss not in allowlist",
+			allowedISS:  []string{"https://trusted.example.com"},
+			iss:         "https://evil.example.com",
+			accessToken: "token",
+			wantErrMsg:  "invalid issuer",
+		},
+		{
+			name:        "second iss not in allowlist",
+			allowedISS:  []string{"https://a.example.com", "https://b.example.com"},
+			iss:         "https://c.example.com",
+			accessToken: "token",
+			wantErrMsg:  "invalid issuer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &User{allowedISS: tt.allowedISS}
+			_, err := u.getUserInfoFromISS(context.Background(), tt.iss, tt.accessToken)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
+func TestUser_getUserInfoFromISS_AllowlistPermits(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowedISS []string
+		iss        string
+	}{
+		{
+			name:       "empty allowlist permits any iss",
+			allowedISS: nil,
+			iss:        "https://any.example.com",
+		},
+		{
+			name:       "iss present in single-entry allowlist",
+			allowedISS: []string{"https://trusted.example.com"},
+			iss:        "https://trusted.example.com",
+		},
+		{
+			name:       "iss present in multi-entry allowlist",
+			allowedISS: []string{"https://a.example.com", "https://b.example.com"},
+			iss:        "https://b.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &User{allowedISS: tt.allowedISS}
+			// The ISS passes the allowlist check; error comes from the unreachable host,
+			// not from the "invalid issuer" guard.
+			_, err := u.getUserInfoFromISS(context.Background(), tt.iss, "token")
+			assert.Error(t, err)
+			assert.NotContains(t, err.Error(), "invalid issuer")
+		})
+	}
+}
+
+func TestUser_getUserInfoFromISS_MockServer(t *testing.T) {
+	var serverURL string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenIDConfiguration{
+			UserinfoEndpoint: serverURL + "/userinfo",
+		})
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer mytoken", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UserInfo{
+			Sub:   "sub123",
+			Name:  "Test User",
+			Email: "test@example.com",
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	u := &User{allowedISS: []string{srv.URL}}
+	info, err := u.getUserInfoFromISS(context.Background(), srv.URL, "mytoken")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "sub123", info.Sub)
+	assert.Equal(t, "test@example.com", info.Email)
+	assert.Equal(t, "Test User", info.Name)
+}
+
+func TestUser_getUserInfoFromISS_ContextDeadlinePropagated(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	u := &User{}
+	_, err := u.getUserInfoFromISS(ctx, srv.URL, "token")
+
+	assert.Error(t, err)
+}
+
+func TestUser_SignupOIDC_AllowlistRejectsUnknownISS(t *testing.T) {
+	ctx := context.Background()
+	r := accountmemory.New()
+
+	uc := NewUser(r, nil, "", "", "https://trusted.example.com")
+
+	_, err := uc.SignupOIDC(ctx, interfaces.SignupOIDCParam{
+		Issuer:      "https://evil.example.com",
+		AccessToken: "sometoken",
+		// Sub and Email intentionally empty to trigger getUserInfoFromISS
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid issuer")
+}
+
+func TestUser_SignupOIDC_AllowlistPermitsKnownISS(t *testing.T) {
+	var serverURL string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenIDConfiguration{
+			UserinfoEndpoint: serverURL + "/userinfo",
+		})
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UserInfo{
+			Sub:   "sub-signup",
+			Email: "oidcuser@example.com",
+			Name:  "OIDC User",
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	ctx := context.Background()
+	r := accountmemory.New()
+
+	selfRole := role.New().NewID().Name(interfaces.RoleSelf).MustBuild()
+	ownerRole := role.New().NewID().Name(role.RoleOwner.String()).MustBuild()
+	assert.NoError(t, r.Role.Save(ctx, *selfRole))
+	assert.NoError(t, r.Role.Save(ctx, *ownerRole))
+
+	uc := NewUser(r, nil, "", "", srv.URL)
+
+	u, err := uc.SignupOIDC(ctx, interfaces.SignupOIDCParam{
+		Issuer:      srv.URL,
+		AccessToken: "token",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+	assert.Equal(t, "oidcuser@example.com", u.Email())
+}
+
+func TestUser_FindOrCreate_AllowlistRejectsUnknownISS(t *testing.T) {
+	ctx := context.Background()
+	r := accountmemory.New()
+
+	uc := NewUser(r, nil, "", "", "https://trusted.example.com").(*User)
+
+	_, err := uc.FindOrCreate(ctx, interfaces.UserFindOrCreateParam{
+		Sub:   "sub123",
+		ISS:   "https://evil.example.com",
+		Token: "sometoken",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid issuer")
 }
 
 // mockAuthenticator is a test helper that implements the Authenticator interface


### PR DESCRIPTION
## Why

Addresses REL-02 (AI Scan Issue #12): `getOpenIDConfiguration` and `getUserInfo` used `http.DefaultClient` with no timeout. An attacker supplying a slow `iss` that accepts TCP but never responds could park goroutines indefinitely, denying service to legitimate signups.

**Root causes fixed:**
1. `http.DefaultClient` has no `Timeout` — a hung OIDC endpoint blocks the goroutine forever with no recovery path.
2. The `iss` parameter was never validated against a trusted list before making an outbound connection — any attacker-controlled endpoint could be targeted.
3. Pre-existing bug: `SignupOIDC` called `FindByEmail`/`FindBySub` using `param.Email`/`param.Sub` (the original empty request values) instead of the locally-updated variables fetched from the OIDC userinfo endpoint, causing `ErrInvalidParams` on the happy path when sub/email were populated from OIDC.

**Changes:**
- Added `oidcHTTPClient = &http.Client{Timeout: 10 * time.Second}` replacing `http.DefaultClient` in both OIDC HTTP calls
- Converted `getUserInfoFromISS` to a `*User` method that checks `iss` against `allowedISS` before any network request
- Added `allowedISS []string` to `User` struct; `NewUser`/`NewMultiUser` accept it as a variadic parameter (backward-compatible)
- Added `AllowedISS []string` to `ContainerConfig`; populated from `cfg.Config.Auths()` in `app.go` using the same trusted issuers already configured for JWT verification
- Fixed `SignupOIDC` duplicate-check to use the resolved `email`/`sub` variables
- Added 7 unit tests covering all new behaviors

## Checklist

- [x] Verified backward compatibility related to feature modifications (`NewUser`/`NewMultiUser` use variadic params — no call sites break)
- [x] Confirmed backward compatibility for migrations (no schema changes)
- [x] Verified that no PII is included in displayed values