### PR TITLE
feat(server): add dedicated API key for sync-sso route

### DIFF
--- a/server/internal/adapter/http/middleware_apikey.go
+++ b/server/internal/adapter/http/middleware_apikey.go
@@ -11,12 +11,21 @@ import (
 const bearerPrefix = "Bearer "
 
 // skipJWTOnAPIKey wraps the JWT middleware so a request whose bearer token equals
-// the configured M2M API key bypasses JWT validation and reaches APIKeyOrAuth.
-// Without this, the JWT validator (which runs first on the /api group) would
-// reject the API key as a malformed JWT before the API-key middleware ever runs,
-// effectively breaking the advertised M2M flow.
-func skipJWTOnAPIKey(apiKey string, jwt echo.MiddlewareFunc) echo.MiddlewareFunc {
-	if jwt == nil || apiKey == "" {
+// any of the configured M2M API keys bypasses JWT validation and reaches the
+// per-route key middleware. Without this, the JWT validator (which runs first on
+// the /api group) would reject the API key as a malformed JWT before the
+// API-key middleware ever runs, effectively breaking the advertised M2M flow.
+func skipJWTOnAPIKey(jwt echo.MiddlewareFunc, apiKeys ...string) echo.MiddlewareFunc {
+	if jwt == nil {
+		return jwt
+	}
+	keys := make([]string, 0, len(apiKeys))
+	for _, k := range apiKeys {
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
 		return jwt
 	}
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -24,8 +33,10 @@ func skipJWTOnAPIKey(apiKey string, jwt echo.MiddlewareFunc) echo.MiddlewareFunc
 			h := c.Request().Header.Get(echo.HeaderAuthorization)
 			if strings.HasPrefix(h, bearerPrefix) {
 				token := strings.TrimPrefix(h, bearerPrefix)
-				if subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) == 1 {
-					return next(c)
+				for _, k := range keys {
+					if subtle.ConstantTimeCompare([]byte(token), []byte(k)) == 1 {
+						return next(c)
+					}
 				}
 			}
 			return jwt(next)(c)

--- a/server/internal/adapter/http/middleware_apikey_test.go
+++ b/server/internal/adapter/http/middleware_apikey_test.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	httpinternal "github.com/reearth/reearth-accounts/server/internal/adapter/http/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipJWTOnAPIKey(t *testing.T) {
+	ok := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+	jwtCalled := false
+	jwtMW := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			jwtCalled = true
+			return next(c)
+		}
+	}
+
+	newCtx := func(token string) echo.Context {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if token != "" {
+			req.Header.Set(echo.HeaderAuthorization, bearerPrefix+token)
+		}
+		return e.NewContext(req, httptest.NewRecorder())
+	}
+
+	t.Run("nil jwt returns nil", func(t *testing.T) {
+		assert.Nil(t, skipJWTOnAPIKey(nil, "key"))
+	})
+
+	t.Run("no keys returns jwt directly", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW)
+		_ = m(ok)(newCtx("anything"))
+		assert.True(t, jwtCalled)
+	})
+
+	t.Run("all empty keys returns jwt directly", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW, "", "")
+		_ = m(ok)(newCtx("anything"))
+		assert.True(t, jwtCalled)
+	})
+
+	t.Run("token matches first key skips JWT", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW, "key1", "key2")
+		_ = m(ok)(newCtx("key1"))
+		assert.False(t, jwtCalled)
+	})
+
+	t.Run("token matches second key skips JWT", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW, "key1", "key2")
+		_ = m(ok)(newCtx("key2"))
+		assert.False(t, jwtCalled)
+	})
+
+	t.Run("unrecognized token runs JWT", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW, "key1", "key2")
+		_ = m(ok)(newCtx("unknown"))
+		assert.True(t, jwtCalled)
+	})
+
+	t.Run("no authorization header runs JWT", func(t *testing.T) {
+		jwtCalled = false
+		m := skipJWTOnAPIKey(jwtMW, "key1")
+		_ = m(ok)(newCtx(""))
+		assert.True(t, jwtCalled)
+	})
+}
+
+func TestAPIKeyOrAuth(t *testing.T) {
+	ok := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+	call := func(cfgKey, authHeader string) int {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if authHeader != "" {
+			req.Header.Set(echo.HeaderAuthorization, authHeader)
+		}
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		mw := APIKeyOrAuth(cfgKey)
+		if err := mw(ok)(c); err != nil {
+			httpinternal.CustomHTTPErrorHandler(err, c)
+		}
+		return rec.Code
+	}
+
+	t.Run("no key configured rejects request", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, call("", bearerPrefix+"anything"))
+	})
+
+	t.Run("correct key is accepted", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, call("secret", bearerPrefix+"secret"))
+	})
+
+	t.Run("wrong key is rejected", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, call("secret", bearerPrefix+"wrong"))
+	})
+
+	t.Run("no authorization header is rejected", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, call("secret", ""))
+	})
+
+	t.Run("token without Bearer prefix is rejected", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, call("secret", "secret"))
+	})
+}

