### PR TITLE
fix(server): set default SSO user name to trigger intake form on first login

### DIFF
--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -375,7 +375,7 @@ func (h *UserHandler) SyncSSOUser(c echo.Context) error {
 	param := interfaces.SyncSSOUserParam{
 		Email:       req.Email,
 		Lang:        httpmodel.ParseLang(req.Lang),
-		Name:        httpmodel.SanitizeUsername(req.Name),
+		Name:        "user-", // To trigger intake-form on first login; the actual name is set by the user in the intake form.
 		Sub:         req.Sub,
 		Theme:       httpmodel.ParseTheme(req.Theme),
 		UserID:      uid,


### PR DESCRIPTION
## Why

On first SSO login, the user's name was being set from the SSO token directly via `SanitizeUsername`. This bypassed the intake form flow, which is intended to let users set their own display name.

By defaulting the name to `"user-"`, the intake form is triggered on first login, ensuring users go through the proper onboarding flow before their name is set.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values