### PR TITLE
fix(server): add Cache-Control: private, no-store middleware to admin API (SEC-01)

### DIFF
--- a/server/internal/admin/presentation/middleware.go
+++ b/server/internal/admin/presentation/middleware.go
@@ -8,12 +8,14 @@ import (
 // AppMiddlewares holds application-level middleware for admin-api, applied to
 // every route.
 type AppMiddlewares struct {
+	CacheControl  echo.MiddlewareFunc
 	RequestLogger echo.MiddlewareFunc
 }
 
 // Middlewares returns all application middlewares as a slice.
 func (m *AppMiddlewares) Middlewares() []echo.MiddlewareFunc {
 	return []echo.MiddlewareFunc{
+		m.CacheControl,
 		m.RequestLogger,
 	}
 }
@@ -21,6 +23,18 @@ func (m *AppMiddlewares) Middlewares() []echo.MiddlewareFunc {
 // NewAppMiddlewares is a Wire provider for the admin-api middleware bundle.
 func NewAppMiddlewares() *AppMiddlewares {
 	return &AppMiddlewares{
+		CacheControl:  cacheControlMiddleware,
 		RequestLogger: middleware.Logger(),
+	}
+}
+
+// cacheControlMiddleware sets Cache-Control: private, no-store on every response.
+// Cookie-authenticated admin routes return PII; without this header, shared
+// caches and CDNs may serve one admin's response to another caller on the same
+// path (RFC 7234 §3 — cookies do not make a response uncacheable by default).
+func cacheControlMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("Cache-Control", "private, no-store")
+		return next(c)
 	}
 }

--- a/server/internal/admin/presentation/middleware_test.go
+++ b/server/internal/admin/presentation/middleware_test.go
@@ -1,0 +1,31 @@
+package presentation
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheControlMiddleware(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := cacheControlMiddleware(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	assert.NoError(t, handler(c))
+	assert.Equal(t, "private, no-store", rec.Header().Get("Cache-Control"))
+}
+
+func TestNewAppMiddlewares_CacheControlSet(t *testing.T) {
+	m := NewAppMiddlewares()
+	assert.NotNil(t, m.CacheControl)
+	assert.NotNil(t, m.RequestLogger)
+	assert.Len(t, m.Middlewares(), 2)
+}


### PR DESCRIPTION
## Why

The admin API's global middleware bundle (`AppMiddlewares`) lacked any `Cache-Control` directive. Because admin routes (e.g. `GET /api/v1/me`) are authenticated by an `admin_session` **Cookie** rather than an `Authorization` header, RFC 7234 shared caches and CDNs may cache the 200 response by default and serve one admin's PII (email, name, status, approvedBy) to another caller hitting the same path.

The main REST API already mitigates this via an injected `CacheControl: private` middleware (commit `031c390`), but the admin binary added in #256/#271 had no equivalent.

This PR adds `Cache-Control: private, no-store` to every admin response via a new `cacheControlMiddleware` wired into `AppMiddlewares`, and adds unit tests to prevent silent regression.

Closes https://github.com/eukarya-inc/reearth-dashboard/issues/1318

## Checklist

- [x] Verified backward compatibility related to feature modifications (header addition is additive and non-breaking)
- [x] Confirmed backward compatibility for migrations (no schema changes)
- [x] Verified that no PII is included in displayed values