### PR TITLE
feat(server): add admin-users list/approve/reject with approval gating

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -15,6 +15,175 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin-users": {
+            "get": {
+                "description": "Lists admin users in creation order, optionally filtered by status, with offset pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "List admin users",
+                "parameters": [
+                    {
+                        "enum": [
+                            "pending",
+                            "approved",
+                            "rejected"
+                        ],
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListAdminUsersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid query",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin-users/{id}/approve": {
+            "post": {
+                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Approve an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin-users/{id}/reject": {
+            "post": {
+                "description": "Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Reject or revoke an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self / last approved admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
@@ -164,6 +333,38 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "AdminUser": {
+            "type": "object",
+            "properties": {
+                "approvedAt": {
+                    "type": "string"
+                },
+                "approvedBy": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pictureUrl": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "ErrorResponse": {
             "type": "object",
             "properties": {
@@ -202,6 +403,26 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "ListAdminUsersResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdminUser"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "perPage": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
                 }
             }
         },

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -8,6 +8,175 @@
     },
     "basePath": "/api/v1",
     "paths": {
+        "/admin-users": {
+            "get": {
+                "description": "Lists admin users in creation order, optionally filtered by status, with offset pagination.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "List admin users",
+                "parameters": [
+                    {
+                        "enum": [
+                            "pending",
+                            "approved",
+                            "rejected"
+                        ],
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListAdminUsersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid query",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin-users/{id}/approve": {
+            "post": {
+                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Approve an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin-users/{id}/reject": {
+            "post": {
+                "description": "Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Reject or revoke an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self / last approved admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
@@ -157,6 +326,38 @@
         }
     },
     "definitions": {
+        "AdminUser": {
+            "type": "object",
+            "properties": {
+                "approvedAt": {
+                    "type": "string"
+                },
+                "approvedBy": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pictureUrl": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "ErrorResponse": {
             "type": "object",
             "properties": {
@@ -195,6 +396,26 @@
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "ListAdminUsersResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdminUser"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "perPage": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
                 }
             }
         },

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -1,5 +1,26 @@
 basePath: /api/v1
 definitions:
+  AdminUser:
+    properties:
+      approvedAt:
+        type: string
+      approvedBy:
+        type: string
+      createdAt:
+        type: string
+      email:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      pictureUrl:
+        type: string
+      status:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   ErrorResponse:
     properties:
       code:
@@ -26,6 +47,19 @@ definitions:
         type: string
       status:
         type: string
+    type: object
+  ListAdminUsersResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/AdminUser'
+        type: array
+      page:
+        type: integer
+      perPage:
+        type: integer
+      totalCount:
+        type: integer
     type: object
   ListUsersResponse:
     properties:
@@ -72,6 +106,121 @@ info:
   title: Re:Earth Accounts Admin API
   version: "1.0"
 paths:
+  /admin-users:
+    get:
+      description: Lists admin users in creation order, optionally filtered by status,
+        with offset pagination.
+      parameters:
+      - description: Filter by status
+        enum:
+        - pending
+        - approved
+        - rejected
+        in: query
+        name: status
+        type: string
+      - description: Page number (1-based)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (max 100)
+        in: query
+        name: per_page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListAdminUsersResponse'
+        "400":
+          description: invalid query
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: List admin users
+      tags:
+      - admin-users
+  /admin-users/{id}/approve:
+    post:
+      description: Approves a pending admin user, recording the current admin as approver.
+        Cannot approve your own account.
+      parameters:
+      - description: Admin user ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminUser'
+        "400":
+          description: invalid id / cannot modify self
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: admin user not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Approve an admin user
+      tags:
+      - admin-users
+  /admin-users/{id}/reject:
+    post:
+      description: Rejects a pending admin user or revokes an approved one. Cannot
+        reject your own account, and the last approved admin cannot be rejected.
+      parameters:
+      - description: Admin user ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminUser'
+        "400":
+          description: invalid id / cannot modify self / last approved admin
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: admin user not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Reject or revoke an admin user
+      tags:
+      - admin-users
   /auth/google:
     post:
       consumes:

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -7,9 +7,11 @@ package di
 
 import (
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation"
+	adminuserhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/auth"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/user"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
@@ -52,6 +54,10 @@ func InitializeEcho() (*Server, func(), error) {
 	}
 	cookieSecure := provideCookieSecure(config)
 	authHandler := auth.NewHandler(googleSignInUseCase, getMeUseCase, manager, cookieSecure)
+	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(adminUserRepo)
+	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(adminUserRepo)
+	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(adminUserRepo)
+	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
 	v := provideJWTProviders(config)
 	middlewareFunc, err := middleware.NewAuthMiddleware(v, repo)
 	if err != nil {
@@ -59,7 +65,8 @@ func InitializeEcho() (*Server, func(), error) {
 		return nil, nil, err
 	}
 	sessionMiddleware := middleware.NewSessionMiddleware(manager)
-	presentationHandler := presentation.NewHandler(authHandler, userHandler, middlewareFunc, sessionMiddleware)
+	requireApprovedMiddleware := middleware.NewRequireApprovedMiddleware(manager, adminUserRepo)
+	presentationHandler := presentation.NewHandler(adminUserHandler, authHandler, userHandler, middlewareFunc, sessionMiddleware, requireApprovedMiddleware)
 	appMiddlewares := presentation.NewAppMiddlewares()
 	server := NewAppEchoServer(config, presentationHandler, appMiddlewares)
 	return server, func() {

--- a/server/internal/admin/di/wire_handler.go
+++ b/server/internal/admin/di/wire_handler.go
@@ -6,12 +6,14 @@ package di
 import (
 	"github.com/goforj/wire"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation"
+	adminuserhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
 	authhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/auth"
 	userhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/user"
 )
 
 // handlerWire provides the per-resource handlers and the aggregated Handler.
 var handlerWire = wire.NewSet(
+	adminuserhandler.NewHandler,
 	authhandler.NewHandler,
 	provideCookieSecure,
 	userhandler.NewHandler,

--- a/server/internal/admin/di/wire_middleware.go
+++ b/server/internal/admin/di/wire_middleware.go
@@ -15,5 +15,6 @@ var middlewareWire = wire.NewSet(
 	provideJWTProviders,
 	mw.NewAuthMiddleware,
 	mw.NewSessionMiddleware,
+	mw.NewRequireApprovedMiddleware,
 	presentation.NewAppMiddlewares,
 )

--- a/server/internal/admin/di/wire_usecase.go
+++ b/server/internal/admin/di/wire_usecase.go
@@ -5,6 +5,7 @@ package di
 
 import (
 	"github.com/goforj/wire"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
@@ -22,4 +23,9 @@ var usecaseWire = wire.NewSet(
 	provideGoogleSignInOptions,
 	authuc.NewGoogleSignInUseCase,
 	authuc.NewGetMeUseCase,
+
+	// admin-user management usecases
+	adminuseruc.NewListAdminUsersUseCase,
+	adminuseruc.NewApproveAdminUserUseCase,
+	adminuseruc.NewRejectAdminUserUseCase,
 )

--- a/server/internal/admin/presentation/error_handler.go
+++ b/server/internal/admin/presentation/error_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
 	"github.com/reearth/reearthx/log"
@@ -50,6 +51,10 @@ func classify(err error) (status int, code, msg string) {
 		return http.StatusForbidden, http.StatusText(http.StatusForbidden), "email not verified"
 	case errors.Is(err, authuc.ErrDomainNotAllowed):
 		return http.StatusForbidden, http.StatusText(http.StatusForbidden), "email domain not allowed"
+	case errors.Is(err, adminuseruc.ErrCannotModifySelf):
+		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot modify your own admin account"
+	case errors.Is(err, adminuseruc.ErrLastApprovedAdmin):
+		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot reject the last approved admin"
 	case errors.Is(err, rerror.ErrNotFound):
 		return http.StatusNotFound, http.StatusText(http.StatusNotFound), "not found"
 	default:

--- a/server/internal/admin/presentation/handler.go
+++ b/server/internal/admin/presentation/handler.go
@@ -2,6 +2,7 @@ package presentation
 
 import (
 	"github.com/labstack/echo/v4"
+	adminuserhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/auth"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/user"
 	mw "github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
@@ -9,18 +10,29 @@ import (
 
 // Handler aggregates all resource-specific admin handlers plus the middlewares.
 type Handler struct {
-	Auth      *auth.Handler
-	User      *user.Handler
-	AuthMw    echo.MiddlewareFunc
-	SessionMw mw.SessionMiddleware
+	AdminUser       *adminuserhandler.Handler
+	Auth            *auth.Handler
+	User            *user.Handler
+	AuthMw          echo.MiddlewareFunc
+	SessionMw       mw.SessionMiddleware
+	RequireApproved mw.RequireApprovedMiddleware
 }
 
 // NewHandler is a Wire provider that assembles the top-level admin Handler.
-func NewHandler(authHandler *auth.Handler, userHandler *user.Handler, authMw echo.MiddlewareFunc, sessionMw mw.SessionMiddleware) *Handler {
+func NewHandler(
+	adminUserHandler *adminuserhandler.Handler,
+	authHandler *auth.Handler,
+	userHandler *user.Handler,
+	authMw echo.MiddlewareFunc,
+	sessionMw mw.SessionMiddleware,
+	requireApproved mw.RequireApprovedMiddleware,
+) *Handler {
 	return &Handler{
-		Auth:      authHandler,
-		User:      userHandler,
-		AuthMw:    authMw,
-		SessionMw: sessionMw,
+		AdminUser:       adminUserHandler,
+		Auth:            authHandler,
+		User:            userHandler,
+		AuthMw:          authMw,
+		SessionMw:       sessionMw,
+		RequireApproved: requireApproved,
 	}
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler.go
@@ -1,0 +1,23 @@
+// Package adminuser implements the admin-user management endpoints (list /
+// approve / reject), all behind the RequireApproved middleware.
+package adminuser
+
+import (
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
+)
+
+// Handler serves the /admin-users endpoints.
+type Handler struct {
+	list    *adminuseruc.ListAdminUsersUseCase
+	approve *adminuseruc.ApproveAdminUserUseCase
+	reject  *adminuseruc.RejectAdminUserUseCase
+}
+
+// NewHandler is a Wire provider for the admin-user Handler.
+func NewHandler(
+	list *adminuseruc.ListAdminUsersUseCase,
+	approve *adminuseruc.ApproveAdminUserUseCase,
+	reject *adminuseruc.RejectAdminUserUseCase,
+) *Handler {
+	return &Handler{list: list, approve: approve, reject: reject}
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_approve.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_approve.go
@@ -1,0 +1,39 @@
+package adminuser
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// ApproveAdminUser godoc
+//
+//	@Summary		Approve an admin user
+//	@Description	Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.
+//	@Tags			admin-users
+//	@Produce		json
+//	@Param			id	path		string	true	"Admin user ID"
+//	@Success		200	{object}	AdminUserResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Router			/admin-users/{id}/approve [post]
+func (h *Handler) ApproveAdminUser(c echo.Context) error {
+	operator, err := internal.GetAdminUser(c)
+	if err != nil {
+		return err
+	}
+	targetID, err := adminuser.IDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	u, err := h.approve.Execute(c.Request().Context(), operator.ID(), targetID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newAdminUserResponse(u))
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_list.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_list.go
@@ -1,0 +1,70 @@
+package adminuser
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearth-accounts/server/pkg/pagination"
+)
+
+// ListAdminUsers godoc
+//
+//	@Summary		List admin users
+//	@Description	Lists admin users in creation order, optionally filtered by status, with offset pagination.
+//	@Tags			admin-users
+//	@Produce		json
+//	@Param			status		query		string	false	"Filter by status"	Enums(pending, approved, rejected)
+//	@Param			page		query		int		false	"Page number (1-based)"
+//	@Param			per_page	query		int		false	"Items per page (max 100)"
+//	@Success		200			{object}	ListAdminUsersResponse
+//	@Failure		400			{object}	internal.ErrorResponse	"invalid query"
+//	@Failure		401			{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403			{object}	internal.ErrorResponse	"not approved"
+//	@Router			/admin-users [get]
+func (h *Handler) ListAdminUsers(c echo.Context) error {
+	var filter adminuser.ListFilter
+
+	if s := c.QueryParam("status"); s != "" {
+		status, err := adminuser.StatusFrom(s)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid status")
+		}
+		filter.Status = &status
+	}
+
+	page := parseInt(c.QueryParam("page"))
+	perPage := parseInt(c.QueryParam("per_page"))
+	p := pagination.ToPagination(page, perPage)
+	filter.Pagination = p
+
+	list, pi, err := h.list.Execute(c.Request().Context(), filter)
+	if err != nil {
+		return err
+	}
+
+	effectivePage := int64(1)
+	if page > 0 {
+		effectivePage = page
+	}
+	return c.JSON(http.StatusOK, ListAdminUsersResponse{
+		Items:      newAdminUserResponses(list),
+		TotalCount: pi.TotalCount,
+		Page:       effectivePage,
+		PerPage:    p.Offset.Limit,
+	})
+}
+
+// parseInt returns the parsed positive int64, or 0 when empty/invalid (callers
+// treat 0 as "use the default").
+func parseInt(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_reject.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_reject.go
@@ -1,0 +1,39 @@
+package adminuser
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// RejectAdminUser godoc
+//
+//	@Summary		Reject or revoke an admin user
+//	@Description	Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.
+//	@Tags			admin-users
+//	@Produce		json
+//	@Param			id	path		string	true	"Admin user ID"
+//	@Success		200	{object}	AdminUserResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self / last approved admin"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Router			/admin-users/{id}/reject [post]
+func (h *Handler) RejectAdminUser(c echo.Context) error {
+	operator, err := internal.GetAdminUser(c)
+	if err != nil {
+		return err
+	}
+	targetID, err := adminuser.IDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	u, err := h.reject.Execute(c.Request().Context(), operator.ID(), targetID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newAdminUserResponse(u))
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -1,0 +1,141 @@
+package adminuser_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/auth/session"
+	adminpresentation "github.com/reearth/reearth-accounts/server/internal/admin/presentation"
+	adminuserhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
+	mw "github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecret = "test-secret-test-secret-test-secret"
+
+func approvedUser(email string) *adminuser.AdminUser {
+	return adminuser.New().NewID().Name(email).Email(email).Status(adminuser.StatusApproved).MustBuild()
+}
+func pendingUser(email string) *adminuser.AdminUser {
+	return adminuser.New().NewID().Name(email).Email(email).Status(adminuser.StatusPending).MustBuild()
+}
+
+func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
+	h := adminuserhandler.NewHandler(
+		adminuseruc.NewListAdminUsersUseCase(repo),
+		adminuseruc.NewApproveAdminUserUseCase(repo),
+		adminuseruc.NewRejectAdminUserUseCase(repo),
+	)
+	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, repo))
+
+	e := echo.New()
+	e.HTTPErrorHandler = adminpresentation.CustomHTTPErrorHandler
+	g := e.Group("/api/v1/admin-users", requireApproved)
+	g.GET("", h.ListAdminUsers)
+	g.POST("/:id/approve", h.ApproveAdminUser)
+	g.POST("/:id/reject", h.RejectAdminUser)
+	return e
+}
+
+func cookieFor(t *testing.T, sess *session.Manager, id adminuser.ID) *http.Cookie {
+	t.Helper()
+	tok, err := sess.Issue(id, time.Now())
+	require.NoError(t, err)
+	return &http.Cookie{Name: session.CookieName, Value: tok}
+}
+
+func TestListAdminUsers_OK(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	target := pendingUser("new@eukarya.io")
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-users", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body adminuserhandler.ListAdminUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, int64(2), body.TotalCount)
+	assert.Len(t, body.Items, 2)
+}
+
+func TestListAdminUsers_Unauthorized_NoCookie(t *testing.T) {
+	repo := memory.NewAdminUserWith(approvedUser("op@eukarya.io"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-users", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAdminUsers_Forbidden_WhenNotApproved(t *testing.T) {
+	pendingOp := pendingUser("pending@eukarya.io")
+	repo := memory.NewAdminUserWith(pendingOp)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-users", nil)
+	req.AddCookie(cookieFor(t, sess, pendingOp.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestApproveAdminUser_OK(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	target := pendingUser("new@eukarya.io")
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+target.ID().String()+"/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body adminuserhandler.AdminUserResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "approved", body.Status)
+	assert.Equal(t, op.ID().String(), body.ApprovedBy)
+}
+
+func TestApproveAdminUser_CannotApproveSelf(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+op.ID().String()+"/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRejectAdminUser_InvalidID(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/not-an-id/reject", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/server/internal/admin/presentation/handler/adminuser/response.go
+++ b/server/internal/admin/presentation/handler/adminuser/response.go
@@ -1,0 +1,55 @@
+package adminuser
+
+import (
+	"time"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// AdminUserResponse is a single admin user in the admin API.
+type AdminUserResponse struct {
+	ID         string     `json:"id"`
+	Email      string     `json:"email"`
+	Name       string     `json:"name"`
+	PictureURL string     `json:"pictureUrl"`
+	Status     string     `json:"status"`
+	ApprovedBy string     `json:"approvedBy,omitempty"`
+	ApprovedAt *time.Time `json:"approvedAt,omitempty"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+} // @name AdminUser
+
+// ListAdminUsersResponse is the paginated list of admin users.
+type ListAdminUsersResponse struct {
+	Items      []AdminUserResponse `json:"items"`
+	TotalCount int64               `json:"totalCount"`
+	Page       int64               `json:"page"`
+	PerPage    int64               `json:"perPage"`
+} // @name ListAdminUsersResponse
+
+func newAdminUserResponse(u *adminuser.AdminUser) AdminUserResponse {
+	res := AdminUserResponse{
+		ID:         u.ID().String(),
+		Email:      u.Email(),
+		Name:       u.Name(),
+		PictureURL: u.PictureURL(),
+		Status:     u.Status().String(),
+		CreatedAt:  u.CreatedAt(),
+		UpdatedAt:  u.UpdatedAt(),
+	}
+	if by := u.ApprovedBy(); !by.IsEmpty() {
+		res.ApprovedBy = by.String()
+	}
+	if at := u.ApprovedAt(); !at.IsZero() {
+		res.ApprovedAt = &at
+	}
+	return res
+}
+
+func newAdminUserResponses(list adminuser.List) []AdminUserResponse {
+	items := make([]AdminUserResponse, 0, len(list))
+	for _, u := range list {
+		items = append(items, newAdminUserResponse(u))
+	}
+	return items
+}

--- a/server/internal/admin/presentation/internal/context.go
+++ b/server/internal/admin/presentation/internal/context.go
@@ -14,6 +14,8 @@ const userContextKey = "admin:auth:user"
 
 const sessionAdminUserIDKey = "admin:session:adminuserid"
 
+const adminUserContextKey = "admin:session:adminuser"
+
 // SetUser stores the authenticated admin user in the echo context.
 // It must only be called from the auth middleware.
 func SetUser(c echo.Context, u *user.User) {
@@ -42,4 +44,20 @@ func GetSessionAdminUserID(c echo.Context) (adminuser.ID, error) {
 		return id, nil
 	}
 	return adminuser.ID{}, echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+}
+
+// SetAdminUser stores the fully-loaded, approved admin user in the echo context.
+// It must only be called from the RequireApproved middleware.
+func SetAdminUser(c echo.Context, u *adminuser.AdminUser) {
+	c.Set(adminUserContextKey, u)
+}
+
+// GetAdminUser retrieves the approved admin user loaded by the RequireApproved
+// middleware, returning 401 if absent. It must only be called from handlers
+// behind that middleware.
+func GetAdminUser(c echo.Context) (*adminuser.AdminUser, error) {
+	if u, ok := c.Get(adminUserContextKey).(*adminuser.AdminUser); ok && u != nil {
+		return u, nil
+	}
+	return nil, echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
 }

--- a/server/internal/admin/presentation/middleware/require_approved.go
+++ b/server/internal/admin/presentation/middleware/require_approved.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/auth/session"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/log"
+	"github.com/reearth/reearthx/rerror"
+)
+
+// RequireApprovedMiddleware is a named type so Wire can distinguish it from the
+// other middlewares (all echo.MiddlewareFunc underneath).
+type RequireApprovedMiddleware echo.MiddlewareFunc
+
+// NewRequireApprovedMiddleware builds middleware that authenticates via the
+// admin_session cookie AND requires the admin user to be approved. It loads the
+// user on every request (so a revoked admin loses access immediately) and
+// stores it in the context as the operator. Unauthenticated → 401; a
+// non-approved (pending/rejected) user → 403.
+func NewRequireApprovedMiddleware(sess *session.Manager, repo adminuser.Repo) RequireApprovedMiddleware {
+	return RequireApprovedMiddleware(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := c.Request().Context()
+
+			cookie, err := c.Cookie(session.CookieName)
+			if err != nil || cookie.Value == "" {
+				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+			}
+
+			id, err := sess.Parse(cookie.Value)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+			}
+
+			u, err := repo.FindByID(ctx, id)
+			if err != nil {
+				if errors.Is(err, rerror.ErrNotFound) {
+					return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+				}
+				log.Errorfc(ctx, "[admin] error loading admin user: %v", err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+
+			if !u.IsApproved() {
+				return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+			}
+
+			internal.SetAdminUser(c, u)
+			return next(c)
+		}
+	})
+}

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -27,6 +27,13 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		// Current admin user (any status)
 		v1.GET("/me", h.Auth.Me, sessionMw)
 
+		// Admin-user management (requires an approved admin session)
+		requireApproved := echo.MiddlewareFunc(h.RequireApproved)
+		adminUsers := v1.Group("/admin-users", requireApproved)
+		adminUsers.GET("", h.AdminUser.ListAdminUsers)
+		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser)
+		adminUsers.POST("/:id/reject", h.AdminUser.RejectAdminUser)
+
 		// Users (requires admin auth)
 		users := v1.Group("/users", h.AuthMw)
 		users.GET("", h.User.ListUsers)

--- a/server/internal/admin/usecase/adminuseruc/adminuseruc.go
+++ b/server/internal/admin/usecase/adminuseruc/adminuseruc.go
@@ -1,0 +1,20 @@
+// Package adminuseruc holds the admin-user management usecases: listing admin
+// users and approving / rejecting (revoking) them. Authorization is coarse for
+// V1 — every approved admin may manage others — so these usecases only enforce
+// the domain guards (no self-modification, keep at least one approved admin);
+// the "must be approved" gate is applied by the RequireApproved middleware.
+package adminuseruc
+
+import (
+	"github.com/reearth/reearthx/i18n"
+	"github.com/reearth/reearthx/rerror"
+)
+
+var (
+	// ErrCannotModifySelf is returned when an admin tries to approve/reject
+	// their own account.
+	ErrCannotModifySelf = rerror.NewE(i18n.T("cannot modify your own admin account"))
+	// ErrLastApprovedAdmin is returned when rejecting would remove the last
+	// approved admin.
+	ErrLastApprovedAdmin = rerror.NewE(i18n.T("cannot reject the last approved admin"))
+)

--- a/server/internal/admin/usecase/adminuseruc/adminuseruc_test.go
+++ b/server/internal/admin/usecase/adminuseruc/adminuseruc_test.go
@@ -1,0 +1,120 @@
+package adminuseruc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pending(email string) *adminuser.AdminUser {
+	return adminuser.New().NewID().Name(email).Email(email).Status(adminuser.StatusPending).MustBuild()
+}
+
+func approved(email string) *adminuser.AdminUser {
+	return adminuser.New().NewID().Name(email).Email(email).Status(adminuser.StatusApproved).MustBuild()
+}
+
+func TestApprove(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsApproved())
+	assert.Equal(t, operator.ID(), got.ApprovedBy())
+
+	// persisted
+	reloaded, err := repo.FindByID(ctx, target.ID())
+	require.NoError(t, err)
+	assert.True(t, reloaded.IsApproved())
+}
+
+func TestApprove_CannotApproveSelf(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), operator.ID())
+	assert.ErrorIs(t, err, ErrCannotModifySelf)
+}
+
+func TestApprove_NotFound(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), adminuser.NewID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+}
+
+func TestReject_Pending(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsRejected())
+}
+
+func TestReject_RevokeApproved(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	other := approved("other@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, other)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), other.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsRejected())
+}
+
+func TestReject_CannotRejectSelf(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), operator.ID())
+	assert.ErrorIs(t, err, ErrCannotModifySelf)
+}
+
+func TestReject_LastApprovedAdminBlocked(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	// only one approved admin (the operator); revoking the sole other approved
+	// admin is fine, but here target is the only approved besides operator...
+	// construct: operator + one approved target; total approved = 2, so ok.
+	// To hit the guard, make target the ONLY approved admin.
+	target := approved("solo@eukarya.io")
+	repo := memory.NewAdminUserWith(target) // operator not persisted; only target approved
+	uc := NewRejectAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), target.ID())
+	assert.ErrorIs(t, err, ErrLastApprovedAdmin)
+}
+
+func TestList_StatusFilter(t *testing.T) {
+	ctx := context.Background()
+	repo := memory.NewAdminUserWith(pending("p@eukarya.io"), approved("a@eukarya.io"))
+	uc := NewListAdminUsersUseCase(repo)
+
+	st := adminuser.StatusPending
+	got, pi, err := uc.Execute(ctx, adminuser.ListFilter{Status: &st})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, int64(1), pi.TotalCount)
+	assert.True(t, got[0].IsPending())
+}

--- a/server/internal/admin/usecase/adminuseruc/approve.go
+++ b/server/internal/admin/usecase/adminuseruc/approve.go
@@ -1,0 +1,36 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// ApproveAdminUserUseCase approves a (typically pending) admin user.
+type ApproveAdminUserUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewApproveAdminUserUseCase is a Wire provider for ApproveAdminUserUseCase.
+func NewApproveAdminUserUseCase(repo adminuser.Repo) *ApproveAdminUserUseCase {
+	return &ApproveAdminUserUseCase{repo: repo}
+}
+
+// Execute approves the target admin user, recording the operator as approver.
+// An admin cannot approve their own account.
+func (uc *ApproveAdminUserUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID) (*adminuser.AdminUser, error) {
+	if operatorID == targetID {
+		return nil, ErrCannotModifySelf
+	}
+
+	target, err := uc.repo.FindByID(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	target.Approve(operatorID)
+	if err := uc.repo.Save(ctx, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}

--- a/server/internal/admin/usecase/adminuseruc/list.go
+++ b/server/internal/admin/usecase/adminuseruc/list.go
@@ -1,0 +1,24 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/usecasex"
+)
+
+// ListAdminUsersUseCase lists admin users, optionally filtered by status, in
+// creation order with offset pagination.
+type ListAdminUsersUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewListAdminUsersUseCase is a Wire provider for ListAdminUsersUseCase.
+func NewListAdminUsersUseCase(repo adminuser.Repo) *ListAdminUsersUseCase {
+	return &ListAdminUsersUseCase{repo: repo}
+}
+
+// Execute returns the matching admin users and pagination info.
+func (uc *ListAdminUsersUseCase) Execute(ctx context.Context, filter adminuser.ListFilter) (adminuser.List, *usecasex.PageInfo, error) {
+	return uc.repo.List(ctx, filter)
+}

--- a/server/internal/admin/usecase/adminuseruc/reject.go
+++ b/server/internal/admin/usecase/adminuseruc/reject.go
@@ -1,0 +1,49 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// RejectAdminUserUseCase rejects a pending admin user or revokes an approved one.
+type RejectAdminUserUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewRejectAdminUserUseCase is a Wire provider for RejectAdminUserUseCase.
+func NewRejectAdminUserUseCase(repo adminuser.Repo) *RejectAdminUserUseCase {
+	return &RejectAdminUserUseCase{repo: repo}
+}
+
+// Execute rejects/revokes the target admin user. An admin cannot reject their
+// own account, and the last remaining approved admin cannot be rejected.
+func (uc *RejectAdminUserUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID) (*adminuser.AdminUser, error) {
+	if operatorID == targetID {
+		return nil, ErrCannotModifySelf
+	}
+
+	target, err := uc.repo.FindByID(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Revoking an approved admin must never drop the count of approved admins
+	// to zero (otherwise nobody could ever approve again).
+	if target.IsApproved() {
+		approved := adminuser.StatusApproved
+		_, pi, err := uc.repo.List(ctx, adminuser.ListFilter{Status: &approved})
+		if err != nil {
+			return nil, err
+		}
+		if pi != nil && pi.TotalCount <= 1 {
+			return nil, ErrLastApprovedAdmin
+		}
+	}
+
+	target.Reject()
+	if err := uc.repo.Save(ctx, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}


### PR DESCRIPTION
## Why

Implements **U-ADMIN-AUTH-04** (sub-issue of the admin auth epic: [eukarya-inc/reearth-dashboard#1233](https://github.com/eukarya-inc/reearth-dashboard/issues/1233)), building on the Google sign-in / session flow (#271) and the `AdminUser` domain/repos (#268/#269).

This adds the admin-user **management** surface: an approval gate plus the endpoints an approved admin uses to list, approve, and reject/revoke other admins.

## What's included

**RequireApproved middleware** (`internal/admin/presentation/middleware/require_approved.go`)
- Authenticates via the `admin_session` cookie and **loads the admin user on every request**, so a revoked admin loses access immediately (the design's "check status per request" option). Requires `status=approved`: unauthenticated → `401`, non-approved (pending/rejected) → `403`. Exposes the loaded user as the operator via context.

**Usecases** (`internal/admin/usecase/adminuseruc`)
- `List` — status filter (`?status=`) + creation-ordered offset pagination.
- `Approve` — approves a pending user, recording the operator as approver.
- `Reject` — rejects a pending user or revokes an approved one.
- Domain guards: an admin **cannot approve/reject their own account** (`400`), and the **last approved admin cannot be rejected** (`400`).

> Authorization is coarse for V1 per the epic non-goals (every approved admin may manage others), so there's no per-role Cerbos check here — the RequireApproved middleware is the gate.

**Endpoints** (`internal/admin/presentation/handler/adminuser`, behind RequireApproved)
- `GET  /api/v1/admin-users` (`?status`, `?page`, `?per_page`) → `{ items, totalCount, page, perPage }`
- `POST /api/v1/admin-users/{id}/approve`
- `POST /api/v1/admin-users/{id}/reject`

**Wiring / docs**
- DI providers + regenerated `wire_gen.go`; regenerated admin swagger; new `adminuseruc` error → HTTP mappings (`400`).

## Testing

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/admin/...` all pass:
- usecase unit tests: approve, reject (pending + revoke), self-guard, last-approved-admin guard, not-found, list status filter.
- HTTP tests: list OK, `401` without cookie, `403` for a non-approved session, approve OK, cannot-approve-self `400`, invalid-id `400`.

## Out of scope

- Frontend (`admin/`) admin-users UI (U-ADMIN-AUTH-06/07) and E2E (08).
- The double-submit CSRF token remains deferred per the epic design (SameSite=Lax for V1).

## Checklist

- [x] Verified backward compatibility related to feature modifications (new endpoints + additive wiring; existing auth untouched)
- [x] Confirmed backward compatibility for migrations (no migrations in this PR)
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
