### PR TITLE
feat(server): add admin-users reject endpoint

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -176,7 +176,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "admin user not found",
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -131,6 +131,59 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin-users/{id}/reject": {
+            "post": {
+                "description": "Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Reject or revoke an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self / last approved admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -124,6 +124,59 @@
                 }
             }
         },
+        "/admin-users/{id}/reject": {
+            "post": {
+                "description": "Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Reject or revoke an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / cannot modify self / last approved admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "admin user not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -169,7 +169,7 @@
                         }
                     },
                     "404": {
-                        "description": "admin user not found",
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -216,7 +216,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":
-          description: admin user not found
+          description: not found
           schema:
             $ref: '#/definitions/ErrorResponse'
       summary: Reject or revoke an admin user

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -186,6 +186,42 @@ paths:
       summary: Approve an admin user
       tags:
       - admin-users
+  /admin-users/{id}/reject:
+    post:
+      description: Rejects a pending admin user or revokes an approved one. Cannot
+        reject your own account, and the last approved admin cannot be rejected.
+      parameters:
+      - description: Admin user ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminUser'
+        "400":
+          description: invalid id / cannot modify self / last approved admin
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: admin user not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Reject or revoke an admin user
+      tags:
+      - admin-users
   /auth/google:
     post:
       consumes:

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -56,7 +56,8 @@ func InitializeEcho() (*Server, func(), error) {
 	authHandler := auth.NewHandler(googleSignInUseCase, getMeUseCase, manager, cookieSecure)
 	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(adminUserRepo)
 	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(adminUserRepo)
-	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase)
+	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(adminUserRepo)
+	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
 	v := provideJWTProviders(config)
 	middlewareFunc, err := middleware.NewAuthMiddleware(v, repo)
 	if err != nil {

--- a/server/internal/admin/di/wire_usecase.go
+++ b/server/internal/admin/di/wire_usecase.go
@@ -27,4 +27,5 @@ var usecaseWire = wire.NewSet(
 	// admin-user management usecases
 	adminuseruc.NewListAdminUsersUseCase,
 	adminuseruc.NewApproveAdminUserUseCase,
+	adminuseruc.NewRejectAdminUserUseCase,
 )

--- a/server/internal/admin/presentation/error_handler.go
+++ b/server/internal/admin/presentation/error_handler.go
@@ -53,6 +53,8 @@ func classify(err error) (status int, code, msg string) {
 		return http.StatusForbidden, http.StatusText(http.StatusForbidden), "email domain not allowed"
 	case errors.Is(err, adminuseruc.ErrCannotModifySelf):
 		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot modify your own admin account"
+	case errors.Is(err, adminuseruc.ErrLastApprovedAdmin):
+		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot reject the last approved admin"
 	case errors.Is(err, rerror.ErrNotFound):
 		return http.StatusNotFound, http.StatusText(http.StatusNotFound), "not found"
 	default:

--- a/server/internal/admin/presentation/handler/adminuser/handler.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler.go
@@ -10,12 +10,14 @@ import (
 type Handler struct {
 	list    *adminuseruc.ListAdminUsersUseCase
 	approve *adminuseruc.ApproveAdminUserUseCase
+	reject  *adminuseruc.RejectAdminUserUseCase
 }
 
 // NewHandler is a Wire provider for the admin-user Handler.
 func NewHandler(
 	list *adminuseruc.ListAdminUsersUseCase,
 	approve *adminuseruc.ApproveAdminUserUseCase,
+	reject *adminuseruc.RejectAdminUserUseCase,
 ) *Handler {
-	return &Handler{list: list, approve: approve}
+	return &Handler{list: list, approve: approve, reject: reject}
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_reject.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_reject.go
@@ -19,7 +19,7 @@ import (
 //	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self / last approved admin"
 //	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
 //	@Failure		403	{object}	internal.ErrorResponse	"not approved"
-//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Failure		404	{object}	internal.ErrorResponse	"not found"
 //	@Router			/admin-users/{id}/reject [post]
 func (h *Handler) RejectAdminUser(c echo.Context) error {
 	operator, err := internal.GetAdminUser(c)

--- a/server/internal/admin/presentation/handler/adminuser/handler_reject.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_reject.go
@@ -1,0 +1,39 @@
+package adminuser
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// RejectAdminUser godoc
+//
+//	@Summary		Reject or revoke an admin user
+//	@Description	Rejects a pending admin user or revokes an approved one. Cannot reject your own account, and the last approved admin cannot be rejected.
+//	@Tags			admin-users
+//	@Produce		json
+//	@Param			id	path		string	true	"Admin user ID"
+//	@Success		200	{object}	AdminUserResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id / cannot modify self / last approved admin"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"admin user not found"
+//	@Router			/admin-users/{id}/reject [post]
+func (h *Handler) RejectAdminUser(c echo.Context) error {
+	operator, err := internal.GetAdminUser(c)
+	if err != nil {
+		return err
+	}
+	targetID, err := adminuser.IDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	u, err := h.reject.Execute(c.Request().Context(), operator.ID(), targetID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newAdminUserResponse(u))
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -32,6 +32,7 @@ func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
 	h := adminuserhandler.NewHandler(
 		adminuseruc.NewListAdminUsersUseCase(repo),
 		adminuseruc.NewApproveAdminUserUseCase(repo),
+		adminuseruc.NewRejectAdminUserUseCase(repo),
 	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, repo))
 
@@ -40,6 +41,7 @@ func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
 	g := e.Group("/api/v1/admin-users", requireApproved)
 	g.GET("", h.ListAdminUsers)
 	g.POST("/:id/approve", h.ApproveAdminUser)
+	g.POST("/:id/reject", h.RejectAdminUser)
 	return e
 }
 
@@ -198,4 +200,49 @@ func TestApproveAdminUser_NotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestRejectAdminUser_OK(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	target := pendingUser("new@eukarya.io")
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+target.ID().String()+"/reject", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body adminuserhandler.AdminUserResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "rejected", body.Status)
+}
+
+func TestRejectAdminUser_CannotRejectSelf(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	other := approvedUser("other@eukarya.io") // keep >1 approved so self-guard is what triggers
+	repo := memory.NewAdminUserWith(op, other)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+op.ID().String()+"/reject", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRejectAdminUser_InvalidID(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/not-an-id/reject", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -246,3 +246,17 @@ func TestRejectAdminUser_InvalidID(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+func TestRejectAdminUser_NotFound(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	// valid but non-existent id -> rerror.ErrNotFound -> 404 via error handler
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-users/"+adminuser.NewID().String()+"/reject", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -32,6 +32,7 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		adminUsers := v1.Group("/admin-users", requireApproved)
 		adminUsers.GET("", h.AdminUser.ListAdminUsers)
 		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser)
+		adminUsers.POST("/:id/reject", h.AdminUser.RejectAdminUser)
 
 		// Users (requires admin auth)
 		users := v1.Group("/users", h.AuthMw)

--- a/server/internal/admin/usecase/adminuseruc/errors.go
+++ b/server/internal/admin/usecase/adminuseruc/errors.go
@@ -5,6 +5,11 @@ import (
 	"github.com/reearth/reearthx/rerror"
 )
 
-// ErrCannotModifySelf is returned when an admin tries to approve/reject their
-// own account.
-var ErrCannotModifySelf = rerror.NewE(i18n.T("cannot modify your own admin account"))
+var (
+	// ErrCannotModifySelf is returned when an admin tries to approve/reject
+	// their own account.
+	ErrCannotModifySelf = rerror.NewE(i18n.T("cannot modify your own admin account"))
+	// ErrLastApprovedAdmin is returned when rejecting would remove the last
+	// approved admin.
+	ErrLastApprovedAdmin = rerror.NewE(i18n.T("cannot reject the last approved admin"))
+)

--- a/server/internal/admin/usecase/adminuseruc/reject.go
+++ b/server/internal/admin/usecase/adminuseruc/reject.go
@@ -2,8 +2,10 @@ package adminuseruc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 )
 
@@ -50,7 +52,14 @@ func (uc *RejectAdminUserUseCase) Execute(ctx context.Context, operatorID, targe
 		if err != nil {
 			return nil, err
 		}
-		if pi != nil && pi.TotalCount <= 1 {
+		// PageInfo is part of the Repo.List contract (the ListAdminUsers handler
+		// dereferences it unconditionally too). Fail fast on a nil rather than
+		// silently skipping the guard, which would let the last approved admin be
+		// rejected.
+		if pi == nil {
+			return nil, rerror.ErrInternalBy(errors.New("admin user list returned nil page info"))
+		}
+		if pi.TotalCount <= 1 {
 			return nil, ErrLastApprovedAdmin
 		}
 	}

--- a/server/internal/admin/usecase/adminuseruc/reject.go
+++ b/server/internal/admin/usecase/adminuseruc/reject.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/usecasex"
 )
 
 // RejectAdminUserUseCase rejects a pending admin user or revokes an approved one.
@@ -32,7 +33,12 @@ func (uc *RejectAdminUserUseCase) Execute(ctx context.Context, operatorID, targe
 	// to zero (otherwise nobody could ever approve again).
 	if target.IsApproved() {
 		approved := adminuser.StatusApproved
-		_, pi, err := uc.repo.List(ctx, adminuser.ListFilter{Status: &approved})
+		// Only the total count is needed; limit to a single row so repos don't
+		// fetch the entire approved-admin list on every revoke.
+		_, pi, err := uc.repo.List(ctx, adminuser.ListFilter{
+			Status:     &approved,
+			Pagination: usecasex.OffsetPagination{Offset: 0, Limit: 1}.Wrap(),
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/server/internal/admin/usecase/adminuseruc/reject.go
+++ b/server/internal/admin/usecase/adminuseruc/reject.go
@@ -1,0 +1,49 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// RejectAdminUserUseCase rejects a pending admin user or revokes an approved one.
+type RejectAdminUserUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewRejectAdminUserUseCase is a Wire provider for RejectAdminUserUseCase.
+func NewRejectAdminUserUseCase(repo adminuser.Repo) *RejectAdminUserUseCase {
+	return &RejectAdminUserUseCase{repo: repo}
+}
+
+// Execute rejects/revokes the target admin user. An admin cannot reject their
+// own account, and the last remaining approved admin cannot be rejected.
+func (uc *RejectAdminUserUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID) (*adminuser.AdminUser, error) {
+	if operatorID == targetID {
+		return nil, ErrCannotModifySelf
+	}
+
+	target, err := uc.repo.FindByID(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Revoking an approved admin must never drop the count of approved admins
+	// to zero (otherwise nobody could ever approve again).
+	if target.IsApproved() {
+		approved := adminuser.StatusApproved
+		_, pi, err := uc.repo.List(ctx, adminuser.ListFilter{Status: &approved})
+		if err != nil {
+			return nil, err
+		}
+		if pi != nil && pi.TotalCount <= 1 {
+			return nil, ErrLastApprovedAdmin
+		}
+	}
+
+	target.Reject()
+	if err := uc.repo.Save(ctx, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}

--- a/server/internal/admin/usecase/adminuseruc/reject.go
+++ b/server/internal/admin/usecase/adminuseruc/reject.go
@@ -31,6 +31,14 @@ func (uc *RejectAdminUserUseCase) Execute(ctx context.Context, operatorID, targe
 
 	// Revoking an approved admin must never drop the count of approved admins
 	// to zero (otherwise nobody could ever approve again).
+	//
+	// NOTE: this is a check-then-act guard, not atomic. Two approved admins
+	// rejecting each other at the exact same moment could both observe
+	// TotalCount == 2 and both succeed, leaving zero approved admins. Given the
+	// admin set is a tiny closed group (Eukarya employees) this race is
+	// acceptable for V1; enforcing it atomically would require backend-specific
+	// locking (e.g. a Postgres advisory lock / serializable transaction or a
+	// conditional update) and is deferred until it's actually needed.
 	if target.IsApproved() {
 		approved := adminuser.StatusApproved
 		// Only the total count is needed; limit to a single row so repos don't

--- a/server/internal/admin/usecase/adminuseruc/reject_test.go
+++ b/server/internal/admin/usecase/adminuseruc/reject_test.go
@@ -45,11 +45,12 @@ func TestReject_CannotRejectSelf(t *testing.T) {
 
 func TestReject_LastApprovedAdminBlocked(t *testing.T) {
 	ctx := context.Background()
-	operator := approved("op@eukarya.io")
-	// target is the only approved admin in the repo; rejecting it would leave
-	// zero approved admins.
+	// The target is the only approved admin in the repo; the operator is still
+	// pending. Rejecting the sole approved admin would leave zero approved
+	// admins, so it must be blocked.
+	operator := pending("op@eukarya.io")
 	target := approved("solo@eukarya.io")
-	repo := memory.NewAdminUserWith(target)
+	repo := memory.NewAdminUserWith(operator, target)
 	uc := NewRejectAdminUserUseCase(repo)
 
 	_, err := uc.Execute(ctx, operator.ID(), target.ID())

--- a/server/internal/admin/usecase/adminuseruc/reject_test.go
+++ b/server/internal/admin/usecase/adminuseruc/reject_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +43,16 @@ func TestReject_CannotRejectSelf(t *testing.T) {
 
 	_, err := uc.Execute(ctx, operator.ID(), operator.ID())
 	assert.ErrorIs(t, err, ErrCannotModifySelf)
+}
+
+func TestReject_NotFound(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), adminuser.NewID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
 }
 
 func TestReject_LastApprovedAdminBlocked(t *testing.T) {

--- a/server/internal/admin/usecase/adminuseruc/reject_test.go
+++ b/server/internal/admin/usecase/adminuseruc/reject_test.go
@@ -1,0 +1,57 @@
+package adminuseruc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReject_Pending(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsRejected())
+}
+
+func TestReject_RevokeApproved(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	other := approved("other@eukarya.io")
+	repo := memory.NewAdminUserWith(operator, other)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), other.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsRejected())
+}
+
+func TestReject_CannotRejectSelf(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), operator.ID())
+	assert.ErrorIs(t, err, ErrCannotModifySelf)
+}
+
+func TestReject_LastApprovedAdminBlocked(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	// target is the only approved admin in the repo; rejecting it would leave
+	// zero approved admins.
+	target := approved("solo@eukarya.io")
+	repo := memory.NewAdminUserWith(target)
+	uc := NewRejectAdminUserUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), target.ID())
+	assert.ErrorIs(t, err, ErrLastApprovedAdmin)
+}


### PR DESCRIPTION
## Why

Part 3/3 of **U-ADMIN-AUTH-04**. Stacked on #274 (approve).

> Base branch is `feat/admin-users-approve-ep`, so the diff shows only the reject changes. Review/merge #273 then #274 first.

## What's included

- **adminuseruc.Reject** usecase: rejects a pending admin user or revokes an approved one. Guards: an admin **cannot reject their own account** (`ErrCannotModifySelf` → 400) and the **last approved admin cannot be rejected** (`ErrLastApprovedAdmin` → 400).
- `POST /api/v1/admin-users/{id}/reject` behind RequireApproved.
- DI wiring + regenerated `wire_gen.go` and admin swagger; error mapping.

This completes the backend for U-ADMIN-AUTH-04 (list / approve / reject + approval gating + self-modification guards).

## Testing

`go build`, `go vet`, `gofmt`, `go test ./internal/admin/...` all pass. Reject usecase tests (reject pending, revoke approved, self-guard, last-approved guard) + HTTP tests (reject OK, cannot-reject-self, invalid id).

## Checklist

- [x] Verified backward compatibility (new endpoint + additive wiring)
- [x] Confirmed backward compatibility for migrations (none in this PR)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)