### PR TITLE
fix(server): copy docs/ in Dockerfile so swaggo blank import resolves

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,6 +10,7 @@ COPY go.mod go.sum main.go /reearth-accounts-api/
 RUN go mod download
 
 COPY cmd/ /reearth-accounts-api/cmd/
+COPY docs/ /reearth-accounts-api/docs/
 COPY pkg/ /reearth-accounts-api/pkg/
 COPY internal/ /reearth-accounts-api/internal/
 


### PR DESCRIPTION
## Why

The Docker build on `main` is failing after PR #248 was merged ([run 26798542016](https://github.com/reearth/reearth-accounts/actions/runs/26798542016)):

```
internal/adapter/http/router.go:11:2: no required module provides package
github.com/reearth/reearth-accounts/server/docs
```

PR #248 added a blank import of the generated swaggo package in `internal/adapter/http/router.go` so `echoSwagger.WrapHandler` can serve `/swagger`. The CI test/lint jobs pass because they run on the full source tree, but `server/Dockerfile` only `COPY`s `cmd/`, `pkg/`, and `internal/` into the build context — `docs/` is missing, so `go build` inside the image can't find the package and fails.

## What

Add `COPY docs/ /reearth-accounts-api/docs/` alongside the existing `COPY` lines so the generated swagger package is present at the same path the Go module path expects.

## Checklist

- [x] Verified backward compatibility (Dockerfile-only change; adds one COPY line, no behavior change for non-Docker builds)
- [x] Confirmed backward compatibility for migrations (none added/changed)
- [x] Verified no PII is included in displayed values