### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-accounts
+  namespace: reearth
+  description: Centralized account management and authorization (Auth0 + Cerbos) for
+    Re:Earth microservices
+  annotations:
+    github.com/project-slug: reearth/reearth-accounts
+  links:
+  - url: https://github.com/reearth/reearth-accounts
+    title: GitHub
+    icon: github
+  tags:
+  - go
+  - graphql
+  - auth
+  - ddd
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cto-office


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-accounts` (namespace `reearth`)
- **Owner:** `reearth/cto-office`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.