### PR TITLE
fix(server): downgrade 401 error log to warn level

### DIFF
--- a/server/pkg/gqlclient/gqlerror/error.go
+++ b/server/pkg/gqlclient/gqlerror/error.go
@@ -19,9 +19,10 @@ func IsUnauthorized(err error) bool {
 
 func ReturnAccountsError(ctx context.Context, err error) AccountsError {
 	_, file, line, _ := runtime.Caller(1)
-	log.Errorfc(ctx, "[Error] error with caller logging at %s:%d %+v", file, line, err)
 	if strings.Contains(err.Error(), "401") {
+		log.Warnfc(ctx, "[Warn] unauthorized at %s:%d %+v", file, line, err)
 		return ErrUnauthorized
 	}
+	log.Errorfc(ctx, "[Error] error with caller logging at %s:%d %+v", file, line, err)
 	return err
 }


### PR DESCRIPTION
## Why

`ReturnAccountsError` was logging every error at ERROR level, including expected 401 responses (expired JWT, unauthenticated requests). This flooded error logs and alerting with non-actionable noise.

Downgrade the 401 branch to WARN so the events remain visible (useful for diagnosing spikes) while preserving ERROR for genuinely unexpected failures (5xx, network errors, etc.).

### Before
```go
log.Errorfc(ctx, "[Error] error with caller logging at %s:%d %+v", file, line, err)
if strings.Contains(err.Error(), "401") {
    return ErrUnauthorized
}
return err
```

### After
```go
if strings.Contains(err.Error(), "401") {
    log.Warnfc(ctx, "[Warn] unauthorized at %s:%d %+v", file, line, err)
    return ErrUnauthorized
}
log.Errorfc(ctx, "[Error] error with caller logging at %s:%d %+v", file, line, err)
return err
```

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values