### PR TITLE
fix(server): apply Cache-Control: private to REST API routes (SEC-01)

### DIFF
--- a/server/internal/adapter/http/router.go
+++ b/server/internal/adapter/http/router.go
@@ -16,6 +16,8 @@ import (
 type RouterConfig struct {
 	// AuthResolver reuses app/auth.go's FindBySub + operator builder pipeline.
 	AuthResolver AuthResolver
+	// CacheControl sets response cache headers (e.g. Cache-Control: private) on all REST responses.
+	CacheControl echo.MiddlewareFunc
 	// UsecaseMiddleware attaches *interfaces.Container to context (same as GraphQL path).
 	UsecaseMiddleware echo.MiddlewareFunc
 	// JWTMiddleware validates the bearer token into adapter.AuthInfoKey (appx). May be nil under mock auth.
@@ -55,6 +57,9 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 	}
 	if cfg.UsecaseMiddleware != nil {
 		base = append(base, cfg.UsecaseMiddleware)
+	}
+	if cfg.CacheControl != nil {
+		base = append(base, cfg.CacheControl)
 	}
 
 	required := RequiredAuth(cfg.AuthResolver)

--- a/server/internal/adapter/http/router_test.go
+++ b/server/internal/adapter/http/router_test.go
@@ -1,0 +1,63 @@
+package http_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	adapterhttp "github.com/reearth/reearth-accounts/server/internal/adapter/http"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubAuthConfigProvider struct{}
+
+func (stubAuthConfigProvider) GetAuth0Domain() string    { return "" }
+func (stubAuthConfigProvider) GetAuth0Audience() string  { return "" }
+func (stubAuthConfigProvider) GetAuth0WebClientID() string { return "" }
+func (stubAuthConfigProvider) GetAuthProvider() string   { return "auth0" }
+func (stubAuthConfigProvider) GetCIPAPIKey() string      { return "" }
+func (stubAuthConfigProvider) GetCIPAuthDomain() string  { return "" }
+func (stubAuthConfigProvider) GetCIPProjectID() string   { return "" }
+func (stubAuthConfigProvider) GetCIPTenantID() string    { return "" }
+
+func cacheControlMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("Cache-Control", "private")
+		return next(c)
+	}
+}
+
+func newRESTEcho(cfg adapterhttp.RouterConfig) *echo.Echo {
+	e := echo.New()
+	adapterhttp.RegisterRESTRouter(e, cfg)
+	return e
+}
+
+func TestRegisterRESTRouter_CacheControlHeader(t *testing.T) {
+	e := newRESTEcho(adapterhttp.RouterConfig{
+		AuthConfigProvider: stubAuthConfigProvider{},
+		CacheControl:       cacheControlMiddleware,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/config", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private", rec.Header().Get("Cache-Control"))
+}
+
+func TestRegisterRESTRouter_NoCacheControlWithoutMiddleware(t *testing.T) {
+	e := newRESTEcho(adapterhttp.RouterConfig{
+		AuthConfigProvider: stubAuthConfigProvider{},
+		// CacheControl deliberately omitted
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/config", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Cache-Control"))
+}

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -141,6 +141,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	}
 	adapterhttp.RegisterRESTRouter(e, adapterhttp.RouterConfig{
 		AuthResolver:       restAuthResolver(cfg),
+		CacheControl:       cacheControl,
 		UsecaseMiddleware:  usecaseMiddleware,
 		JWTMiddleware:      restJWT,
 		AuthConfigProvider: cfg.Config,


### PR DESCRIPTION
## Why

The REST `/api` group introduced in #248 was missing the `cacheControl` middleware that the GraphQL route already carries. Authenticated, per-user responses such as `GET /api/users/me` were emitted with no `Cache-Control` header, dropping below the baseline the project deliberately set for equivalent GraphQL responses.

Without `Cache-Control: private`, intermediary proxies or CDNs that apply heuristic TTLs could retain and serve one user's account data to another user on shared or proxied deployments (OWASP A02:2025, flagged as SEC-01).

**Root cause:** `RegisterRESTRouter` built the `/api` group with only `skipJWTOnAPIKey` + `UsecaseMiddleware` — the `cacheControl` middleware was never threaded through.

**Fix:** Added a `CacheControl echo.MiddlewareFunc` field to `RouterConfig` and appended it to the base middleware slice when non-nil. `app.go` now passes the existing `cacheControl` function (sets `Cache-Control: private`) into the new field, restoring parity with the GraphQL route.

Closes [SEC-01](https://github.com/eukarya-inc/compliance/issues/33)

## Checklist

- [x] Verified backward compatibility related to feature modifications (middleware is additive; nil-safe guard means no behaviour change when field is unset)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values