### PR TITLE
feat(server): add admin user/workspace detail endpoints

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -398,7 +398,7 @@ const docTemplate = `{
         },
         "/users/{id}/workspaces": {
             "get": {
-                "description": "Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.",
+                "description": "Returns the workspaces the user belongs to, with the user's role in each. An existing user in no workspace returns an empty list; a non-existent user returns 404.",
                 "produces": [
                     "application/json"
                 ],
@@ -439,6 +439,12 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "user not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -343,6 +343,109 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/{id}": {
+            "get": {
+                "description": "Returns the detail of a single user by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/UserDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/workspaces": {
+            "get": {
+                "description": "Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's workspaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserWorkspace"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces": {
             "get": {
                 "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.",
@@ -400,6 +503,115 @@ const docTemplate = `{
                     },
                     "501": {
                         "description": "not implemented on this backend",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}": {
+            "get": {
+                "description": "Returns the detail of a single workspace by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get a workspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Workspace"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/members": {
+            "get": {
+                "description": "Returns the members of a workspace, each with their role and (when resolvable) the underlying user's name and email.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "List a workspace's members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/WorkspaceMember"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -591,6 +803,46 @@ const docTemplate = `{
                 }
             }
         },
+        "UserDetail": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "UserWorkspace": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "personal": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
         "Workspace": {
             "type": "object",
             "properties": {
@@ -610,6 +862,26 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "WorkspaceMember": {
+            "type": "object",
+            "properties": {
+                "disabled": {
+                    "type": "boolean"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "userId": {
                     "type": "string"
                 }
             }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -873,9 +873,11 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "email": {
+                    "description": "empty string if the member's user cannot be resolved",
                     "type": "string"
                 },
                 "name": {
+                    "description": "empty string if the member's user cannot be resolved",
                     "type": "string"
                 },
                 "role": {

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -866,9 +866,11 @@
                     "type": "boolean"
                 },
                 "email": {
+                    "description": "empty string if the member's user cannot be resolved",
                     "type": "string"
                 },
                 "name": {
+                    "description": "empty string if the member's user cannot be resolved",
                     "type": "string"
                 },
                 "role": {

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -336,6 +336,109 @@
                 }
             }
         },
+        "/users/{id}": {
+            "get": {
+                "description": "Returns the detail of a single user by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/UserDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/workspaces": {
+            "get": {
+                "description": "Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's workspaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserWorkspace"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces": {
             "get": {
                 "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.",
@@ -393,6 +496,115 @@
                     },
                     "501": {
                         "description": "not implemented on this backend",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}": {
+            "get": {
+                "description": "Returns the detail of a single workspace by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Get a workspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Workspace"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/members": {
+            "get": {
+                "description": "Returns the members of a workspace, each with their role and (when resolvable) the underlying user's name and email.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "List a workspace's members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/WorkspaceMember"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -584,6 +796,46 @@
                 }
             }
         },
+        "UserDetail": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "UserWorkspace": {
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "personal": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
         "Workspace": {
             "type": "object",
             "properties": {
@@ -603,6 +855,26 @@
                     "type": "boolean"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "WorkspaceMember": {
+            "type": "object",
+            "properties": {
+                "disabled": {
+                    "type": "boolean"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "userId": {
                     "type": "string"
                 }
             }

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -391,7 +391,7 @@
         },
         "/users/{id}/workspaces": {
             "get": {
-                "description": "Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.",
+                "description": "Returns the workspaces the user belongs to, with the user's role in each. An existing user in no workspace returns an empty list; a non-existent user returns 404.",
                 "produces": [
                     "application/json"
                 ],
@@ -432,6 +432,12 @@
                     },
                     "403": {
                         "description": "not approved",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "user not found",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -442,7 +442,8 @@ paths:
   /users/{id}/workspaces:
     get:
       description: Returns the workspaces the user belongs to, with the user's role
-        in each. A user in no workspace returns an empty list.
+        in each. An existing user in no workspace returns an empty list; a non-existent
+        user returns 404.
       parameters:
       - description: User ID
         in: path
@@ -468,6 +469,10 @@ paths:
             $ref: '#/definitions/ErrorResponse'
         "403":
           description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: user not found
           schema:
             $ref: '#/definitions/ErrorResponse'
       summary: List a user's workspaces

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -165,8 +165,10 @@ definitions:
       disabled:
         type: boolean
       email:
+        description: empty string if the member's user cannot be resolved
         type: string
       name:
+        description: empty string if the member's user cannot be resolved
         type: string
       role:
         type: string

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -119,6 +119,32 @@ definitions:
       name:
         type: string
     type: object
+  UserDetail:
+    properties:
+      alias:
+        type: string
+      email:
+        type: string
+      host:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  UserWorkspace:
+    properties:
+      alias:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      personal:
+        type: boolean
+      role:
+        type: string
+    type: object
   Workspace:
     properties:
       alias:
@@ -132,6 +158,19 @@ definitions:
       personal:
         type: boolean
       updatedAt:
+        type: string
+    type: object
+  WorkspaceMember:
+    properties:
+      disabled:
+        type: boolean
+      email:
+        type: string
+      name:
+        type: string
+      role:
+        type: string
+      userId:
         type: string
     type: object
 info:
@@ -363,6 +402,75 @@ paths:
       summary: List users
       tags:
       - users
+  /users/{id}:
+    get:
+      description: Returns the detail of a single user by ID.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/UserDetail'
+        "400":
+          description: invalid id
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Get a user
+      tags:
+      - users
+  /users/{id}/workspaces:
+    get:
+      description: Returns the workspaces the user belongs to, with the user's role
+        in each. A user in no workspace returns an empty list.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/UserWorkspace'
+            type: array
+        "400":
+          description: invalid id
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: List a user's workspaces
+      tags:
+      - users
   /workspaces:
     get:
       description: Lists workspaces across all tenants, optionally filtered by a name/alias
@@ -404,6 +512,79 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       summary: List workspaces
+      tags:
+      - workspaces
+  /workspaces/{id}:
+    get:
+      description: Returns the detail of a single workspace by ID.
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/Workspace'
+        "400":
+          description: invalid id
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Get a workspace
+      tags:
+      - workspaces
+  /workspaces/{id}/members:
+    get:
+      description: Returns the members of a workspace, each with their role and (when
+        resolvable) the underlying user's name and email.
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/WorkspaceMember'
+            type: array
+        "400":
+          description: invalid id
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: not approved
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: List a workspace's members
       tags:
       - workspaces
 securityDefinitions:

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -32,7 +32,7 @@ func InitializeEcho() (*Server, func(), error) {
 	repo := container.User
 	workspaceRepo := container.Workspace
 	getUserUseCase := useruc.NewGetUserUseCase(repo)
-	getUserWorkspacesUseCase := useruc.NewGetUserWorkspacesUseCase(workspaceRepo)
+	getUserWorkspacesUseCase := useruc.NewGetUserWorkspacesUseCase(repo, workspaceRepo)
 	listUsersUseCase := useruc.NewListUsersUseCase(repo)
 	userHandler := user.NewHandler(getUserUseCase, getUserWorkspacesUseCase, listUsersUseCase)
 	verifier, err := provideGoogleVerifier(config)

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -30,8 +30,11 @@ func InitializeEcho() (*Server, func(), error) {
 	}
 	adminUserRepo := container.AdminUser
 	repo := container.User
+	workspaceRepo := container.Workspace
+	getUserUseCase := useruc.NewGetUserUseCase(repo)
+	getUserWorkspacesUseCase := useruc.NewGetUserWorkspacesUseCase(workspaceRepo)
 	listUsersUseCase := useruc.NewListUsersUseCase(repo)
-	userHandler := user.NewHandler(listUsersUseCase)
+	userHandler := user.NewHandler(getUserUseCase, getUserWorkspacesUseCase, listUsersUseCase)
 	verifier, err := provideGoogleVerifier(config)
 	if err != nil {
 		cleanup()
@@ -51,9 +54,10 @@ func InitializeEcho() (*Server, func(), error) {
 	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(adminUserRepo)
 	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(adminUserRepo)
 	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
-	workspaceRepo := container.Workspace
+	getWorkspaceUseCase := workspaceuc.NewGetWorkspaceUseCase(workspaceRepo)
 	listWorkspacesUseCase := workspaceuc.NewListWorkspacesUseCase(workspaceRepo)
-	workspaceHandler := workspacehandler.NewHandler(listWorkspacesUseCase)
+	listWorkspaceMembersUseCase := workspaceuc.NewListWorkspaceMembersUseCase(workspaceRepo, repo)
+	workspaceHandler := workspacehandler.NewHandler(getWorkspaceUseCase, listWorkspacesUseCase, listWorkspaceMembersUseCase)
 	sessionMiddleware := middleware.NewSessionMiddleware(manager)
 	requireApprovedMiddleware := middleware.NewRequireApprovedMiddleware(manager, adminUserRepo)
 	presentationHandler := presentation.NewHandler(adminUserHandler, authHandler, userHandler, workspaceHandler, sessionMiddleware, requireApprovedMiddleware)

--- a/server/internal/admin/di/wire_usecase.go
+++ b/server/internal/admin/di/wire_usecase.go
@@ -16,6 +16,8 @@ import (
 // (one struct per action).
 var usecaseWire = wire.NewSet(
 	authz.NewChecker,
+	useruc.NewGetUserUseCase,
+	useruc.NewGetUserWorkspacesUseCase,
 	useruc.NewListUsersUseCase,
 
 	// session auth dependencies + usecases
@@ -31,5 +33,7 @@ var usecaseWire = wire.NewSet(
 	adminuseruc.NewRejectAdminUserUseCase,
 
 	// cross-tenant workspace usecases
+	workspaceuc.NewGetWorkspaceUseCase,
+	workspaceuc.NewListWorkspaceMembersUseCase,
 	workspaceuc.NewListWorkspacesUseCase,
 )

--- a/server/internal/admin/presentation/handler/user/handler.go
+++ b/server/internal/admin/presentation/handler/user/handler.go
@@ -8,10 +8,12 @@ import (
 
 // Handler aggregates the user-related admin usecases.
 type Handler struct {
-	listUC *useruc.ListUsersUseCase
+	getUC           *useruc.GetUserUseCase
+	getWorkspacesUC *useruc.GetUserWorkspacesUseCase
+	listUC          *useruc.ListUsersUseCase
 }
 
 // NewHandler is a Wire provider for the user Handler.
-func NewHandler(listUC *useruc.ListUsersUseCase) *Handler {
-	return &Handler{listUC: listUC}
+func NewHandler(getUC *useruc.GetUserUseCase, getWorkspacesUC *useruc.GetUserWorkspacesUseCase, listUC *useruc.ListUsersUseCase) *Handler {
+	return &Handler{getUC: getUC, getWorkspacesUC: getWorkspacesUC, listUC: listUC}
 }

--- a/server/internal/admin/presentation/handler/user/handler_get.go
+++ b/server/internal/admin/presentation/handler/user/handler_get.go
@@ -1,0 +1,34 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+)
+
+// GetUser godoc
+//
+//	@Summary		Get a user
+//	@Description	Returns the detail of a single user by ID.
+//	@Tags			users
+//	@Produce		json
+//	@Param			id	path		string	true	"User ID"
+//	@Success		200	{object}	UserDetailResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"not found"
+//	@Router			/users/{id} [get]
+func (h *Handler) GetUser(c echo.Context) error {
+	uid, err := id.UserIDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	u, err := h.getUC.Execute(c.Request().Context(), uid)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newUserDetailResponse(u))
+}

--- a/server/internal/admin/presentation/handler/user/handler_test.go
+++ b/server/internal/admin/presentation/handler/user/handler_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
 	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
 	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,13 +33,23 @@ func usr(name, alias, email string) *user.User {
 }
 
 func newTestEcho(userRepo user.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
-	h := userhandler.NewHandler(useruc.NewListUsersUseCase(userRepo))
+	return newTestEchoWithWorkspaces(userRepo, memory.NewWorkspaceWith(), adminRepo, sess)
+}
+
+func newTestEchoWithWorkspaces(userRepo user.Repo, wsRepo workspace.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
+	h := userhandler.NewHandler(
+		useruc.NewGetUserUseCase(userRepo),
+		useruc.NewGetUserWorkspacesUseCase(wsRepo),
+		useruc.NewListUsersUseCase(userRepo),
+	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, adminRepo))
 
 	e := echo.New()
 	e.HTTPErrorHandler = adminpresentation.CustomHTTPErrorHandler
 	g := e.Group("/api/v1/users", requireApproved)
 	g.GET("", h.ListUsers)
+	g.GET("/:id", h.GetUser)
+	g.GET("/:id/workspaces", h.GetUserWorkspaces)
 	return e
 }
 
@@ -115,4 +127,98 @@ func TestListUsers_InvalidPagination(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		})
 	}
+}
+
+func TestGetUser_OK(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	u := usr("Alice", "alice", "alice@example.com")
+	userRepo := memory.NewUserWith(u)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(userRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+u.ID().String(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body userhandler.UserDetailResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, u.ID().String(), body.ID)
+	assert.Equal(t, "Alice", body.Name)
+	assert.Equal(t, "alice@example.com", body.Email)
+}
+
+func TestGetUser_InvalidID(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	userRepo := memory.NewUserWith(usr("A", "a", "a@example.com"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(userRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/not-an-id", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetUser_NotFound(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	userRepo := memory.NewUserWith(usr("A", "a", "a@example.com"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(userRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+user.NewID().String(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetUserWorkspaces_OK(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	u := usr("Alice", "alice", "alice@example.com")
+	userRepo := memory.NewUserWith(u)
+	w := workspace.New().NewID().Name("Team").Alias("team").Members(map[workspace.UserID]workspace.Member{
+		u.ID(): {Role: role.RoleOwner},
+	}).MustBuild()
+	wsRepo := memory.NewWorkspaceWith(w)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEchoWithWorkspaces(userRepo, wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+u.ID().String()+"/workspaces", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body []userhandler.UserWorkspaceResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body, 1)
+	assert.Equal(t, w.ID().String(), body[0].ID)
+	assert.Equal(t, "owner", body[0].Role)
+}
+
+func TestGetUserWorkspaces_Empty(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	u := usr("Alice", "alice", "alice@example.com")
+	userRepo := memory.NewUserWith(u)
+	wsRepo := memory.NewWorkspaceWith()
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEchoWithWorkspaces(userRepo, wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+u.ID().String()+"/workspaces", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body []userhandler.UserWorkspaceResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Empty(t, body)
 }

--- a/server/internal/admin/presentation/handler/user/handler_test.go
+++ b/server/internal/admin/presentation/handler/user/handler_test.go
@@ -39,7 +39,7 @@ func newTestEcho(userRepo user.Repo, adminRepo adminuser.Repo, sess *session.Man
 func newTestEchoWithWorkspaces(userRepo user.Repo, wsRepo workspace.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
 	h := userhandler.NewHandler(
 		useruc.NewGetUserUseCase(userRepo),
-		useruc.NewGetUserWorkspacesUseCase(wsRepo),
+		useruc.NewGetUserWorkspacesUseCase(userRepo, wsRepo),
 		useruc.NewListUsersUseCase(userRepo),
 	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, adminRepo))
@@ -221,4 +221,21 @@ func TestGetUserWorkspaces_Empty(t *testing.T) {
 	var body []userhandler.UserWorkspaceResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Empty(t, body)
+}
+
+func TestGetUserWorkspaces_NotFound(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	userRepo := memory.NewUserWith(usr("Alice", "alice", "alice@example.com"))
+	wsRepo := memory.NewWorkspaceWith()
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEchoWithWorkspaces(userRepo, wsRepo, adminRepo, sess)
+
+	// A well-formed but non-existent user id must return 404, not an empty list.
+	missing := user.NewID()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+missing.String()+"/workspaces", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/server/internal/admin/presentation/handler/user/handler_workspaces.go
+++ b/server/internal/admin/presentation/handler/user/handler_workspaces.go
@@ -10,7 +10,7 @@ import (
 // GetUserWorkspaces godoc
 //
 //	@Summary		List a user's workspaces
-//	@Description	Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.
+//	@Description	Returns the workspaces the user belongs to, with the user's role in each. An existing user in no workspace returns an empty list; a non-existent user returns 404.
 //	@Tags			users
 //	@Produce		json
 //	@Param			id	path		string	true	"User ID"
@@ -18,6 +18,7 @@ import (
 //	@Failure		400	{object}	internal.ErrorResponse	"invalid id"
 //	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
 //	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"user not found"
 //	@Router			/users/{id}/workspaces [get]
 func (h *Handler) GetUserWorkspaces(c echo.Context) error {
 	uid, err := id.UserIDFrom(c.Param("id"))

--- a/server/internal/admin/presentation/handler/user/handler_workspaces.go
+++ b/server/internal/admin/presentation/handler/user/handler_workspaces.go
@@ -1,0 +1,47 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+)
+
+// GetUserWorkspaces godoc
+//
+//	@Summary		List a user's workspaces
+//	@Description	Returns the workspaces the user belongs to, with the user's role in each. A user in no workspace returns an empty list.
+//	@Tags			users
+//	@Produce		json
+//	@Param			id	path		string	true	"User ID"
+//	@Success		200	{array}		UserWorkspaceResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Router			/users/{id}/workspaces [get]
+func (h *Handler) GetUserWorkspaces(c echo.Context) error {
+	uid, err := id.UserIDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	list, err := h.getWorkspacesUC.Execute(c.Request().Context(), uid)
+	if err != nil {
+		return err
+	}
+
+	res := make([]UserWorkspaceResponse, 0, len(list))
+	for _, ws := range list {
+		item := UserWorkspaceResponse{
+			ID:       ws.ID().String(),
+			Name:     ws.Name(),
+			Alias:    ws.Alias(),
+			Personal: ws.IsPersonal(),
+		}
+		if m := ws.Members(); m != nil {
+			item.Role = string(m.UserRole(uid))
+		}
+		res = append(res, item)
+	}
+	return c.JSON(http.StatusOK, res)
+}

--- a/server/internal/admin/presentation/handler/user/response.go
+++ b/server/internal/admin/presentation/handler/user/response.go
@@ -20,6 +20,34 @@ type ListUsersResponse struct {
 	PerPage    int64          `json:"perPage"`
 } // @name ListUsersResponse
 
+// UserDetailResponse is the detail view of a single user.
+type UserDetailResponse struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Alias string `json:"alias"`
+	Host  string `json:"host"`
+} // @name UserDetail
+
+// UserWorkspaceResponse is a workspace a user belongs to, with the user's role.
+type UserWorkspaceResponse struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Alias    string `json:"alias"`
+	Personal bool   `json:"personal"`
+	Role     string `json:"role"`
+} // @name UserWorkspace
+
+func newUserDetailResponse(u *user.User) UserDetailResponse {
+	return UserDetailResponse{
+		ID:    u.ID().String(),
+		Name:  u.Name(),
+		Email: u.Email(),
+		Alias: u.Alias(),
+		Host:  u.Host(),
+	}
+}
+
 func newUserResponse(u *user.User) UserResponse {
 	return UserResponse{
 		ID:    u.ID().String(),

--- a/server/internal/admin/presentation/handler/workspace/handler.go
+++ b/server/internal/admin/presentation/handler/workspace/handler.go
@@ -8,10 +8,12 @@ import (
 
 // Handler serves the /workspaces endpoints.
 type Handler struct {
-	list *workspaceuc.ListWorkspacesUseCase
+	get     *workspaceuc.GetWorkspaceUseCase
+	list    *workspaceuc.ListWorkspacesUseCase
+	members *workspaceuc.ListWorkspaceMembersUseCase
 }
 
 // NewHandler is a Wire provider for the workspace Handler.
-func NewHandler(list *workspaceuc.ListWorkspacesUseCase) *Handler {
-	return &Handler{list: list}
+func NewHandler(get *workspaceuc.GetWorkspaceUseCase, list *workspaceuc.ListWorkspacesUseCase, members *workspaceuc.ListWorkspaceMembersUseCase) *Handler {
+	return &Handler{get: get, list: list, members: members}
 }

--- a/server/internal/admin/presentation/handler/workspace/handler_get.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_get.go
@@ -1,0 +1,34 @@
+package workspace
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+)
+
+// GetWorkspace godoc
+//
+//	@Summary		Get a workspace
+//	@Description	Returns the detail of a single workspace by ID.
+//	@Tags			workspaces
+//	@Produce		json
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200	{object}	WorkspaceResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"not found"
+//	@Router			/workspaces/{id} [get]
+func (h *Handler) GetWorkspace(c echo.Context) error {
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	ws, err := h.get.Execute(c.Request().Context(), wid)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newWorkspaceResponse(ws))
+}

--- a/server/internal/admin/presentation/handler/workspace/handler_members.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_members.go
@@ -1,0 +1,53 @@
+package workspace
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+)
+
+// GetWorkspaceMembers godoc
+//
+//	@Summary		List a workspace's members
+//	@Description	Returns the members of a workspace, each with their role and (when resolvable) the underlying user's name and email.
+//	@Tags			workspaces
+//	@Produce		json
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200	{array}		WorkspaceMemberResponse
+//	@Failure		400	{object}	internal.ErrorResponse	"invalid id"
+//	@Failure		401	{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403	{object}	internal.ErrorResponse	"not approved"
+//	@Failure		404	{object}	internal.ErrorResponse	"not found"
+//	@Router			/workspaces/{id}/members [get]
+func (h *Handler) GetWorkspaceMembers(c echo.Context) error {
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	ws, users, err := h.members.Execute(c.Request().Context(), wid)
+	if err != nil {
+		return err
+	}
+
+	res := make([]WorkspaceMemberResponse, 0)
+	if m := ws.Members(); m != nil {
+		for uid, member := range m.Users() {
+			item := WorkspaceMemberResponse{
+				UserID:   uid.String(),
+				Role:     string(member.Role),
+				Disabled: member.Disabled,
+			}
+			if u, ok := users[uid]; ok {
+				item.Name = u.Name()
+				item.Email = u.Email()
+			}
+			res = append(res, item)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].UserID < res[j].UserID })
+
+	return c.JSON(http.StatusOK, res)
+}

--- a/server/internal/admin/presentation/handler/workspace/handler_members.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_members.go
@@ -34,7 +34,12 @@ func (h *Handler) GetWorkspaceMembers(c echo.Context) error {
 
 	res := make([]WorkspaceMemberResponse, 0)
 	if m := ws.Members(); m != nil {
-		for uid, member := range m.Users() {
+		// Iterate ids + per-id lookup instead of Users(), which clones the map.
+		for _, uid := range m.UserIDs() {
+			member := m.User(uid)
+			if member == nil {
+				continue
+			}
 			item := WorkspaceMemberResponse{
 				UserID:   uid.String(),
 				Role:     string(member.Role),

--- a/server/internal/admin/presentation/handler/workspace/handler_test.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/workspaceuc"
 	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,13 +33,23 @@ func ws(name, alias string) *workspace.Workspace {
 }
 
 func newTestEcho(wsRepo workspace.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
-	h := workspacehandler.NewHandler(workspaceuc.NewListWorkspacesUseCase(wsRepo))
+	return newTestEchoWithUsers(wsRepo, memory.NewUserWith(), adminRepo, sess)
+}
+
+func newTestEchoWithUsers(wsRepo workspace.Repo, userRepo user.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
+	h := workspacehandler.NewHandler(
+		workspaceuc.NewGetWorkspaceUseCase(wsRepo),
+		workspaceuc.NewListWorkspacesUseCase(wsRepo),
+		workspaceuc.NewListWorkspaceMembersUseCase(wsRepo, userRepo),
+	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, adminRepo))
 
 	e := echo.New()
 	e.HTTPErrorHandler = adminpresentation.CustomHTTPErrorHandler
 	g := e.Group("/api/v1/workspaces", requireApproved)
 	g.GET("", h.ListWorkspaces)
+	g.GET("/:id", h.GetWorkspace)
+	g.GET("/:id/members", h.GetWorkspaceMembers)
 	return e
 }
 
@@ -125,4 +137,94 @@ func TestListWorkspaces_Forbidden_WhenNotApproved(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetWorkspace_OK(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	w := ws("Alpha", "alpha")
+	wsRepo := memory.NewWorkspaceWith(w)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+w.ID().String(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.WorkspaceResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, w.ID().String(), body.ID)
+	assert.Equal(t, "Alpha", body.Name)
+}
+
+func TestGetWorkspace_InvalidID(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/not-an-id", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetWorkspace_NotFound(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+workspace.NewID().String(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetWorkspaceMembers_OK(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+
+	u := user.New().NewID().Name("Alice").Alias("alice").Email("alice@example.com").MustBuild()
+	w := workspace.New().NewID().Name("Team").Alias("team").Members(map[workspace.UserID]workspace.Member{
+		u.ID(): {Role: role.RoleOwner},
+	}).MustBuild()
+	wsRepo := memory.NewWorkspaceWith(w)
+	userRepo := memory.NewUserWith(u)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEchoWithUsers(wsRepo, userRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+w.ID().String()+"/members", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body []workspacehandler.WorkspaceMemberResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body, 1)
+	assert.Equal(t, u.ID().String(), body[0].UserID)
+	assert.Equal(t, "Alice", body[0].Name)
+	assert.Equal(t, "alice@example.com", body[0].Email)
+	assert.Equal(t, "owner", body[0].Role)
+}
+
+func TestGetWorkspaceMembers_NotFound(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+workspace.NewID().String()+"/members", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/server/internal/admin/presentation/handler/workspace/response.go
+++ b/server/internal/admin/presentation/handler/workspace/response.go
@@ -25,11 +25,12 @@ type ListWorkspacesResponse struct {
 } // @name ListWorkspacesResponse
 
 // WorkspaceMemberResponse is a single member of a workspace, with the member's
-// role and (when resolvable) the underlying user's name and email.
+// role. Name and Email are always present in the response; they are empty
+// strings when the member's underlying user cannot be resolved.
 type WorkspaceMemberResponse struct {
 	UserID   string `json:"userId"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
+	Name     string `json:"name"`  // empty string if the member's user cannot be resolved
+	Email    string `json:"email"` // empty string if the member's user cannot be resolved
 	Role     string `json:"role"`
 	Disabled bool   `json:"disabled"`
 } // @name WorkspaceMember

--- a/server/internal/admin/presentation/handler/workspace/response.go
+++ b/server/internal/admin/presentation/handler/workspace/response.go
@@ -24,6 +24,16 @@ type ListWorkspacesResponse struct {
 	PerPage    int64               `json:"perPage"`
 } // @name ListWorkspacesResponse
 
+// WorkspaceMemberResponse is a single member of a workspace, with the member's
+// role and (when resolvable) the underlying user's name and email.
+type WorkspaceMemberResponse struct {
+	UserID   string `json:"userId"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+	Disabled bool   `json:"disabled"`
+} // @name WorkspaceMember
+
 func newWorkspaceResponse(w *workspace.Workspace) WorkspaceResponse {
 	res := WorkspaceResponse{
 		ID:        w.ID().String(),

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -37,9 +37,13 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		// Users (requires an approved admin session)
 		users := v1.Group("/users", requireApproved)
 		users.GET("", h.User.ListUsers)
+		users.GET("/:id", h.User.GetUser)
+		users.GET("/:id/workspaces", h.User.GetUserWorkspaces)
 
 		// Cross-tenant workspace listing (requires an approved admin session)
 		workspaces := v1.Group("/workspaces", requireApproved)
 		workspaces.GET("", h.Workspace.ListWorkspaces)
+		workspaces.GET("/:id", h.Workspace.GetWorkspace)
+		workspaces.GET("/:id/members", h.Workspace.GetWorkspaceMembers)
 	}
 }

--- a/server/internal/admin/usecase/useruc/get_user.go
+++ b/server/internal/admin/usecase/useruc/get_user.go
@@ -1,0 +1,22 @@
+package useruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+)
+
+// GetUserUseCase fetches a single user by ID for the admin console.
+type GetUserUseCase struct {
+	userRepo user.Repo
+}
+
+// NewGetUserUseCase is a Wire provider for GetUserUseCase.
+func NewGetUserUseCase(userRepo user.Repo) *GetUserUseCase {
+	return &GetUserUseCase{userRepo: userRepo}
+}
+
+// Execute returns the user with the given ID, or rerror.ErrNotFound if absent.
+func (uc *GetUserUseCase) Execute(ctx context.Context, id user.ID) (*user.User, error) {
+	return uc.userRepo.FindByID(ctx, id)
+}

--- a/server/internal/admin/usecase/useruc/get_user_workspaces.go
+++ b/server/internal/admin/usecase/useruc/get_user_workspaces.go
@@ -11,18 +11,24 @@ import (
 
 // GetUserWorkspacesUseCase lists the workspaces a user belongs to.
 type GetUserWorkspacesUseCase struct {
+	userRepo      user.Repo
 	workspaceRepo workspace.Repo
 }
 
 // NewGetUserWorkspacesUseCase is a Wire provider for GetUserWorkspacesUseCase.
-func NewGetUserWorkspacesUseCase(workspaceRepo workspace.Repo) *GetUserWorkspacesUseCase {
-	return &GetUserWorkspacesUseCase{workspaceRepo: workspaceRepo}
+func NewGetUserWorkspacesUseCase(userRepo user.Repo, workspaceRepo workspace.Repo) *GetUserWorkspacesUseCase {
+	return &GetUserWorkspacesUseCase{userRepo: userRepo, workspaceRepo: workspaceRepo}
 }
 
-// Execute returns the workspaces the user belongs to. A user that belongs to no
-// workspace is a valid empty result, not a 404, so rerror.ErrNotFound from the
-// repository is translated into an empty list.
+// Execute returns the workspaces the user belongs to. The user is verified to
+// exist first, so a missing user surfaces as rerror.ErrNotFound (404); an
+// existing user that belongs to no workspace is a valid empty result, so
+// rerror.ErrNotFound from FindByUser is translated into an empty list.
 func (uc *GetUserWorkspacesUseCase) Execute(ctx context.Context, id user.ID) (workspace.List, error) {
+	if _, err := uc.userRepo.FindByID(ctx, id); err != nil {
+		return nil, err
+	}
+
 	list, err := uc.workspaceRepo.FindByUser(ctx, id)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {

--- a/server/internal/admin/usecase/useruc/get_user_workspaces.go
+++ b/server/internal/admin/usecase/useruc/get_user_workspaces.go
@@ -1,0 +1,34 @@
+package useruc
+
+import (
+	"context"
+	"errors"
+
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+)
+
+// GetUserWorkspacesUseCase lists the workspaces a user belongs to.
+type GetUserWorkspacesUseCase struct {
+	workspaceRepo workspace.Repo
+}
+
+// NewGetUserWorkspacesUseCase is a Wire provider for GetUserWorkspacesUseCase.
+func NewGetUserWorkspacesUseCase(workspaceRepo workspace.Repo) *GetUserWorkspacesUseCase {
+	return &GetUserWorkspacesUseCase{workspaceRepo: workspaceRepo}
+}
+
+// Execute returns the workspaces the user belongs to. A user that belongs to no
+// workspace is a valid empty result, not a 404, so rerror.ErrNotFound from the
+// repository is translated into an empty list.
+func (uc *GetUserWorkspacesUseCase) Execute(ctx context.Context, id user.ID) (workspace.List, error) {
+	list, err := uc.workspaceRepo.FindByUser(ctx, id)
+	if err != nil {
+		if errors.Is(err, rerror.ErrNotFound) {
+			return workspace.List{}, nil
+		}
+		return nil, err
+	}
+	return list, nil
+}

--- a/server/internal/admin/usecase/workspaceuc/get.go
+++ b/server/internal/admin/usecase/workspaceuc/get.go
@@ -1,0 +1,22 @@
+package workspaceuc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+)
+
+// GetWorkspaceUseCase fetches a single workspace by ID for the admin console.
+type GetWorkspaceUseCase struct {
+	workspaceRepo workspace.Repo
+}
+
+// NewGetWorkspaceUseCase is a Wire provider for GetWorkspaceUseCase.
+func NewGetWorkspaceUseCase(workspaceRepo workspace.Repo) *GetWorkspaceUseCase {
+	return &GetWorkspaceUseCase{workspaceRepo: workspaceRepo}
+}
+
+// Execute returns the workspace with the given ID, or rerror.ErrNotFound if absent.
+func (uc *GetWorkspaceUseCase) Execute(ctx context.Context, id workspace.ID) (*workspace.Workspace, error) {
+	return uc.workspaceRepo.FindByID(ctx, id)
+}

--- a/server/internal/admin/usecase/workspaceuc/members.go
+++ b/server/internal/admin/usecase/workspaceuc/members.go
@@ -1,0 +1,52 @@
+package workspaceuc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+)
+
+// ListWorkspaceMembersUseCase fetches a workspace and resolves the domain users
+// of its members so callers can render names and emails alongside roles.
+type ListWorkspaceMembersUseCase struct {
+	userRepo      user.Repo
+	workspaceRepo workspace.Repo
+}
+
+// NewListWorkspaceMembersUseCase is a Wire provider for ListWorkspaceMembersUseCase.
+func NewListWorkspaceMembersUseCase(workspaceRepo workspace.Repo, userRepo user.Repo) *ListWorkspaceMembersUseCase {
+	return &ListWorkspaceMembersUseCase{userRepo: userRepo, workspaceRepo: workspaceRepo}
+}
+
+// Execute returns the workspace and a map from member user ID to the resolved
+// *user.User. Members whose users cannot be found are simply absent from the map;
+// a missing workspace propagates rerror.ErrNotFound.
+func (uc *ListWorkspaceMembersUseCase) Execute(ctx context.Context, id workspace.ID) (*workspace.Workspace, map[user.ID]*user.User, error) {
+	ws, err := uc.workspaceRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ids := make(user.IDList, 0)
+	if m := ws.Members(); m != nil {
+		for uid := range m.Users() {
+			ids = append(ids, uid)
+		}
+	}
+
+	users := make(map[user.ID]*user.User, len(ids))
+	if len(ids) > 0 {
+		list, err := uc.userRepo.FindByIDs(ctx, ids)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, u := range list {
+			if u != nil {
+				users[u.ID()] = u
+			}
+		}
+	}
+
+	return ws, users, nil
+}

--- a/server/internal/admin/usecase/workspaceuc/members.go
+++ b/server/internal/admin/usecase/workspaceuc/members.go
@@ -28,11 +28,11 @@ func (uc *ListWorkspaceMembersUseCase) Execute(ctx context.Context, id workspace
 		return nil, nil, err
 	}
 
-	ids := make(user.IDList, 0)
+	var ids user.IDList
 	if m := ws.Members(); m != nil {
-		for uid := range m.Users() {
-			ids = append(ids, uid)
-		}
+		// UserIDs() avoids cloning the whole members map (Users()) when only the
+		// ids are needed to resolve users.
+		ids = user.IDList(m.UserIDs())
 	}
 
 	users := make(map[user.ID]*user.User, len(ids))


### PR DESCRIPTION
## Why

Part of the admin-auth epic (reearth-dashboard#1233; per-resource endpoints reearth-dashboard#1304). After the cross-tenant **list** endpoints (workspaces #276, users #277), the admin app's Users and Workspaces pages also need **detail** and **sub-resource** views. This adds the read-only detail endpoints backed by reearth-accounts.

> **Stacked on #277** (`feat/admin-users-list-session`). Review/merge #277 first; this PR's own diff is the detail-endpoints commit. (Subscriptions/Billing from #1304 are out of scope here — those live in reearth-dashboard/Stripe, not reearth-accounts.)

## What's included

All four are gated by the **Google admin session** (`RequireApproved`), read-only, and follow the existing list-endpoint conventions (camelCase JSON, `internal.ErrorResponse` on failure). Invalid ids → **400**, missing entities → **404**.

| Method | Path | Returns |
| --- | --- | --- |
| `GET` | `/api/v1/users/:id` | user detail: `{ id, name, email, alias, host }` |
| `GET` | `/api/v1/users/:id/workspaces` | workspaces the user belongs to: `[{ id, name, alias, personal, role }]` — a user in **no** workspace yields `[]` (not 404) |
| `GET` | `/api/v1/workspaces/:id` | workspace detail (reuses the list item shape: `{ id, name, alias, personal, memberCount, updatedAt }`) |
| `GET` | `/api/v1/workspaces/:id/members` | `[{ userId, name, email, role, disabled }]`, member user name/email resolved via the user repo, sorted by `userId` |

New usecases: `useruc.GetUser`, `useruc.GetUserWorkspaces`, `workspaceuc.GetWorkspace`, `workspaceuc.ListWorkspaceMembers`. Plus handlers, response types, DI wiring, routes, handler tests, and regenerated admin swagger.

## Testing

`go build ./...`, `go vet`, `gofmt`, `go test ./internal/admin/...`, and `golangci-lint run ./internal/admin/...` all pass. Handler tests cover happy path, invalid id (400), not found (404), empty user-workspaces (200 `[]`), and member role/name resolution.

## Checklist

- [x] Verified backward compatibility related to feature modifications (additive: new read-only endpoints; existing behavior unchanged)
- [x] Confirmed backward compatibility for migrations (none in this PR)
- [x] Verified that no PII is included beyond what the admin views intentionally expose (user name/email/alias/host; member name/email/role)