--- a/server/internal/adapter/http/router.go
+++ b/server/internal/adapter/http/router.go
@@ -24,8 +24,10 @@ type RouterConfig struct {
 	JWTMiddleware echo.MiddlewareFunc
 	// AuthConfigProvider exposes Auth0 settings for GET /api/auth/config.
 	AuthConfigProvider adapter.Auth0ConfigProvider
-	// APIKey is the M2M key for service-to-service routes.
+	// APIKey is the M2M key for service-to-service routes (find-or-create, permissions/check).
 	APIKey string
+	// SyncSSOAPIKey is the dedicated M2M key for the sync-sso route.
+	SyncSSOAPIKey string
 	// Swagger basic-auth (optional).
 	SwaggerUser, SwaggerPass string
 	// Debug enables serving /swagger without credentials (debug/dev only); in
@@ -53,7 +55,7 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 		// APIKeyOrAuth (the API key is not a JWT, so the validator would otherwise
 		// reject it as malformed before APIKeyOrAuth ever runs). When no API key is
 		// configured this is a no-op.
-		base = append(base, skipJWTOnAPIKey(cfg.APIKey, cfg.JWTMiddleware))
+		base = append(base, skipJWTOnAPIKey(cfg.JWTMiddleware, cfg.APIKey, cfg.SyncSSOAPIKey))
 	}
 	if cfg.UsecaseMiddleware != nil {
 		base = append(base, cfg.UsecaseMiddleware)
@@ -65,6 +67,7 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 	required := RequiredAuth(cfg.AuthResolver)
 	optional := OptionalAuth(cfg.AuthResolver)
 	apikeyOrAuth := APIKeyOrAuth(cfg.APIKey)
+	syncSSOApikeyOrAuth := APIKeyOrAuth(cfg.SyncSSOAPIKey)
 
 	api := e.Group("/api", base...)
 
@@ -87,7 +90,7 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 	api.GET("/users/:id", uh.Get, required)
 	api.POST("/users/signup", uh.Signup, optional)
 	api.POST("/users/signup-oidc", uh.SignupOIDC, optional)
-	api.POST("/users/sync-sso", uh.SyncSSOUser, optional)
+	api.POST("/users/sync-sso", uh.SyncSSOUser, optional, syncSSOApikeyOrAuth)
 	api.POST("/users/verifications", uh.CreateVerification, optional)
 	api.POST("/users/verify", uh.VerifyUser)
 	api.POST("/users/password-reset/start", uh.StartPasswordReset)

--- a/server/internal/adapter/http/router_test.go
+++ b/server/internal/adapter/http/router_test.go
@@ -7,8 +7,16 @@ import (
 
 	"github.com/labstack/echo/v4"
 	adapterhttp "github.com/reearth/reearth-accounts/server/internal/adapter/http"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/appx"
 	"github.com/stretchr/testify/assert"
 )
+
+// stubAuthResolver always returns unauthenticated (no user resolved).
+func stubAuthResolver(_ echo.Context, _ *appx.AuthInfo) (*user.User, *workspace.Operator, error) {
+	return nil, nil, nil
+}
 
 type stubAuthConfigProvider struct{}
 
@@ -60,4 +68,57 @@ func TestRegisterRESTRouter_NoCacheControlWithoutMiddleware(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Empty(t, rec.Header().Get("Cache-Control"))
+}
+
+// TestSyncSSORoute_AuthGate verifies that the sync-sso route is protected by
+// SyncSSOAPIKey and is not accessible with the general RestAPIKey or no credentials.
+func TestSyncSSORoute_AuthGate(t *testing.T) {
+	const restKey = "rest-key"
+	const syncKey = "sync-key"
+
+	e := newRESTEcho(adapterhttp.RouterConfig{
+		AuthConfigProvider: stubAuthConfigProvider{},
+		AuthResolver:       stubAuthResolver,
+		APIKey:             restKey,
+		SyncSSOAPIKey:      syncKey,
+	})
+
+	doPost := func(authHeader string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/users/sync-sso", nil)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	assert.Equal(t, http.StatusUnauthorized, doPost(""), "no credentials → 401")
+	assert.Equal(t, http.StatusUnauthorized, doPost("Bearer "+restKey), "RestAPIKey must not grant access to sync-sso")
+	assert.NotEqual(t, http.StatusUnauthorized, doPost("Bearer "+syncKey), "SyncSSOAPIKey must pass the auth gate")
+}
+
+// TestSyncSSORoute_KeyIsolation verifies that the SyncSSOAPIKey is not accepted on
+// routes guarded by the general RestAPIKey (find-or-create, permissions/check).
+func TestSyncSSORoute_KeyIsolation(t *testing.T) {
+	const syncKey = "sync-key"
+
+	e := newRESTEcho(adapterhttp.RouterConfig{
+		AuthConfigProvider: stubAuthConfigProvider{},
+		AuthResolver:       stubAuthResolver,
+		SyncSSOAPIKey:      syncKey,
+		// APIKey (RestAPIKey) deliberately omitted
+	})
+
+	routes := []string{
+		"/api/users/find-or-create",
+		"/api/permissions/check",
+	}
+	for _, path := range routes {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set("Authorization", "Bearer "+syncKey)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "SyncSSOAPIKey must not grant access to %s", path)
+	}
 }

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -149,6 +149,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		JWTMiddleware:      restJWT,
 		AuthConfigProvider: cfg.Config,
 		APIKey:             cfg.Config.RestAPIKey,
+		SyncSSOAPIKey:      cfg.Config.SyncSSOAPIKey,
 		SwaggerUser:        cfg.Config.SwaggerBasicUser,
 		SwaggerPass:        cfg.Config.SwaggerBasicPass,
 		Debug:              cfg.Debug || cfg.Config.Dev,

--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -65,6 +65,7 @@ type Config struct {
 
 	// REST
 	RestAPIKey       string `envconfig:"REEARTH_ACCOUNTS_REST_API_KEY"`
+	SyncSSOAPIKey    string `envconfig:"REEARTH_ACCOUNTS_SYNC_SSO_API_KEY"`
 	SwaggerBasicUser string `envconfig:"REEARTH_ACCOUNTS_SWAGGER_BASIC_USER"`
 	SwaggerBasicPass string `envconfig:"REEARTH_ACCOUNTS_SWAGGER_BASIC_PASS"`
 


### PR DESCRIPTION
## Why

`POST /api/users/sync-sso` was previously protected only by `optional` auth, meaning unauthenticated requests could reach the handler. This PR introduces a dedicated M2M API key (`REEARTH_ACCOUNTS_SYNC_SSO_API_KEY`) for this route.

Using a separate key instead of reusing `REEARTH_ACCOUNTS_REST_API_KEY` follows the principle of least privilege:
- The SSO sync caller (e.g. an SSO provider integration) does not need access to `find-or-create` or `permissions/check`, and vice versa.
- Each key can be rotated independently without affecting other integrations.
- A compromised key limits blast radius to a single route.

The `skipJWTOnAPIKey` helper was also refactored from single-key to variadic so the JWT bypass layer correctly handles all configured M2M keys without duplication.

## Checklist

- [x] Verified backward compatibility related to feature modifications (callers that previously relied on unauthenticated access to sync-sso must set `REEARTH_ACCOUNTS_SYNC_SSO_API_KEY`)
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values