### PR TITLE
fix(server): cap FindByNameOrAlias results at 50 to prevent full collection scans

### DIFF
--- a/server/internal/infrastructure/conformance/conformance.go
+++ b/server/internal/infrastructure/conformance/conformance.go
@@ -2,6 +2,7 @@ package conformance
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,13 +21,14 @@ import (
 
 // Caps gates backend-specific assertions; memory leaves them false.
 type Caps struct {
-	RealTransactions     bool
+	CaseInsensitiveEmail bool
 	EnforcesFilter       bool
+	EnforcesLimit        bool
 	OrderedFindByIDs     bool
 	RealPagination       bool
-	UniqueEmail          bool
+	RealTransactions     bool
 	SubstringSearch      bool
-	CaseInsensitiveEmail bool
+	UniqueEmail          bool
 }
 
 type Factory func(t *testing.T) (*repo.Container, Caps, func())
@@ -38,6 +40,7 @@ func Run(t *testing.T, nc Factory) {
 	t.Run("User_FindByName_Alias_NameOrEmail", func(t *testing.T) { testUserFindByNameAliasEmail(t, nc) })
 	t.Run("User_FindByNameOrAlias", func(t *testing.T) { testUserFindByNameOrAlias(t, nc) })
 	t.Run("User_FindByNameOrAlias_Substring", func(t *testing.T) { testUserFindByNameOrAliasSubstring(t, nc) })
+	t.Run("User_FindByNameOrAlias_Limit", func(t *testing.T) { testUserFindByNameOrAliasLimit(t, nc) })
 	t.Run("User_CaseInsensitiveEmailAlias", func(t *testing.T) { testUserCaseInsensitiveEmailAlias(t, nc) })
 	t.Run("User_FindBySub", func(t *testing.T) { testUserFindBySub(t, nc) })
 	t.Run("User_FindBySubOrCreate", func(t *testing.T) { testUserFindBySubOrCreate(t, nc) })
@@ -198,6 +201,28 @@ func testUserFindByNameOrAliasSubstring(t *testing.T, nc Factory) {
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	assert.Equal(t, u.ID(), res[0].ID())
+}
+
+func testUserFindByNameOrAliasLimit(t *testing.T, nc Factory) {
+	c, caps, done := nc(t)
+	defer done()
+	if !caps.EnforcesLimit {
+		t.Skip("backend does not enforce FindByNameOrAlias result limit")
+	}
+	ctx := context.Background()
+	for i := range 51 {
+		u, err := user.New().NewID().
+			Name(fmt.Sprintf("LimitTest%02d", i)).
+			Alias(fmt.Sprintf("limitalias%02d", i)).
+			Email(fmt.Sprintf("limit%02d@example.com", i)).
+			Workspace(id.NewWorkspaceID()).Build()
+		require.NoError(t, err)
+		require.NoError(t, c.User.Create(ctx, u))
+	}
+
+	res, err := c.User.FindByNameOrAlias(ctx, "LimitTest")
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(res), 50)
 }
 
 func testUserCaseInsensitiveEmailAlias(t *testing.T, nc Factory) {

--- a/server/internal/infrastructure/conformance/mongo_test.go
+++ b/server/internal/infrastructure/conformance/mongo_test.go
@@ -43,10 +43,11 @@ func TestMongoConformance(t *testing.T) {
 		require.NoError(t, err)
 		return repos, Caps{
 			EnforcesFilter:   true,
+			EnforcesLimit:    true,
 			OrderedFindByIDs: true,
 			RealPagination:   true,
-			UniqueEmail:      true,
 			SubstringSearch:  true,
+			UniqueEmail:      true,
 		}, func() { _ = db.Drop(ctx) }
 	})
 }

--- a/server/internal/infrastructure/conformance/postgres_test.go
+++ b/server/internal/infrastructure/conformance/postgres_test.go
@@ -41,13 +41,14 @@ func TestPostgresConformance(t *testing.T) {
 		repos, err := postgres.New(ctx, pool, nil)
 		require.NoError(t, err)
 		return repos, Caps{
-			RealTransactions:     true,
+			CaseInsensitiveEmail: true,
 			EnforcesFilter:       true,
+			EnforcesLimit:        true,
 			OrderedFindByIDs:     true,
 			RealPagination:       true,
-			UniqueEmail:          true,
+			RealTransactions:     true,
 			SubstringSearch:      true,
-			CaseInsensitiveEmail: true,
+			UniqueEmail:          true,
 		}, func() {}
 	})
 }

--- a/server/internal/infrastructure/mongo/user.go
+++ b/server/internal/infrastructure/mongo/user.go
@@ -116,7 +116,7 @@ func (r *User) FindByNameOrAlias(ctx context.Context, nameOrAlias string) (user.
 			{"name": regex},
 			{"alias": regex},
 		},
-	})
+	}, options.Find().SetLimit(50).SetSort(bson.M{"name": 1}))
 }
 
 func (r *User) FindByNameOrEmail(ctx context.Context, nameOrEmail string) (*user.User, error) {

--- a/server/internal/infrastructure/postgres/user.go
+++ b/server/internal/infrastructure/postgres/user.go
@@ -177,7 +177,7 @@ func (r *User) FindByPasswordResetRequest(ctx context.Context, token string) (*u
 func (r *User) FindByNameOrAlias(ctx context.Context, nameOrAlias string) (user.List, error) {
 	kw := likeContains(nameOrAlias)
 	rows, err := r.c.db(ctx).Query(ctx,
-		`SELECT `+userColumns+` FROM users WHERE name ILIKE $1 OR alias ILIKE $1 ORDER BY id`, kw)
+		`SELECT `+userColumns+` FROM users WHERE name ILIKE $1 OR alias ILIKE $1 ORDER BY name LIMIT 50`, kw)
 	if err != nil {
 		return nil, rerror.ErrInternalByWithContext(ctx, err)
 	}


### PR DESCRIPTION
## Why

`FindByNameOrAlias` ran an unbounded case-insensitive `$regex` query over `name`/`alias` with no result limit, causing a full `COLLSCAN` on every call. As the user collection grows, this degrades linearly and can cause CPU/IO/memory blow-up when a common substring matches thousands of users.

Addresses [SCA-01](https://github.com/eukarya-inc/compliance/issues/33).

**Changes:**
- Added `.SetLimit(50).SetSort(bson.M{"name": 1})` to the Mongo `FindByNameOrAlias` query, matching the pattern already used by `SearchByKeyword`
- Added `LIMIT 50 ORDER BY name` to the Postgres equivalent
- Added a conformance test `User_FindByNameOrAlias_Limit` that inserts 51 matching users and asserts the result is capped at 50, gated by a new `EnforcesLimit` capability flag

## Checklist

- [x] Verified backward compatibility related to feature modifications (callers receive at most 50 results instead of unbounded — acceptable cap for a search-by-name query)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values