### PR TITLE
feat(server): add admin-users approve endpoint

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -123,7 +123,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "admin user not found",
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -78,6 +78,59 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin-users/{id}/approve": {
+            "post": {
+                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Approve an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -80,7 +80,7 @@ const docTemplate = `{
         },
         "/admin-users/{id}/approve": {
             "post": {
-                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "description": "Approves a pending or rejected admin user, recording the current admin as approver. Idempotent for already-approved users (the original approver/timestamp is kept). Cannot approve your own account.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -71,6 +71,59 @@
                 }
             }
         },
+        "/admin-users/{id}/approve": {
+            "post": {
+                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Approve an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -73,7 +73,7 @@
         },
         "/admin-users/{id}/approve": {
             "post": {
-                "description": "Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.",
+                "description": "Approves a pending or rejected admin user, recording the current admin as approver. Idempotent for already-approved users (the original approver/timestamp is kept). Cannot approve your own account.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -116,7 +116,7 @@
                         }
                     },
                     "404": {
-                        "description": "admin user not found",
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -151,8 +151,9 @@ paths:
       - admin-users
   /admin-users/{id}/approve:
     post:
-      description: Approves a pending admin user, recording the current admin as approver.
-        Cannot approve your own account.
+      description: Approves a pending or rejected admin user, recording the current
+        admin as approver. Idempotent for already-approved users (the original approver/timestamp
+        is kept). Cannot approve your own account.
       parameters:
       - description: Admin user ID
         in: path

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -179,7 +179,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":
-          description: admin user not found
+          description: not found
           schema:
             $ref: '#/definitions/ErrorResponse'
       summary: Approve an admin user

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -149,6 +149,42 @@ paths:
       summary: List admin users
       tags:
       - admin-users
+  /admin-users/{id}/approve:
+    post:
+      description: Approves a pending admin user, recording the current admin as approver.
+        Cannot approve your own account.
+      parameters:
+      - description: Admin user ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminUser'
+        "400":
+          description: invalid id / cannot modify self
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: admin user not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Approve an admin user
+      tags:
+      - admin-users
   /auth/google:
     post:
       consumes:

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -55,7 +55,8 @@ func InitializeEcho() (*Server, func(), error) {
 	cookieSecure := provideCookieSecure(config)
 	authHandler := auth.NewHandler(googleSignInUseCase, getMeUseCase, manager, cookieSecure)
 	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(adminUserRepo)
-	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase)
+	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(adminUserRepo)
+	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase)
 	v := provideJWTProviders(config)
 	middlewareFunc, err := middleware.NewAuthMiddleware(v, repo)
 	if err != nil {

--- a/server/internal/admin/di/wire_usecase.go
+++ b/server/internal/admin/di/wire_usecase.go
@@ -26,4 +26,5 @@ var usecaseWire = wire.NewSet(
 
 	// admin-user management usecases
 	adminuseruc.NewListAdminUsersUseCase,
+	adminuseruc.NewApproveAdminUserUseCase,
 )

--- a/server/internal/admin/presentation/error_handler.go
+++ b/server/internal/admin/presentation/error_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
 	"github.com/reearth/reearthx/log"
@@ -50,6 +51,8 @@ func classify(err error) (status int, code, msg string) {
 		return http.StatusForbidden, http.StatusText(http.StatusForbidden), "email not verified"
 	case errors.Is(err, authuc.ErrDomainNotAllowed):
 		return http.StatusForbidden, http.StatusText(http.StatusForbidden), "email domain not allowed"
+	case errors.Is(err, adminuseruc.ErrCannotModifySelf):
+		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot modify your own admin account"
 	case errors.Is(err, rerror.ErrNotFound):
 		return http.StatusNotFound, http.StatusText(http.StatusNotFound), "not found"
 	default:

--- a/server/internal/admin/presentation/handler/adminuser/handler.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler.go
@@ -8,10 +8,14 @@ import (
 
 // Handler serves the /admin-users endpoints.
 type Handler struct {
-	list *adminuseruc.ListAdminUsersUseCase
+	list    *adminuseruc.ListAdminUsersUseCase
+	approve *adminuseruc.ApproveAdminUserUseCase
 }
 
 // NewHandler is a Wire provider for the admin-user Handler.
-func NewHandler(list *adminuseruc.ListAdminUsersUseCase) *Handler {
-	return &Handler{list: list}
+func NewHandler(
+	list *adminuseruc.ListAdminUsersUseCase,
+	approve *adminuseruc.ApproveAdminUserUseCase,
+) *Handler {
+	return &Handler{list: list, approve: approve}
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_approve.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_approve.go
@@ -11,7 +11,7 @@ import (
 // ApproveAdminUser godoc
 //
 //	@Summary		Approve an admin user
-//	@Description	Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.
+//	@Description	Approves a pending or rejected admin user, recording the current admin as approver. Idempotent for already-approved users (the original approver/timestamp is kept). Cannot approve your own account.
 //	@Tags			admin-users
 //	@Produce		json
 //	@Param			id	path		string	true	"Admin user ID"

--- a/server/internal/admin/presentation/handler/adminuser/handler_approve.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_approve.go
@@ -19,7 +19,7 @@ import (
 //	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self"
 //	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
 //	@Failure		403	{object}	internal.ErrorResponse	"not approved"
-//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Failure		404	{object}	internal.ErrorResponse	"not found"
 //	@Router			/admin-users/{id}/approve [post]
 func (h *Handler) ApproveAdminUser(c echo.Context) error {
 	operator, err := internal.GetAdminUser(c)

--- a/server/internal/admin/presentation/handler/adminuser/handler_approve.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_approve.go
@@ -1,0 +1,39 @@
+package adminuser
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// ApproveAdminUser godoc
+//
+//	@Summary		Approve an admin user
+//	@Description	Approves a pending admin user, recording the current admin as approver. Cannot approve your own account.
+//	@Tags			admin-users
+//	@Produce		json
+//	@Param			id	path		string	true	"Admin user ID"
+//	@Success		200	{object}	AdminUserResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Router			/admin-users/{id}/approve [post]
+func (h *Handler) ApproveAdminUser(c echo.Context) error {
+	operator, err := internal.GetAdminUser(c)
+	if err != nil {
+		return err
+	}
+	targetID, err := adminuser.IDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	u, err := h.approve.Execute(c.Request().Context(), operator.ID(), targetID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newAdminUserResponse(u))
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -29,13 +29,17 @@ func pendingUser(email string) *adminuser.AdminUser {
 }
 
 func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
-	h := adminuserhandler.NewHandler(adminuseruc.NewListAdminUsersUseCase(repo))
+	h := adminuserhandler.NewHandler(
+		adminuseruc.NewListAdminUsersUseCase(repo),
+		adminuseruc.NewApproveAdminUserUseCase(repo),
+	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, repo))
 
 	e := echo.New()
 	e.HTTPErrorHandler = adminpresentation.CustomHTTPErrorHandler
 	g := e.Group("/api/v1/admin-users", requireApproved)
 	g.GET("", h.ListAdminUsers)
+	g.POST("/:id/approve", h.ApproveAdminUser)
 	return e
 }
 
@@ -135,4 +139,49 @@ func TestListAdminUsers_Forbidden_WhenNotApproved(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestApproveAdminUser_OK(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	target := pendingUser("new@eukarya.io")
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+target.ID().String()+"/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body adminuserhandler.AdminUserResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "approved", body.Status)
+	assert.Equal(t, op.ID().String(), body.ApprovedBy)
+}
+
+func TestApproveAdminUser_CannotApproveSelf(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+op.ID().String()+"/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestApproveAdminUser_InvalidID(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/not-an-id/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -185,3 +185,17 @@ func TestApproveAdminUser_InvalidID(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+func TestApproveAdminUser_NotFound(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	// valid but non-existent id -> rerror.ErrNotFound -> 404 via error handler
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+adminuser.NewID().String()+"/approve", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -31,6 +31,7 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		requireApproved := echo.MiddlewareFunc(h.RequireApproved)
 		adminUsers := v1.Group("/admin-users", requireApproved)
 		adminUsers.GET("", h.AdminUser.ListAdminUsers)
+		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser)
 
 		// Users (requires admin auth)
 		users := v1.Group("/users", h.AuthMw)

--- a/server/internal/admin/usecase/adminuseruc/approve.go
+++ b/server/internal/admin/usecase/adminuseruc/approve.go
@@ -28,6 +28,13 @@ func (uc *ApproveAdminUserUseCase) Execute(ctx context.Context, operatorID, targ
 		return nil, err
 	}
 
+	// Approve is idempotent: for an already-approved user AdminUser.Approve is a
+	// no-op (it preserves the original approver/timestamp), so skip the redundant
+	// write and return the record as-is.
+	if target.IsApproved() {
+		return target, nil
+	}
+
 	target.Approve(operatorID)
 	if err := uc.repo.Save(ctx, target); err != nil {
 		return nil, err

--- a/server/internal/admin/usecase/adminuseruc/approve.go
+++ b/server/internal/admin/usecase/adminuseruc/approve.go
@@ -1,0 +1,36 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// ApproveAdminUserUseCase approves a (typically pending) admin user.
+type ApproveAdminUserUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewApproveAdminUserUseCase is a Wire provider for ApproveAdminUserUseCase.
+func NewApproveAdminUserUseCase(repo adminuser.Repo) *ApproveAdminUserUseCase {
+	return &ApproveAdminUserUseCase{repo: repo}
+}
+
+// Execute approves the target admin user, recording the operator as approver.
+// An admin cannot approve their own account.
+func (uc *ApproveAdminUserUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID) (*adminuser.AdminUser, error) {
+	if operatorID == targetID {
+		return nil, ErrCannotModifySelf
+	}
+
+	target, err := uc.repo.FindByID(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	target.Approve(operatorID)
+	if err := uc.repo.Save(ctx, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}

--- a/server/internal/admin/usecase/adminuseruc/approve.go
+++ b/server/internal/admin/usecase/adminuseruc/approve.go
@@ -31,6 +31,13 @@ func (uc *ApproveAdminUserUseCase) Execute(ctx context.Context, operatorID, targ
 	// Approve is idempotent: for an already-approved user AdminUser.Approve is a
 	// no-op (it preserves the original approver/timestamp), so skip the redundant
 	// write and return the record as-is.
+	//
+	// NOTE: this is a read-modify-write, not atomic. Two admins approving the
+	// same pending user at the exact same moment could both read it as pending
+	// and both write, so the last write wins and records that approver. This is
+	// benign — the recorded approver is still one of the two legitimate admins
+	// and no invariant is violated (unlike reject, this can't leave zero approved
+	// admins) — so atomic enforcement is not worth the cost here.
 	if target.IsApproved() {
 		return target, nil
 	}

--- a/server/internal/admin/usecase/adminuseruc/approve_test.go
+++ b/server/internal/admin/usecase/adminuseruc/approve_test.go
@@ -1,0 +1,49 @@
+package adminuseruc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApprove(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsApproved())
+	assert.Equal(t, operator.ID(), got.ApprovedBy())
+
+	reloaded, err := repo.FindByID(ctx, target.ID())
+	require.NoError(t, err)
+	assert.True(t, reloaded.IsApproved())
+}
+
+func TestApprove_CannotApproveSelf(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), operator.ID())
+	assert.ErrorIs(t, err, ErrCannotModifySelf)
+}
+
+func TestApprove_NotFound(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), adminuser.NewID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+}

--- a/server/internal/admin/usecase/adminuseruc/approve_test.go
+++ b/server/internal/admin/usecase/adminuseruc/approve_test.go
@@ -28,6 +28,21 @@ func TestApprove(t *testing.T) {
 	assert.True(t, reloaded.IsApproved())
 }
 
+func TestApprove_AlreadyApprovedIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	firstApprover := adminuser.NewID()
+	target := pending("t@eukarya.io")
+	target.Approve(firstApprover) // pending -> approved by firstApprover
+	repo := memory.NewAdminUserWith(target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	// a different operator re-approves: no-op, original approver preserved
+	got, err := uc.Execute(ctx, adminuser.NewID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsApproved())
+	assert.Equal(t, firstApprover, got.ApprovedBy())
+}
+
 func TestApprove_CannotApproveSelf(t *testing.T) {
 	ctx := context.Background()
 	operator := approved("op@eukarya.io")

--- a/server/internal/admin/usecase/adminuseruc/errors.go
+++ b/server/internal/admin/usecase/adminuseruc/errors.go
@@ -1,0 +1,10 @@
+package adminuseruc
+
+import (
+	"github.com/reearth/reearthx/i18n"
+	"github.com/reearth/reearthx/rerror"
+)
+
+// ErrCannotModifySelf is returned when an admin tries to approve/reject their
+// own account.
+var ErrCannotModifySelf = rerror.NewE(i18n.T("cannot modify your own admin account"))


### PR DESCRIPTION
## Why

Part 2/3 of **U-ADMIN-AUTH-04**. Stacked on #273 (RequireApproved + list).

> Base branch is `feat/admin-users-list`, so the diff shows only the approve changes. Review/merge #273 first.

## What's included

- **adminuseruc.Approve** usecase: approves a pending admin user, recording the operator as approver. An admin **cannot approve their own account** (`ErrCannotModifySelf` → 400).
- `POST /api/v1/admin-users/{id}/approve` behind RequireApproved.
- DI wiring + regenerated `wire_gen.go` and admin swagger; error mapping.

## Testing

`go build`, `go vet`, `gofmt`, `go test ./internal/admin/...` all pass. Approve usecase test (approve, self-guard, not-found) + HTTP tests (approve OK, cannot-approve-self, invalid id).

## Checklist

- [x] Verified backward compatibility (new endpoint + additive wiring)
- [x] Confirmed backward compatibility for migrations (none in this PR)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)