### PR TITLE
feat(server): add SSO workspace config backend (U-D20-02)

### DIFF
--- a/server/internal/adapter/rest/sso_handler.go
+++ b/server/internal/adapter/rest/sso_handler.go
@@ -1,0 +1,245 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/adapter"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+)
+
+type SSOHandler struct{}
+
+func NewSSOHandler() *SSOHandler {
+	return &SSOHandler{}
+}
+
+// ssoConfigResponse is returned by GET and PUT /workspaces/:id/sso.
+// Secrets are masked in responses.
+type ssoConfigResponse struct {
+	Auth0ConnectionID string   `json:"auth0_connection_id,omitempty"`
+	Auth0OrgID        string   `json:"auth0_org_id,omitempty"`
+	ClientID          string   `json:"client_id,omitempty"`
+	ClientSecret      string   `json:"client_secret,omitempty"`
+	ConnectionType    string   `json:"connection_type"`
+	DirectoryDomain   string   `json:"directory_domain,omitempty"`
+	EmailDomains      []string `json:"email_domains"`
+	Enabled           bool     `json:"enabled"`
+	JITDefaultRole    string   `json:"jit_default_role,omitempty"`
+	OIDCClientID      string   `json:"oidc_client_id,omitempty"`
+	OIDCClientSecret  string   `json:"oidc_client_secret,omitempty"`
+	OIDCDiscoveryURL  string   `json:"oidc_discovery_url,omitempty"`
+	SAMLEntityID      string   `json:"saml_entity_id,omitempty"`
+	SAMLMetadataURL   string   `json:"saml_metadata_url,omitempty"`
+	SAMLSignInURL     string   `json:"saml_sign_in_url,omitempty"`
+	SAMLSignOutURL    string   `json:"saml_sign_out_url,omitempty"`
+	SAMLX509Cert      string   `json:"saml_x509_cert,omitempty"`
+	Verified          bool     `json:"verified"`
+}
+
+type upsertSSORequest struct {
+	ClientID         *string  `json:"client_id"`
+	ClientSecret     *string  `json:"client_secret"`
+	ConnectionType   string   `json:"connection_type"`
+	DirectoryDomain  *string  `json:"directory_domain"`
+	EmailDomains     []string `json:"email_domains"`
+	Enabled          bool     `json:"enabled"`
+	JITDefaultRole   string   `json:"jit_default_role"`
+	OIDCClientID     *string  `json:"oidc_client_id"`
+	OIDCClientSecret *string  `json:"oidc_client_secret"`
+	OIDCDiscoveryURL *string  `json:"oidc_discovery_url"`
+	SAMLEntityID     *string  `json:"saml_entity_id"`
+	SAMLMetadataURL  *string  `json:"saml_metadata_url"`
+	SAMLSignInURL    *string  `json:"saml_sign_in_url"`
+	SAMLSignOutURL   *string  `json:"saml_sign_out_url"`
+	SAMLX509Cert     *string  `json:"saml_x509_cert"`
+}
+
+type ssoLookupResponse struct {
+	Auth0ConnectionName string `json:"auth0_connection_name"`
+	Auth0OrgID          string `json:"auth0_org_id"`
+	Required            bool   `json:"required"`
+	WorkspaceID         string `json:"workspace_id"`
+}
+
+// DeleteSSOConfig handles DELETE /workspaces/:workspace_id/sso
+func (h *SSOHandler) DeleteSSOConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	op := adapter.Operator(ctx)
+	uc := adapter.Usecases(ctx)
+
+	wsID, err := workspace.IDFrom(c.Param("workspace_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid workspace ID")
+	}
+
+	if err := uc.SSO.DeleteSSOConfig(ctx, wsID, op); err != nil {
+		return toHTTPError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// GetSSOConfig handles GET /workspaces/:workspace_id/sso
+func (h *SSOHandler) GetSSOConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	op := adapter.Operator(ctx)
+	uc := adapter.Usecases(ctx)
+
+	wsID, err := workspace.IDFrom(c.Param("workspace_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid workspace ID")
+	}
+
+	cfg, err := uc.SSO.GetSSOConfig(ctx, wsID, op)
+	if err != nil {
+		return toHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, toSSOConfigResponse(cfg, true))
+}
+
+// Lookup handles GET /sso/lookup?email=<email>
+func (h *SSOHandler) Lookup(c echo.Context) error {
+	ctx := c.Request().Context()
+	uc := adapter.Usecases(ctx)
+
+	email := strings.TrimSpace(c.QueryParam("email"))
+	if email == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email query parameter is required")
+	}
+
+	result, err := uc.SSO.LookupByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, rerror.ErrNotFound) {
+			return c.JSON(http.StatusOK, &ssoLookupResponse{Required: false})
+		}
+		return toHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, &ssoLookupResponse{
+		Auth0ConnectionName: result.Auth0ConnectionName,
+		Auth0OrgID:          result.Auth0OrgID,
+		Required:            result.Required,
+		WorkspaceID:         result.WorkspaceID.String(),
+	})
+}
+
+// UpsertSSOConfig handles PUT /workspaces/:workspace_id/sso
+func (h *SSOHandler) UpsertSSOConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	op := adapter.Operator(ctx)
+	uc := adapter.Usecases(ctx)
+
+	wsID, err := workspace.IDFrom(c.Param("workspace_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid workspace ID")
+	}
+
+	var req upsertSSORequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	param := interfaces.UpsertSSOConfigParam{
+		ClientID:         req.ClientID,
+		ClientSecret:     req.ClientSecret,
+		ConnectionType:   sso.ConnectionType(req.ConnectionType),
+		DirectoryDomain:  req.DirectoryDomain,
+		EmailDomains:     req.EmailDomains,
+		Enabled:          req.Enabled,
+		JITDefaultRole:   req.JITDefaultRole,
+		OIDCClientID:     req.OIDCClientID,
+		OIDCClientSecret: req.OIDCClientSecret,
+		OIDCDiscoveryURL: req.OIDCDiscoveryURL,
+		SAMLEntityID:     req.SAMLEntityID,
+		SAMLMetadataURL:  req.SAMLMetadataURL,
+		SAMLSignInURL:    req.SAMLSignInURL,
+		SAMLSignOutURL:   req.SAMLSignOutURL,
+		SAMLX509Cert:     req.SAMLX509Cert,
+	}
+
+	cfg, err := uc.SSO.UpsertSSOConfig(ctx, wsID, param, op)
+	if err != nil {
+		return toHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, toSSOConfigResponse(cfg, true))
+}
+
+// VerifySSOConfig handles POST /workspaces/:workspace_id/sso/verify
+func (h *SSOHandler) VerifySSOConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	op := adapter.Operator(ctx)
+	uc := adapter.Usecases(ctx)
+
+	wsID, err := workspace.IDFrom(c.Param("workspace_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid workspace ID")
+	}
+
+	if err := uc.SSO.VerifySSOConfig(ctx, wsID, op); err != nil {
+		return toHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func toSSOConfigResponse(cfg *sso.Config, maskSecrets bool) *ssoConfigResponse {
+	mask := func(s string) string {
+		if maskSecrets && s != "" {
+			return "***"
+		}
+		return s
+	}
+
+	domains := cfg.EmailDomains()
+	if domains == nil {
+		domains = []string{}
+	}
+
+	return &ssoConfigResponse{
+		Auth0ConnectionID: cfg.Auth0ConnectionID(),
+		Auth0OrgID:        cfg.Auth0OrgID(),
+		ClientID:          cfg.ClientID(),
+		ClientSecret:      mask(cfg.ClientSecret()),
+		ConnectionType:    string(cfg.ConnectionType()),
+		DirectoryDomain:   cfg.DirectoryDomain(),
+		EmailDomains:      domains,
+		Enabled:           cfg.Enabled(),
+		JITDefaultRole:    cfg.JITDefaultRole(),
+		OIDCClientID:      cfg.OIDCClientID(),
+		OIDCClientSecret:  mask(cfg.OIDCClientSecret()),
+		OIDCDiscoveryURL:  cfg.OIDCDiscoveryURL(),
+		SAMLEntityID:      cfg.SAMLEntityID(),
+		SAMLMetadataURL:   cfg.SAMLMetadataURL(),
+		SAMLSignInURL:     cfg.SAMLSignInURL(),
+		SAMLSignOutURL:    cfg.SAMLSignOutURL(),
+		SAMLX509Cert:      cfg.SAMLX509Cert(),
+		Verified:          cfg.Verified(),
+	}
+}
+
+func toHTTPError(err error) error {
+	if errors.Is(err, rerror.ErrNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, "not found")
+	}
+	if errors.Is(err, interfaces.ErrSSONotEnterprise) {
+		return echo.NewHTTPError(http.StatusForbidden, err.Error())
+	}
+	if errors.Is(err, interfaces.ErrSSOConfigNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	if errors.Is(err, interfaces.ErrOperationDenied) || errors.Is(err, interfaces.ErrPermissionDenied) {
+		return echo.NewHTTPError(http.StatusForbidden, err.Error())
+	}
+	if ierr := rerror.UnwrapErrInternal(err); ierr != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
+	}
+	return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+}

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/reearth/reearth-accounts/server/internal/adapter"
+	"github.com/reearth/reearth-accounts/server/internal/adapter/rest"
 	otelapp "github.com/reearth/reearth-accounts/server/internal/app/otel"
 	"github.com/reearth/reearth-accounts/server/internal/usecase/interactor"
 	"github.com/reearth/reearthx/appx"
