### PR TITLE
fix(server): batch permittable removal to eliminate N+1 on workspace remove

### DIFF
--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -762,17 +762,3 @@ func (i *Workspace) bulkUpdatePermittable(ctx context.Context, workspaceID works
 
 	return i.permittableRepo.SaveMany(ctx, toSave)
 }
-
-func (i *Workspace) removePermittable(ctx context.Context, userID user.ID, workspaceID workspace.ID) error {
-	p, err := i.permittableRepo.FindByUserID(ctx, userID)
-	if err != nil {
-		if errors.Is(err, rerror.ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-
-	p.RemoveWorkspaceRole(workspaceID)
-
-	return i.permittableRepo.Save(ctx, *p)
-}

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -375,10 +375,10 @@ func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.
 			if err != nil {
 				return nil, err
 			}
+		}
 
-			if err := i.removePermittable(ctx, uId, ws.ID()); err != nil {
-				return nil, err
-			}
+		if err := i.bulkRemovePermittable(ctx, id, user.IDList(userIds)); err != nil {
+			return nil, err
 		}
 
 		err = i.repos.Workspace.Save(ctx, ws)
@@ -528,10 +528,12 @@ func (i *Workspace) Remove(ctx context.Context, id workspace.ID, operator *works
 			return workspace.ErrCannotModifyPersonalWorkspace
 		}
 
+		userIDs := make(user.IDList, 0, len(ws.Members().Users()))
 		for uId := range ws.Members().Users() {
-			if err := i.removePermittable(ctx, uId, id); err != nil {
-				return err
-			}
+			userIDs = append(userIDs, uId)
+		}
+		if err := i.bulkRemovePermittable(ctx, id, userIDs); err != nil {
+			return err
 		}
 
 		err = i.repos.Workspace.Remove(ctx, id)
@@ -677,6 +679,29 @@ func (i *Workspace) updatePermittable(ctx context.Context, userID user.ID, works
 	p.UpdateWorkspaceRole(workspaceID, r.ID())
 
 	return i.permittableRepo.Save(ctx, *p)
+}
+
+func (i *Workspace) bulkRemovePermittable(ctx context.Context, workspaceID workspace.ID, userIDs user.IDList) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	existing, err := i.permittableRepo.FindByUserIDs(ctx, userIDs)
+	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+		return applog.ErrorWithCallerLogging(ctx, "failed to fetch permittables", err)
+	}
+
+	toSave := make(permittable.List, 0, len(existing))
+	for _, p := range existing {
+		p.RemoveWorkspaceRole(workspaceID)
+		toSave = append(toSave, p)
+	}
+
+	if len(toSave) == 0 {
+		return nil
+	}
+
+	return i.permittableRepo.SaveMany(ctx, toSave)
 }
 
 func (i *Workspace) bulkUpdatePermittable(ctx context.Context, workspaceID workspace.ID, userRoles map[user.ID]role.RoleType) error {

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -693,8 +693,11 @@ func (i *Workspace) bulkRemovePermittable(ctx context.Context, workspaceID works
 
 	toSave := make(permittable.List, 0, len(existing))
 	for _, p := range existing {
+		before := p.UpdatedAt()
 		p.RemoveWorkspaceRole(workspaceID)
-		toSave = append(toSave, p)
+		if p.UpdatedAt() != before {
+			toSave = append(toSave, p)
+		}
 	}
 
 	if len(toSave) == 0 {

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -2150,3 +2150,110 @@ func TestWorkspace_BulkUpdatePermittable(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestWorkspace_BulkRemovePermittable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	makeInteractor := func(db *repo.Container) *Workspace {
+		return &Workspace{
+			repos:           db,
+			permittableRepo: db.Permittable,
+			roleRepo:        db.Role,
+		}
+	}
+
+	t.Run("empty slice is a no-op", func(t *testing.T) {
+		t.Parallel()
+		db := memory.New()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		err := i.bulkRemovePermittable(ctx, wsID, user.IDList{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("removes workspace role from existing permittable", func(t *testing.T) {
+		t.Parallel()
+		db := memory.New()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		uID := id.NewUserID()
+
+		existing, _ := permittable.New().NewID().UserID(uID).
+			WorkspaceRoles([]permittable.WorkspaceRole{
+				permittable.NewWorkspaceRole(wsID, id.NewRoleID()),
+			}).Build()
+		_ = db.Permittable.Save(ctx, *existing)
+
+		err := i.bulkRemovePermittable(ctx, wsID, user.IDList{uID})
+		assert.NoError(t, err)
+
+		p, err := db.Permittable.FindByUserID(ctx, uID)
+		assert.NoError(t, err)
+		assert.Empty(t, p.WorkspaceRoles())
+	})
+
+	t.Run("skips users with no permittable without error", func(t *testing.T) {
+		t.Parallel()
+		db := memory.New()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+		uID := id.NewUserID()
+
+		err := i.bulkRemovePermittable(ctx, wsID, user.IDList{uID})
+		assert.NoError(t, err)
+	})
+
+	t.Run("preserves other workspace roles when removing one", func(t *testing.T) {
+		t.Parallel()
+		db := memory.New()
+		i := makeInteractor(db)
+		wsID1 := id.NewWorkspaceID()
+		wsID2 := id.NewWorkspaceID()
+		uID := id.NewUserID()
+		roleID2 := id.NewRoleID()
+
+		existing, _ := permittable.New().NewID().UserID(uID).
+			WorkspaceRoles([]permittable.WorkspaceRole{
+				permittable.NewWorkspaceRole(wsID1, id.NewRoleID()),
+				permittable.NewWorkspaceRole(wsID2, roleID2),
+			}).Build()
+		_ = db.Permittable.Save(ctx, *existing)
+
+		err := i.bulkRemovePermittable(ctx, wsID1, user.IDList{uID})
+		assert.NoError(t, err)
+
+		p, err := db.Permittable.FindByUserID(ctx, uID)
+		assert.NoError(t, err)
+		wrs := p.WorkspaceRoles()
+		assert.Len(t, wrs, 1)
+		assert.Equal(t, wsID2, wrs[0].ID())
+		assert.Equal(t, roleID2, wrs[0].RoleID())
+	})
+
+	t.Run("removes permittables for multiple users in one batch", func(t *testing.T) {
+		t.Parallel()
+		db := memory.New()
+		i := makeInteractor(db)
+		wsID := id.NewWorkspaceID()
+
+		uIDs := make(user.IDList, 5)
+		for j := range uIDs {
+			uIDs[j] = id.NewUserID()
+			p, _ := permittable.New().NewID().UserID(uIDs[j]).
+				WorkspaceRoles([]permittable.WorkspaceRole{
+					permittable.NewWorkspaceRole(wsID, id.NewRoleID()),
+				}).Build()
+			_ = db.Permittable.Save(ctx, *p)
+		}
+
+		err := i.bulkRemovePermittable(ctx, wsID, uIDs)
+		assert.NoError(t, err)
+
+		for _, uID := range uIDs {
+			p, err := db.Permittable.FindByUserID(ctx, uID)
+			assert.NoError(t, err)
+			assert.Empty(t, p.WorkspaceRoles())
+		}
+	})
+}


### PR DESCRIPTION
## Why

`Remove` and `RemoveMultipleUserMembers` both looped over workspace members calling `removePermittable` per user — 2 DB round-trips (`FindByUserID` + `Save`) per member, all serialized inside a single open transaction. For large workspaces this exhausts the connection pool and stalls writers (SCA-02).

`AddUserMember` was already fixed with `bulkUpdatePermittable` (commit e05ff50); this PR applies the same pattern to the removal paths.

**Changes:**
- Add `bulkRemovePermittable` — one `FindByUserIDs` + one `SaveMany`, reducing 2N round-trips to O(1)
- `Remove`: collect all member IDs, call `bulkRemovePermittable` once
- `RemoveMultipleUserMembers`: validate/leave loop first, then `bulkRemovePermittable` once
- Add `TestWorkspace_BulkRemovePermittable` covering empty no-op, single removal, missing permittable, role preservation, and multi-user batch

Closes [SCA-02](https://github.com/eukarya-inc/compliance/issues/33)

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values