@@ -123,6 +124,18 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	)
 
 	api.POST("/graphql", GraphqlAPI(cfg.Config, cfg.Config.Dev), middlewares...)
+
+	// SSO REST endpoints — authenticated (workspace-scoped)
+	ssoHandler := rest.NewSSOHandler()
+	wsSSO := api.Group("/workspaces/:workspace_id/sso", middlewares...)
+	wsSSO.GET("", ssoHandler.GetSSOConfig)
+	wsSSO.PUT("", ssoHandler.UpsertSSOConfig)
+	wsSSO.DELETE("", ssoHandler.DeleteSSOConfig)
+	wsSSO.POST("/verify", ssoHandler.VerifySSOConfig)
+
+	// SSO lookup — public (unauthenticated), only usecase middleware needed
+	publicSSO := api.Group("/sso", usecaseMiddleware)
+	publicSSO.GET("/lookup", ssoHandler.Lookup)
 
 	return e
 }

--- a/server/internal/infrastructure/memory/workspace.go
+++ b/server/internal/infrastructure/memory/workspace.go
@@ -135,6 +135,19 @@ func (r *Workspace) FindByName(_ context.Context, name string) (*workspace.Works
 	}), rerror.ErrNotFound)
 }
 
+func (r *Workspace) FindByEmailDomain(_ context.Context, domain string) (*workspace.Workspace, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if domain == "" {
+		return nil, rerror.ErrNotFound
+	}
+	return rerror.ErrIfNil(r.data.Find(func(_ workspace.ID, value *workspace.Workspace) bool {
+		sso := value.SSOConfig()
+		return sso != nil && sso.Enabled() && sso.HasEmailDomain(domain)
+	}), rerror.ErrNotFound)
+}
+
 func (r *Workspace) FindByAlias(_ context.Context, alias string) (*workspace.Workspace, error) {
 	if r.err != nil {
 		return nil, r.err

--- a/server/internal/infrastructure/mongo/mongodoc/workspace.go
+++ b/server/internal/infrastructure/mongo/mongodoc/workspace.go
@@ -5,9 +5,31 @@ import (
 
 	"github.com/reearth/reearth-accounts/server/pkg/id"
 	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/samber/lo"
 )
+
+type WorkspaceSSOConfigDocument struct {
+	Auth0ConnectionID string   `json:"auth0_connection_id,omitempty" bson:"auth0_connection_id,omitempty"`
+	Auth0OrgID        string   `json:"auth0_org_id,omitempty" bson:"auth0_org_id,omitempty"`
+	ClientID          string   `json:"client_id,omitempty" bson:"client_id,omitempty"`
+	ClientSecret      string   `json:"client_secret,omitempty" bson:"client_secret,omitempty"`
+	ConnectionType    string   `json:"connection_type" bson:"connection_type"`
+	DirectoryDomain   string   `json:"directory_domain,omitempty" bson:"directory_domain,omitempty"`
+	EmailDomains      []string `json:"email_domains,omitempty" bson:"email_domains,omitempty"`
+	Enabled           bool     `json:"enabled" bson:"enabled"`
+	JITDefaultRole    string   `json:"jit_default_role,omitempty" bson:"jit_default_role,omitempty"`
+	OIDCClientID      string   `json:"oidc_client_id,omitempty" bson:"oidc_client_id,omitempty"`
+	OIDCClientSecret  string   `json:"oidc_client_secret,omitempty" bson:"oidc_client_secret,omitempty"`
+	OIDCDiscoveryURL  string   `json:"oidc_discovery_url,omitempty" bson:"oidc_discovery_url,omitempty"`
+	SAMLEntityID      string   `json:"saml_entity_id,omitempty" bszon:"saml_entity_id,omitempty"`
+	SAMLMetadataURL   string   `json:"saml_metadata_url,omitempty" bson:"saml_metadata_url,omitempty"`
+	SAMLSignInURL     string   `json:"saml_sign_in_url,omitempty" bson:"saml_sign_in_url,omitempty"`
+	SAMLSignOutURL    string   `json:"saml_sign_out_url,omitempty" bson:"saml_sign_out_url,omitempty"`
+	SAMLX509Cert      string   `json:"saml_x509_cert,omitempty" bson:"saml_x509_cert,omitempty"`
+	Verified          bool     `json:"verified" bson:"verified"`
+}
 
 type WorkspaceMemberDocument struct {
 	Role      string `json:"role" jsonschema:"description=Member role (owner, maintainer, writer, reader). Default: \"\""`
@@ -34,6 +56,7 @@ type WorkspaceDocument struct {
 	MembersHash  string                             `json:"members_hash" bson:"members_hash,omitempty" jsonschema:"description=SHA256 hash of members and integrations for uniqueness tracking. Default: \"\""`
 	Personal     bool                               `json:"personal" bson:"personal" jsonschema:"required,description=Whether this is a personal workspace. Default: false"`
 	Policy       string                             `json:"policy" bson:"policy,omitempty" jsonschema:"description=Policy ID reference. Default: \"\""`
+	SSOConfig    *WorkspaceSSOConfigDocument        `json:"ssoconfig,omitempty" bson:"ssoconfig,omitempty" jsonschema:"description=SSO configuration for enterprise workspaces"`
 	UpdatedAt    time.Time                          `json:"updatedat" bson:"updatedat" jsonschema:"description=Last update timestamp"`
 }
 
@@ -72,6 +95,30 @@ func NewWorkspace(ws *workspace.Workspace) (*WorkspaceDocument, string) {
 		membersHash = ""
 	}
 
+	var ssoDoc *WorkspaceSSOConfigDocument
+	if sso := ws.SSOConfig(); sso != nil {
+		ssoDoc = &WorkspaceSSOConfigDocument{
+			Auth0ConnectionID: sso.Auth0ConnectionID(),
+			Auth0OrgID:        sso.Auth0OrgID(),
+			ClientID:          sso.ClientID(),
+			ClientSecret:      sso.ClientSecret(),
+			ConnectionType:    string(sso.ConnectionType()),
+			DirectoryDomain:   sso.DirectoryDomain(),
+			EmailDomains:      sso.EmailDomains(),
+			Enabled:           sso.Enabled(),
+			JITDefaultRole:    sso.JITDefaultRole(),
+			OIDCClientID:      sso.OIDCClientID(),
+			OIDCClientSecret:  sso.OIDCClientSecret(),
+			OIDCDiscoveryURL:  sso.OIDCDiscoveryURL(),
+			SAMLEntityID:      sso.SAMLEntityID(),
+			SAMLMetadataURL:   sso.SAMLMetadataURL(),
+			SAMLSignInURL:     sso.SAMLSignInURL(),
+			SAMLSignOutURL:    sso.SAMLSignOutURL(),
+			SAMLX509Cert:      sso.SAMLX509Cert(),
+			Verified:          sso.Verified(),
+		}
+	}
+
 	wId := ws.ID().String()
 	updatedAt := ws.UpdatedAt()
 	if updatedAt.IsZero() {
@@ -88,6 +135,7 @@ func NewWorkspace(ws *workspace.Workspace) (*WorkspaceDocument, string) {
 		MembersHash:  membersHash,
 		Personal:     ws.IsPersonal(),
 		Policy:       lo.FromPtr(ws.Policy()).String(),
+		SSOConfig:    ssoDoc,
 		UpdatedAt:    updatedAt,
 	}, wId
 }
@@ -139,6 +187,28 @@ func (d *WorkspaceDocument) Model() (*workspace.Workspace, error) {
 
 	metadata := workspace.MetadataFrom(d.Metadata.Description, d.Metadata.Website, d.Metadata.Location, d.Metadata.BillingEmail, d.Metadata.PhotoURL)
 
+	var ssoConfig *sso.Config
+	if d.SSOConfig != nil {
+		ssoConfig = sso.New(sso.ConnectionType(d.SSOConfig.ConnectionType))
+		ssoConfig.SetAuth0ConnectionID(d.SSOConfig.Auth0ConnectionID)
+		ssoConfig.SetAuth0OrgID(d.SSOConfig.Auth0OrgID)
+		ssoConfig.SetClientID(d.SSOConfig.ClientID)
+		ssoConfig.SetClientSecret(d.SSOConfig.ClientSecret)
+		ssoConfig.SetDirectoryDomain(d.SSOConfig.DirectoryDomain)
+		ssoConfig.SetEmailDomains(d.SSOConfig.EmailDomains)
+		ssoConfig.SetEnabled(d.SSOConfig.Enabled)
+		ssoConfig.SetJITDefaultRole(d.SSOConfig.JITDefaultRole)
+		ssoConfig.SetOIDCClientID(d.SSOConfig.OIDCClientID)
+		ssoConfig.SetOIDCClientSecret(d.SSOConfig.OIDCClientSecret)
+		ssoConfig.SetOIDCDiscoveryURL(d.SSOConfig.OIDCDiscoveryURL)
+		ssoConfig.SetSAMLEntityID(d.SSOConfig.SAMLEntityID)
+		ssoConfig.SetSAMLMetadataURL(d.SSOConfig.SAMLMetadataURL)
+		ssoConfig.SetSAMLSignInURL(d.SSOConfig.SAMLSignInURL)
+		ssoConfig.SetSAMLSignOutURL(d.SSOConfig.SAMLSignOutURL)
+		ssoConfig.SetSAMLX509Cert(d.SSOConfig.SAMLX509Cert)
+		ssoConfig.SetVerified(d.SSOConfig.Verified)
+	}
+
 	return workspace.New().
 		ID(tid).
 		Name(d.Name).
@@ -149,6 +219,7 @@ func (d *WorkspaceDocument) Model() (*workspace.Workspace, error) {
 		Integrations(integrations).
 		Personal(d.Personal).
 		Policy(policy).
+		SSOConfig(ssoConfig).
 		UpdatedAt(d.UpdatedAt).
 		Build()
 }

--- a/server/internal/infrastructure/mongo/workspace.go
+++ b/server/internal/infrastructure/mongo/workspace.go
@@ -125,6 +125,16 @@ func (r *Workspace) FindByName(ctx context.Context, name string) (*workspace.Wor
 	return w, nil
 }
 
+func (r *Workspace) FindByEmailDomain(ctx context.Context, domain string) (*workspace.Workspace, error) {
+	if domain == "" {
+		return nil, rerror.ErrNotFound
+	}
+	return r.findOne(ctx, bson.M{
+		"ssoconfig.email_domains": domain,
+		"ssoconfig.enabled":       true,
+	})
+}
+
 func (r *Workspace) FindByAlias(ctx context.Context, alias string) (*workspace.Workspace, error) {
 	if alias == "" {
 		return nil, rerror.ErrNotFound

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -25,6 +25,7 @@ func NewContainer(
 	cerbos := NewCerbos(r, cerbosAdapter)
 	return interfaces.Container{
 		Cerbos:    cerbos,
+		SSO:       NewSSO(r),
 		User:      NewUser(r, acg, config.SignupSecret, config.AuthSrvUIDomain, config.AllowedISS...),
 		Workspace: NewWorkspace(r, enforcer, cerbos),
 	}

--- a/server/internal/usecase/interactor/sso.go
+++ b/server/internal/usecase/interactor/sso.go
@@ -1,0 +1,195 @@
+package interactor
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+)
+
+type ssoInteractor struct {
+	repos *repo.Container
+}
+
+func NewSSO(r *repo.Container) interfaces.SSO {
+	return &ssoInteractor{repos: r}
+}
+
+func (s *ssoInteractor) DeleteSSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error {
+	return Run0(ctx, operator, s.repos,
+		Usecase().WithOwnableWorkspaces(workspaceID).Transaction(),
+		func(ctx context.Context) error {
+			ws, err := s.repos.Workspace.FindByID(ctx, workspaceID)
+			if err != nil {
+				return err
+			}
+
+			if !ws.IsEnterprise() {
+				return interfaces.ErrSSONotEnterprise
+			}
+
+			if ws.SSOConfig() == nil {
+				return interfaces.ErrSSOConfigNotFound
+			}
+
+			ws.DeleteSSOConfig()
+			return s.repos.Workspace.Save(ctx, ws)
+		})
+}
+
+func (s *ssoInteractor) GetSSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*sso.Config, error) {
+	return Run1(ctx, operator, s.repos,
+		Usecase().WithReadableWorkspaces(workspaceID),
+		func(ctx context.Context) (*sso.Config, error) {
+			ws, err := s.repos.Workspace.FindByID(ctx, workspaceID)
+			if err != nil {
+				return nil, err
+			}
+
+			if !ws.IsEnterprise() {
+				return nil, interfaces.ErrSSONotEnterprise
+			}
+
+			cfg := ws.SSOConfig()
+			if cfg == nil {
+				return nil, interfaces.ErrSSOConfigNotFound
+			}
+
+			return cfg, nil
+		})
+}
+
+func (s *ssoInteractor) LookupByEmail(ctx context.Context, email string) (*interfaces.SSOLookupResult, error) {
+	domain := extractDomain(email)
+	if domain == "" {
+		return nil, rerror.ErrNotFound
+	}
+
+	ws, err := s.repos.Workspace.FindByEmailDomain(ctx, domain)
+	if err != nil {
+		if errors.Is(err, rerror.ErrNotFound) {
+			return nil, rerror.ErrNotFound
+		}
+		return nil, err
+	}
+
+	cfg := ws.SSOConfig()
+	if cfg == nil || !cfg.Enabled() {
+		return nil, rerror.ErrNotFound
+	}
+
+	return &interfaces.SSOLookupResult{
+		Auth0ConnectionName: cfg.Auth0ConnectionID(),
+		Auth0OrgID:          cfg.Auth0OrgID(),
+		Required:            true,
+		WorkspaceID:         ws.ID(),
+	}, nil
+}
+
+func (s *ssoInteractor) UpsertSSOConfig(ctx context.Context, workspaceID workspace.ID, param interfaces.UpsertSSOConfigParam, operator *workspace.Operator) (*sso.Config, error) {
+	return Run1(ctx, operator, s.repos,
+		Usecase().WithOwnableWorkspaces(workspaceID).Transaction(),
+		func(ctx context.Context) (*sso.Config, error) {
+			ws, err := s.repos.Workspace.FindByID(ctx, workspaceID)
+			if err != nil {
+				return nil, err
+			}
+
+			if !ws.IsEnterprise() {
+				return nil, interfaces.ErrSSONotEnterprise
+			}
+
+			cfg := ws.SSOConfig()
+			if cfg == nil {
+				cfg = sso.New(param.ConnectionType)
+			}
+
+			cfg.SetConnectionType(param.ConnectionType)
+			cfg.SetEmailDomains(param.EmailDomains)
+			cfg.SetEnabled(param.Enabled)
+			cfg.SetJITDefaultRole(param.JITDefaultRole)
+
+			if param.ClientID != nil {
+				cfg.SetClientID(*param.ClientID)
+			}
+			if param.ClientSecret != nil {
+				cfg.SetClientSecret(*param.ClientSecret)
+			}
+			if param.DirectoryDomain != nil {
+				cfg.SetDirectoryDomain(*param.DirectoryDomain)
+			}
+
+			if param.OIDCClientID != nil {
+				cfg.SetOIDCClientID(*param.OIDCClientID)
+			}
+			if param.OIDCClientSecret != nil {
+				cfg.SetOIDCClientSecret(*param.OIDCClientSecret)
+			}
+			if param.OIDCDiscoveryURL != nil {
+				cfg.SetOIDCDiscoveryURL(*param.OIDCDiscoveryURL)
+			}
+
+			if param.SAMLEntityID != nil {
+				cfg.SetSAMLEntityID(*param.SAMLEntityID)
+			}
+			if param.SAMLMetadataURL != nil {
+				cfg.SetSAMLMetadataURL(*param.SAMLMetadataURL)
+			}
+			if param.SAMLSignInURL != nil {
+				cfg.SetSAMLSignInURL(*param.SAMLSignInURL)
+			}
+			if param.SAMLSignOutURL != nil {
+				cfg.SetSAMLSignOutURL(*param.SAMLSignOutURL)
+			}
+			if param.SAMLX509Cert != nil {
+				cfg.SetSAMLX509Cert(*param.SAMLX509Cert)
+			}
+
+			cfg.SetVerified(false)
+
+			ws.SetSSOConfig(cfg)
+			if err := s.repos.Workspace.Save(ctx, ws); err != nil {
+				return nil, err
+			}
+
+			return cfg, nil
+		})
+}
+
+func (s *ssoInteractor) VerifySSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error {
+	return Run0(ctx, operator, s.repos,
+		Usecase().WithOwnableWorkspaces(workspaceID).Transaction(),
+		func(ctx context.Context) error {
+			ws, err := s.repos.Workspace.FindByID(ctx, workspaceID)
+			if err != nil {
+				return err
+			}
+
+			if !ws.IsEnterprise() {
+				return interfaces.ErrSSONotEnterprise
+			}
+
+			cfg := ws.SSOConfig()
+			if cfg == nil {
+				return interfaces.ErrSSOConfigNotFound
+			}
+
+			// TODO(U-D20-03): call Auth0 Management API to validate connection
+			cfg.SetVerified(true)
+			ws.SetSSOConfig(cfg)
+			return s.repos.Workspace.Save(ctx, ws)
+		})
+}
+
+func extractDomain(email string) string {
+	parts := strings.SplitN(email, "@", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return strings.ToLower(parts[1])
+}

--- a/server/internal/usecase/interactor/sso_test.go
+++ b/server/internal/usecase/interactor/sso_test.go
@@ -1,0 +1,206 @@
+package interactor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSSOTest(t *testing.T) (*ssoInteractor, *workspace.Workspace, *workspace.Operator) {
+	t.Helper()
+
+	enterprisePolicy := workspace.PolicyEnterprise
+	ws := workspace.New().NewID().Name("Enterprise Corp").Personal(false).Policy(&enterprisePolicy).MustBuild()
+
+	wsRepo := memory.NewWorkspaceWith(ws)
+	r := &repo.Container{Workspace: wsRepo}
+
+	uc := &ssoInteractor{repos: r}
+	op := &workspace.Operator{
+		OwningWorkspaces: workspace.IDList{ws.ID()},
+	}
+
+	return uc, ws, op
+}
+
+func TestSSO_UpsertSSOConfig_Enterprise(t *testing.T) {
+	uc, ws, op := setupSSOTest(t)
+	ctx := context.Background()
+
+	param := interfaces.UpsertSSOConfigParam{
+		ConnectionType: sso.ConnectionTypeSAML,
+		Enabled:        true,
+		EmailDomains:   []string{"corp.com"},
+		JITDefaultRole: "member",
+		SAMLSignInURL:  strPtr("https://idp.corp.com/sso"),
+		SAMLX509Cert:   strPtr("-----BEGIN CERTIFICATE-----\nfake"),
+	}
+
+	cfg, err := uc.UpsertSSOConfig(ctx, ws.ID(), param, op)
+	require.NoError(t, err)
+	assert.Equal(t, sso.ConnectionTypeSAML, cfg.ConnectionType())
+	assert.True(t, cfg.Enabled())
+	assert.Equal(t, []string{"corp.com"}, cfg.EmailDomains())
+	assert.Equal(t, "member", cfg.JITDefaultRole())
+	assert.Equal(t, "https://idp.corp.com/sso", cfg.SAMLSignInURL())
+	assert.False(t, cfg.Verified(), "upsert must reset verified to false")
+}
+
+func TestSSO_UpsertSSOConfig_NonEnterprise(t *testing.T) {
+	freeWS := workspace.New().NewID().Name("Free Workspace").Personal(false).MustBuild()
+	wsRepo := memory.NewWorkspaceWith(freeWS)
+	r := &repo.Container{Workspace: wsRepo}
+	uc := &ssoInteractor{repos: r}
+
+	op := &workspace.Operator{OwningWorkspaces: workspace.IDList{freeWS.ID()}}
+	ctx := context.Background()
+
+	param := interfaces.UpsertSSOConfigParam{
+		ConnectionType: sso.ConnectionTypeOIDC,
+	}
+
+	_, err := uc.UpsertSSOConfig(ctx, freeWS.ID(), param, op)
+	assert.ErrorIs(t, err, interfaces.ErrSSONotEnterprise)
+}
+
+func TestSSO_GetSSOConfig_Found(t *testing.T) {
+	uc, ws, _ := setupSSOTest(t)
+	ctx := context.Background()
+
+	cfg := sso.New(sso.ConnectionTypeOIDC)
+	cfg.SetEnabled(true)
+	cfg.SetEmailDomains([]string{"example.com"})
+	ws.SetSSOConfig(cfg)
+	require.NoError(t, uc.repos.Workspace.Save(ctx, ws))
+
+	readOp := &workspace.Operator{ReadableWorkspaces: workspace.IDList{ws.ID()}}
+
+	got, err := uc.GetSSOConfig(ctx, ws.ID(), readOp)
+	require.NoError(t, err)
+	assert.Equal(t, sso.ConnectionTypeOIDC, got.ConnectionType())
+	assert.True(t, got.Enabled())
+}
+
+func TestSSO_GetSSOConfig_NotFound(t *testing.T) {
+	uc, ws, _ := setupSSOTest(t)
+	ctx := context.Background()
+
+	readOp := &workspace.Operator{ReadableWorkspaces: workspace.IDList{ws.ID()}}
+
+	_, err := uc.GetSSOConfig(ctx, ws.ID(), readOp)
+	assert.ErrorIs(t, err, interfaces.ErrSSOConfigNotFound)
+}
+
+func TestSSO_DeleteSSOConfig(t *testing.T) {
+	uc, ws, op := setupSSOTest(t)
+	ctx := context.Background()
+
+	cfg := sso.New(sso.ConnectionTypeSAML)
+	cfg.SetEnabled(true)
+	ws.SetSSOConfig(cfg)
+	require.NoError(t, uc.repos.Workspace.Save(ctx, ws))
+
+	err := uc.DeleteSSOConfig(ctx, ws.ID(), op)
+	require.NoError(t, err)
+
+	updated, err := uc.repos.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	assert.Nil(t, updated.SSOConfig())
+}
+
+func TestSSO_DeleteSSOConfig_ConfigNotFound(t *testing.T) {
+	uc, ws, op := setupSSOTest(t)
+	ctx := context.Background()
+
+	err := uc.DeleteSSOConfig(ctx, ws.ID(), op)
+	assert.ErrorIs(t, err, interfaces.ErrSSOConfigNotFound)
+}
+
+func TestSSO_LookupByEmail(t *testing.T) {
+	enterprisePolicy := workspace.PolicyEnterprise
+	ws := workspace.New().NewID().Name("Corp").Personal(false).Policy(&enterprisePolicy).MustBuild()
+	cfg := sso.New(sso.ConnectionTypeAzureAD)
+	cfg.SetEnabled(true)
+	cfg.SetEmailDomains([]string{"corp.com"})
+	cfg.SetAuth0ConnectionID("con_abc")
+	cfg.SetAuth0OrgID("org_xyz")
+	ws.SetSSOConfig(cfg)
+
+	wsRepo := memory.NewWorkspaceWith(ws)
+	r := &repo.Container{Workspace: wsRepo}
+	uc := &ssoInteractor{repos: r}
+	ctx := context.Background()
+
+	result, err := uc.LookupByEmail(ctx, "user@corp.com")
+	require.NoError(t, err)
+	assert.True(t, result.Required)
+	assert.Equal(t, ws.ID(), result.WorkspaceID)
+	assert.Equal(t, "con_abc", result.Auth0ConnectionName)
+	assert.Equal(t, "org_xyz", result.Auth0OrgID)
+}
+
+func TestSSO_LookupByEmail_NotFound(t *testing.T) {
+	wsRepo := memory.NewWorkspace()
+	r := &repo.Container{Workspace: wsRepo}
+	uc := &ssoInteractor{repos: r}
+	ctx := context.Background()
+
+	_, err := uc.LookupByEmail(ctx, "user@unknown.com")
+	assert.True(t, errors.Is(err, rerror.ErrNotFound))
+}
+
+func TestSSO_LookupByEmail_InvalidEmail(t *testing.T) {
+	wsRepo := memory.NewWorkspace()
+	r := &repo.Container{Workspace: wsRepo}
+	uc := &ssoInteractor{repos: r}
+	ctx := context.Background()
+
+	_, err := uc.LookupByEmail(ctx, "notanemail")
+	assert.True(t, errors.Is(err, rerror.ErrNotFound))
+}
+
+func TestSSO_VerifySSOConfig_Placeholder(t *testing.T) {
+	uc, ws, op := setupSSOTest(t)
+	ctx := context.Background()
+
+	cfg := sso.New(sso.ConnectionTypeSAML)
+	cfg.SetEnabled(true)
+	ws.SetSSOConfig(cfg)
+	require.NoError(t, uc.repos.Workspace.Save(ctx, ws))
+
+	err := uc.VerifySSOConfig(ctx, ws.ID(), op)
+	require.NoError(t, err)
+
+	updated, err := uc.repos.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	assert.True(t, updated.SSOConfig().Verified())
+}
+
+func TestExtractDomain(t *testing.T) {
+	tests := []struct {
+		email  string
+		domain string
+	}{
+		{"user@example.com", "example.com"},
+		{"USER@EXAMPLE.COM", "example.com"},
+		{"user@sub.domain.org", "sub.domain.org"},
+		{"notanemail", ""},
+		{"@nodomain", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			assert.Equal(t, tt.domain, extractDomain(tt.email))
+		})
+	}
+}

--- a/server/internal/usecase/interfaces/common.go
+++ b/server/internal/usecase/interfaces/common.go
@@ -13,6 +13,7 @@ var (
 
 type Container struct {
 	Cerbos    Cerbos
+	SSO       SSO
 	User      User
 	Workspace Workspace
 }

--- a/server/internal/usecase/interfaces/sso.go
+++ b/server/internal/usecase/interfaces/sso.go
@@ -1,0 +1,48 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/i18n"
+	"github.com/reearth/reearthx/rerror"
+)
+
+var (
+	ErrSSOConfigNotFound = rerror.NewE(i18n.T("SSO configuration not found"))
+	ErrSSONotEnterprise  = rerror.NewE(i18n.T("SSO requires enterprise plan"))
+)
+
+type UpsertSSOConfigParam struct {
+	ClientID         *string
+	ClientSecret     *string
+	ConnectionType   sso.ConnectionType
+	DirectoryDomain  *string
+	EmailDomains     []string
+	Enabled          bool
+	JITDefaultRole   string
+	OIDCClientID     *string
+	OIDCClientSecret *string
+	OIDCDiscoveryURL *string
+	SAMLEntityID     *string
+	SAMLMetadataURL  *string
+	SAMLSignInURL    *string
+	SAMLSignOutURL   *string
+	SAMLX509Cert     *string
+}
+
+type SSOLookupResult struct {
+	Auth0ConnectionName string
+	Auth0OrgID          string
+	Required            bool
+	WorkspaceID         workspace.ID
+}
+
+type SSO interface {
+	DeleteSSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error
+	GetSSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*sso.Config, error)
+	LookupByEmail(ctx context.Context, email string) (*SSOLookupResult, error)
+	UpsertSSOConfig(ctx context.Context, workspaceID workspace.ID, param UpsertSSOConfigParam, operator *workspace.Operator) (*sso.Config, error)
+	VerifySSOConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error
+}

--- a/server/pkg/sso/config.go
+++ b/server/pkg/sso/config.go
@@ -1,0 +1,79 @@
+package sso
+
+import "slices"
+
+type ConnectionType string
+
+const (
+	ConnectionTypeAzureAD         ConnectionType = "azure_ad"
+	ConnectionTypeGoogleWorkspace ConnectionType = "google_workspace"
+	ConnectionTypeOIDC            ConnectionType = "oidc"
+	ConnectionTypeOkta            ConnectionType = "okta"
+	ConnectionTypeSAML            ConnectionType = "saml"
+)
+
+type Config struct {
+	auth0ConnectionID string
+	auth0OrgID        string
+	clientID          string
+	clientSecret      string
+	connectionType    ConnectionType
+	directoryDomain   string
+	emailDomains      []string
+	enabled           bool
+	jitDefaultRole    string
+	oidcClientID      string
+	oidcClientSecret  string
+	oidcDiscoveryURL  string
+	samlEntityID      string
+	samlMetadataURL   string
+	samlSignInURL     string
+	samlSignOutURL    string
+	samlX509Cert      string
+	verified          bool
+}
+
+func New(connectionType ConnectionType) *Config {
+	return &Config{connectionType: connectionType}
+}
+
+func (s *Config) Auth0ConnectionID() string    { return s.auth0ConnectionID }
+func (s *Config) Auth0OrgID() string           { return s.auth0OrgID }
+func (s *Config) ClientID() string             { return s.clientID }
+func (s *Config) ClientSecret() string         { return s.clientSecret }
+func (s *Config) ConnectionType() ConnectionType { return s.connectionType }
+func (s *Config) DirectoryDomain() string      { return s.directoryDomain }
+func (s *Config) EmailDomains() []string       { return append([]string(nil), s.emailDomains...) }
+func (s *Config) Enabled() bool                { return s.enabled }
+func (s *Config) HasEmailDomain(domain string) bool {
+	return slices.Contains(s.emailDomains, domain)
+}
+func (s *Config) JITDefaultRole() string   { return s.jitDefaultRole }
+func (s *Config) OIDCClientID() string     { return s.oidcClientID }
+func (s *Config) OIDCClientSecret() string { return s.oidcClientSecret }
+func (s *Config) OIDCDiscoveryURL() string { return s.oidcDiscoveryURL }
+func (s *Config) SAMLEntityID() string     { return s.samlEntityID }
+func (s *Config) SAMLMetadataURL() string  { return s.samlMetadataURL }
+func (s *Config) SAMLSignInURL() string    { return s.samlSignInURL }
+func (s *Config) SAMLSignOutURL() string   { return s.samlSignOutURL }
+func (s *Config) SAMLX509Cert() string     { return s.samlX509Cert }
+func (s *Config) Verified() bool           { return s.verified }
+
+func (s *Config) SetAuth0ConnectionID(v string)      { s.auth0ConnectionID = v }
+func (s *Config) SetAuth0OrgID(v string)             { s.auth0OrgID = v }
+func (s *Config) SetClientID(v string)               { s.clientID = v }
+func (s *Config) SetClientSecret(v string)           { s.clientSecret = v }
+func (s *Config) SetConnectionType(v ConnectionType) { s.connectionType = v }
+func (s *Config) SetDirectoryDomain(v string)        { s.directoryDomain = v }
+func (s *Config) SetEmailDomains(v []string)         { s.emailDomains = append([]string(nil), v...) }
+func (s *Config) SetEnabled(v bool)                  { s.enabled = v }
+func (s *Config) SetJITDefaultRole(v string)         { s.jitDefaultRole = v }
+func (s *Config) SetOIDCClientID(v string)           { s.oidcClientID = v }
+func (s *Config) SetOIDCClientSecret(v string)       { s.oidcClientSecret = v }
+func (s *Config) SetOIDCDiscoveryURL(v string)       { s.oidcDiscoveryURL = v }
+func (s *Config) SetSAMLEntityID(v string)           { s.samlEntityID = v }
+func (s *Config) SetSAMLMetadataURL(v string)        { s.samlMetadataURL = v }
+func (s *Config) SetSAMLSignInURL(v string)          { s.samlSignInURL = v }
+func (s *Config) SetSAMLSignOutURL(v string)         { s.samlSignOutURL = v }
+func (s *Config) SetSAMLX509Cert(v string)           { s.samlX509Cert = v }
+func (s *Config) SetVerified(v bool)                 { s.verified = v }

--- a/server/pkg/sso/config_test.go
+++ b/server/pkg/sso/config_test.go
@@ -1,0 +1,75 @@
+package sso
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	cfg := New(ConnectionTypeSAML)
+	assert.Equal(t, ConnectionTypeSAML, cfg.ConnectionType())
+	assert.False(t, cfg.Enabled())
+	assert.Empty(t, cfg.EmailDomains())
+	assert.False(t, cfg.Verified())
+}
+
+func TestConfig_HasEmailDomain(t *testing.T) {
+	cfg := New(ConnectionTypeOIDC)
+	cfg.SetEmailDomains([]string{"example.com", "corp.org"})
+
+	assert.True(t, cfg.HasEmailDomain("example.com"))
+	assert.True(t, cfg.HasEmailDomain("corp.org"))
+	assert.False(t, cfg.HasEmailDomain("other.com"))
+	assert.False(t, cfg.HasEmailDomain(""))
+}
+
+func TestConfig_EmailDomainsIsolation(t *testing.T) {
+	cfg := New(ConnectionTypeSAML)
+	original := []string{"a.com", "b.com"}
+	cfg.SetEmailDomains(original)
+
+	original[0] = "changed.com"
+	assert.Equal(t, "a.com", cfg.EmailDomains()[0])
+
+	returned := cfg.EmailDomains()
+	returned[0] = "changed.com"
+	assert.Equal(t, "a.com", cfg.EmailDomains()[0])
+}
+
+func TestConfig_SAMLFields(t *testing.T) {
+	cfg := New(ConnectionTypeSAML)
+	cfg.SetSAMLSignInURL("https://idp.example.com/sso")
+	cfg.SetSAMLSignOutURL("https://idp.example.com/slo")
+	cfg.SetSAMLX509Cert("-----BEGIN CERTIFICATE-----\nMIIC...")
+	cfg.SetSAMLMetadataURL("https://idp.example.com/metadata")
+	cfg.SetSAMLEntityID("urn:example:sp")
+
+	assert.Equal(t, "https://idp.example.com/sso", cfg.SAMLSignInURL())
+	assert.Equal(t, "https://idp.example.com/slo", cfg.SAMLSignOutURL())
+	assert.Contains(t, cfg.SAMLX509Cert(), "CERTIFICATE")
+	assert.Equal(t, "https://idp.example.com/metadata", cfg.SAMLMetadataURL())
+	assert.Equal(t, "urn:example:sp", cfg.SAMLEntityID())
+}
+
+func TestConfig_OIDCFields(t *testing.T) {
+	cfg := New(ConnectionTypeOIDC)
+	cfg.SetOIDCDiscoveryURL("https://accounts.google.com/.well-known/openid-configuration")
+	cfg.SetOIDCClientID("client-id-123")
+	cfg.SetOIDCClientSecret("super-secret")
+
+	assert.Equal(t, "https://accounts.google.com/.well-known/openid-configuration", cfg.OIDCDiscoveryURL())
+	assert.Equal(t, "client-id-123", cfg.OIDCClientID())
+	assert.Equal(t, "super-secret", cfg.OIDCClientSecret())
+}
+
+func TestConfig_Auth0Fields(t *testing.T) {
+	cfg := New(ConnectionTypeAzureAD)
+	cfg.SetAuth0ConnectionID("con_abc123")
+	cfg.SetAuth0OrgID("org_xyz789")
+	cfg.SetVerified(true)
+
+	assert.Equal(t, "con_abc123", cfg.Auth0ConnectionID())
+	assert.Equal(t, "org_xyz789", cfg.Auth0OrgID())
+	assert.True(t, cfg.Verified())
+}

--- a/server/pkg/workspace/id.go
+++ b/server/pkg/workspace/id.go
@@ -25,6 +25,8 @@ var ErrInvalidID = id.ErrInvalidID
 
 type PolicyID string
 
+const PolicyEnterprise PolicyID = "enterprise"
+
 func (id PolicyID) Ref() *PolicyID {
 	return &id
 }

--- a/server/pkg/workspace/mock_workspace.go
+++ b/server/pkg/workspace/mock_workspace.go
@@ -100,6 +100,21 @@ func (mr *MockRepoMockRecorder) FindByAliases(ctx, aliases any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByAliases", reflect.TypeOf((*MockRepo)(nil).FindByAliases), ctx, aliases)
 }
 
+// FindByEmailDomain mocks base method.
+func (m *MockRepo) FindByEmailDomain(ctx context.Context, domain string) (*Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByEmailDomain", ctx, domain)
+	ret0, _ := ret[0].(*Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByEmailDomain indicates an expected call of FindByEmailDomain.
+func (mr *MockRepoMockRecorder) FindByEmailDomain(ctx, domain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByEmailDomain", reflect.TypeOf((*MockRepo)(nil).FindByEmailDomain), ctx, domain)
+}
+
 // FindByID mocks base method.
 func (m *MockRepo) FindByID(arg0 context.Context, arg1 ID) (*Workspace, error) {
 	m.ctrl.T.Helper()

--- a/server/pkg/workspace/repo.go
+++ b/server/pkg/workspace/repo.go
@@ -15,18 +15,19 @@ var (
 //go:generate mockgen -source=./repo.go -destination=./mock_workspace.go -package workspace
 type Repo interface {
 	Filtered(WorkspaceFilter) Repo
-	FindByID(context.Context, ID) (*Workspace, error)
-	FindByName(context.Context, string) (*Workspace, error)
+	Create(context.Context, *Workspace) error
 	FindByAlias(ctx context.Context, alias string) (*Workspace, error)
 	FindByAliases(ctx context.Context, aliases []string) (List, error)
+	FindByEmailDomain(ctx context.Context, domain string) (*Workspace, error)
+	FindByID(context.Context, ID) (*Workspace, error)
 	FindByIDs(context.Context, IDList) (List, error)
-	FindByUser(context.Context, user.ID) (List, error)
-	FindByUserWithPagination(ctx context.Context, id user.ID, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error)
 	FindByIntegration(context.Context, IntegrationID) (List, error)
 	FindByIntegrations(context.Context, IntegrationIDList) (List, error)
-	Create(context.Context, *Workspace) error
-	Save(context.Context, *Workspace) error
-	SaveAll(context.Context, List) error
+	FindByName(context.Context, string) (*Workspace, error)
+	FindByUser(context.Context, user.ID) (List, error)
+	FindByUserWithPagination(ctx context.Context, id user.ID, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error)
 	Remove(context.Context, ID) error
 	RemoveAll(context.Context, IDList) error
+	Save(context.Context, *Workspace) error
+	SaveAll(context.Context, List) error
 }

--- a/server/pkg/workspace/workspace.go
+++ b/server/pkg/workspace/workspace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
 	"github.com/reearth/reearthx/util"
 )
 
@@ -12,9 +13,10 @@ type Workspace struct {
 	name      string
 	alias     string
 	email     string
-	metadata  Metadata
 	members   *Members
+	metadata  Metadata
 	policy    *PolicyID
+	ssoConfig *sso.Config
 	updatedAt time.Time
 }
 
@@ -42,8 +44,16 @@ func (w *Workspace) Members() *Members {
 	return w.members
 }
 
+func (w *Workspace) IsEnterprise() bool {
+	return w.policy != nil && *w.policy == PolicyEnterprise
+}
+
 func (w *Workspace) IsPersonal() bool {
 	return w.members.Fixed()
+}
+
+func (w *Workspace) SSOConfig() *sso.Config {
+	return w.ssoConfig
 }
 
 func (w *Workspace) Rename(name string) {
@@ -77,8 +87,18 @@ func (w *Workspace) PolicytOr(def PolicyID) PolicyID {
 	return *w.policy
 }
 
+func (w *Workspace) DeleteSSOConfig() {
+	w.ssoConfig = nil
+	w.updatedAt = time.Now()
+}
+
 func (w *Workspace) SetPolicy(policy *PolicyID) {
 	w.policy = util.CloneRef(policy)
+	w.updatedAt = time.Now()
+}
+
+func (w *Workspace) SetSSOConfig(cfg *sso.Config) {
+	w.ssoConfig = cfg
 	w.updatedAt = time.Now()
 }
 

--- a/server/pkg/workspace/workspace_builder.go
+++ b/server/pkg/workspace/workspace_builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
 	"github.com/reearth/reearthx/util"
 )
 
@@ -112,6 +113,11 @@ func (b *Builder) Personal(p bool) *Builder {
 
 func (b *Builder) Policy(p *PolicyID) *Builder {
 	b.w.policy = util.CloneRef(p)
+	return b
+}
+
+func (b *Builder) SSOConfig(cfg *sso.Config) *Builder {
+	b.w.ssoConfig = cfg
 	return b
 }
 

--- a/server/pkg/workspace/workspace_test.go
+++ b/server/pkg/workspace/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/sso"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,4 +102,34 @@ func TestWorkspace_UpdatedAt_Getter(t *testing.T) {
 	}
 
 	assert.Equal(t, now, w.UpdatedAt())
+}
+
+func TestWorkspace_IsEnterprise(t *testing.T) {
+	p := PolicyEnterprise
+
+	enterprise := New().NewID().Name("Enterprise Corp").Personal(false).Policy(&p).MustBuild()
+	assert.True(t, enterprise.IsEnterprise())
+
+	free := New().NewID().Name("Free Workspace").Personal(false).MustBuild()
+	assert.False(t, free.IsEnterprise())
+
+	other := PolicyID("starter")
+	other2 := New().NewID().Name("Starter").Personal(false).Policy(&other).MustBuild()
+	assert.False(t, other2.IsEnterprise())
+}
+
+func TestWorkspace_SSOConfig(t *testing.T) {
+	ws := New().NewID().Name("Test").Personal(false).MustBuild()
+	assert.Nil(t, ws.SSOConfig())
+
+	cfg := sso.New(sso.ConnectionTypeSAML)
+	cfg.SetEnabled(true)
+	cfg.SetEmailDomains([]string{"corp.com"})
+
+	ws.SetSSOConfig(cfg)
+	assert.NotNil(t, ws.SSOConfig())
+	assert.True(t, ws.SSOConfig().Enabled())
+
+	ws.DeleteSSOConfig()
+	assert.Nil(t, ws.SSOConfig())
 }


### PR DESCRIPTION
## Why

Implements U-D20-02: backend persistence and REST API layer for workspace SSO configuration, as scoped in the D-20 SSO epic (SAML/OIDC integration via Auth0 Enterprise Connections).

The feature enables workspaces on the enterprise plan to store and manage their SSO configuration, and exposes a public email-domain lookup endpoint so Auth0 post-login actions can redirect users to the correct IdP connection.

**Key changes:**
- `pkg/sso` — new domain package for `Config` struct and `ConnectionType` enum (avoids polluting `pkg/workspace`)
- `pkg/workspace` — added `IsEnterprise()`, `SSOConfig()`, `SetSSOConfig()`, `DeleteSSOConfig()` on the Workspace aggregate; added `FindByEmailDomain` to Repo interface
- `internal/infrastructure/mongo` & `memory` — persist `sso_config` sub-document in workspace, implement `FindByEmailDomain`
- `internal/usecase/interfaces/sso.go` — `SSO` interface with `UpsertSSOConfig`, `GetSSOConfig`, `DeleteSSOConfig`, `VerifySSOConfig`, `LookupByEmail`
- `internal/usecase/interactor/sso.go` — interactor implementation with enterprise-plan gate
- `internal/adapter/rest/sso_handler.go` — Echo REST handlers; secrets masked as `"***"` in responses
- `internal/app/app.go` — routes registered: `GET/PUT/DELETE /api/workspaces/:workspace_id/sso` (auth required) and `GET /api/sso/lookup?email=` (public)

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations (SSO config stored as optional sub-document; no migration needed for existing workspace documents)
- [x] Verified that no PII is included in displayed values