### PR TITLE
docs(server): admin role design doc (#1316)

### DIFF
--- a/server/docs/usecase/admin-role-permittable.md
+++ b/server/docs/usecase/admin-role-permittable.md
@@ -8,7 +8,7 @@
 
 ## Roles
 
-Two roles for V1, a small fixed enum.
+Two roles, a small fixed enum.
 
 | Role (enum value) | Holders | Capabilities |
 |---|---|---|
@@ -32,7 +32,7 @@ mappings; `adminUserRepo.Save` persists it.
 Why this shape: minimal change; no `user.ID`-vs-`adminuser.ID` confusion (the role
 lives in the admin's own ID space, so there is no `permittable`-style lookup); the
 role is already loaded by `RequireApproved`, so the check needs **zero extra reads**;
-and a single role suffices for V1. The deferred multi-role alternative (a binding
+and a single role is sufficient. The deferred multi-role alternative (a binding
 aggregate mapping `adminuser.ID` → `[]role.ID`) is documented in git history and
 revisited only if multi-role is ever needed.
 
@@ -209,4 +209,4 @@ sequenceDiagram
    checked in and the distribution mechanism is not evidenced in this repo. Confirm
    with the platform/Cerbos owner before rollout.
 2. **A third `user_admin` role** (may approve admins but not touch workspaces) —
-   easy to add via the enum + matrix; deferred, not built for V1.
+   easy to add via the enum + matrix; deferred, not built now.

--- a/server/docs/usecase/admin-role-permittable.md
+++ b/server/docs/usecase/admin-role-permittable.md
@@ -1,0 +1,879 @@
+# Admin Role (Granular Admin Permissions)
+
+> **Status: DRAFT for review.** This is a design document (options + trade-offs +
+> recommendation) for reearth-dashboard#1316. It is not an implementation. Code
+> snippets are illustrative pseudocode only. Items that are genuinely undecided
+> are listed under **Open Questions**.
+>
+> **Selected model (this revision):** an admin has **exactly one role**, stored
+> as a `role` enum field **directly on the `adminuser.AdminUser` aggregate**
+> (plus a Mongo/Postgres migration adding the field/column) — *not* a separate
+> binding aggregate. Enforcement is **Cerbos-based**: the admin's single `role`
+> (loaded by `RequireApproved`) becomes the Cerbos principal role, and a
+> `RequirePermission` middleware calls the admin `authz.Checker`, which does a
+> Cerbos `CheckResources` against the **`accounts-admin`** service policy for the
+> route's `(resource, action)`. Because the role lives on the aggregate, the
+> checker takes the **already-loaded role / `adminuser.ID`** (not a `user.ID`) and
+> needs **no** `permittable`-style repo lookup. This consumes the existing (until
+> now dormant) Cerbos admin machinery. An **in-process static check** against the
+> role→action matrix in `internal/admin/rbac/definitions.go` was considered but
+> **not chosen** for V1 (see Design Question 3): the team chose Cerbos for
+> consistency with the end-user `accounts` authorization model. The earlier
+> multi-role / separate-binding design (`pkg/adminpermittable`) is retained only
+> as a **deferred alternative** (see Design Question 2).
+
+## Document Signature
+
+|           |                                                        |
+|-----------|--------------------------------------------------------|
+| Creator   | [author]                                               |
+| Leader    | [pending]                                              |
+| Task Link | reearth-dashboard#1316 (part of epic reearth-dashboard#1233) |
+| Developer | [pending]                                              |
+
+## Background / Problem Statement
+
+The admin application (`reearth-dashboard-admin-api`, implemented in this repo
+under `server/internal/admin/`) currently treats **every approved admin as
+equal**. The only authorization gate is the `RequireApproved` middleware
+(`internal/admin/presentation/middleware/require_approved.go`): once an
+`adminuser.AdminUser` has `status == approved`, it can call every admin
+endpoint — list/read users, list/read workspaces and members, and
+approve/reject/revoke *other* admins.
+
+This was a deliberate V1 non-goal of the ADMIN-AUTH epic (reearth-dashboard#1233):
+
+> Role-based permissions inside admin (V1 treats every approved admin as equal).
+> Roles are a follow-up if needed.
+
+#1316 is that follow-up. The problem it solves:
+
+1. **No least-privilege.** A read-only operator (e.g. support staff who only
+   inspect users/workspaces) is indistinguishable from a super-admin who can
+   approve new admins and, in future, mutate/delete data. This is fact: all
+   approved-admin routes are grouped under a single `requireApproved` middleware
+   in `internal/admin/presentation/router.go` with no per-action check.
+2. **Approve/reject of admins is a high-privilege action** currently available
+   to any approved admin. Granting or revoking admin access should itself be
+   restricted.
+3. **The enforcement machinery already exists but is dormant.** The admin Cerbos
+   `Checker` (`internal/admin/usecase/authz/checker.go`), the RBAC definitions
+   (`internal/admin/rbac/definitions.go`, service `accounts-admin`, single role
+   `admin`), and the Cerbos client provider (`internal/admin/di/config.go`,
+   `provideCerbosClient`, marked `//nolint:unused` and explicitly retained "for
+   reearth-dashboard#1316") are wired but not consumed by any usecase. The
+   preceding endpoint work deliberately kept this wiring so that #1316 is a
+   *purely additive* change, not a rework. The selected design **consumes** this
+   machinery: the `RequirePermission` middleware calls the admin `authz.Checker`,
+   which evaluates the `accounts-admin` Cerbos policy. This honors the issue's
+   "keep Cerbos" directive by actually using the wiring rather than deleting it.
+
+**Fact vs. opinion.** Facts: the current single-role model, the dormant checker,
+the ID-space mismatch described below. Opinions/recommendations: the specific
+role set, the choice to store the role on the aggregate, the Cerbos enforcement
+path, and the rollout ordering.
+
+### A critical distinction to make explicit
+
+There are **two separate identity + authorization worlds** in this repository,
+and #1316 must not conflate them:
+
+| | End-user world (`accounts`) | Admin world (`accounts-admin`) |
+|---|---|---|
+| Identity aggregate | `pkg/user` (`user.ID`) | `pkg/adminuser` (`adminuser.ID` = `id.AdminUserID`) |
+| Cerbos service name | `accounts` (`internal/rbac`) | `accounts-admin` (`internal/admin/rbac`) |
+| Role binding today | `pkg/permittable` binds `user.ID` → `role.ID` (+ workspace roles) | none — every approved admin is equal |
+| Roles today | `role.RoleOwner/Maintainer/Writer/Reader/Self` | single string `"admin"` |
+
+The existing `pkg/permittable` binds **end-users** to **workspace roles** for the
+**`accounts`** service. It is keyed by `user.ID`
+(`permittable.Repo.FindByUserID(ctx, user.ID)`). Admin users live in a
+**different ID space** (`adminuser.ID`). The **selected design sidesteps this
+mismatch entirely**: the admin's role is stored on the `adminuser.AdminUser`
+aggregate itself (its own ID space), so no `permittable`-style binding keyed by
+`user.ID` is involved at all.
+
+There is a latent bug in the (until now dormant) checker that is now **in scope
+and MUST be fixed**, because the selected design consumes the checker: today
+`authz.Checker.Allowed(ctx, caller user.ID, …)` takes a `user.ID`, but the admin
+principal is an `adminuser.ID`. The checker was written against the end-user
+permittable repo and never exercised. The fix is to **re-type `Allowed` to take
+the admin principal** — the already-loaded `role` (or an `adminuser.ID` + a cheap
+`AdminUser` load) — not `user.ID`, and to update the provider-set signature in
+`internal/admin/di` accordingly. Because the role lives on the aggregate, the
+checker does **not** need a `permittable` repo lookup at all.
+
+## Goals
+
+1. Approved admins are **no longer all-equal**: each admin endpoint's access is
+   decided by the caller's single admin **role**, checked via **Cerbos**
+   (`accounts-admin` service policy) by a `RequirePermission` middleware layered
+   on top of `RequireApproved`.
+2. Define a first-class **super-admin role** plus at least one lower-privilege
+   role, with a clear default, so no existing approved admin is locked out on
+   rollout.
+3. Store the admin's role on the `adminuser.AdminUser` aggregate (a `role` enum
+   field), including how the role is granted at/after approval and how the
+   bootstrap admin(s) obtain the highest role.
+4. Keep the `accounts-admin` role→action matrix (`resourceRules` in
+   `internal/admin/rbac/definitions.go`) as the single source of truth for what
+   each role may do. It is compiled into the `accounts-admin` Cerbos policy via
+   the policy generation path (`cmd/policy-generator`, Makefile `gen-policies`),
+   which the checker evaluates at runtime.
+5. Enforce the check on the admin resource endpoints **additively** — no change
+   to paths or response shapes; only new `403` outcomes for under-privileged
+   callers.
+6. Rollout is safe: the migration backfills existing approved admins to the
+   default (super-admin) role, and the check can be enabled in a
+   fail-open → fail-closed order so nobody is locked out mid-deploy.
+
+**Impact when reached:** support-tier admins can be given read-only access;
+approve/reject/revoke and (future) mutations require super-admin; the security
+posture moves from all-or-nothing to least-privilege without touching end-user
+authorization.
+
+## Non-Goals
+
+1. **Admin UI for managing roles** — a separate frontend follow-up. This doc
+   specifies the *server* endpoint(s) for role assignment but not the UI.
+2. **Changing end-user (`accounts`) authorization** — `pkg/user`,
+   `pkg/permittable` end-user bindings, and the `accounts` Cerbos policy are
+   untouched.
+3. **A general audit-log** for role changes beyond what already exists
+   (`approvedBy`/`approvedAt` on the admin user). A dedicated `admin_actions`
+   collection remains out of scope (matching the epic's non-goal), though role
+   changes SHOULD be logged (see Post Deployment).
+4. **Fine-grained per-resource-instance rules** (e.g. "admin X may only see
+   workspaces in region Y"). V1 is per-action/per-resource-type, not
+   per-instance.
+5. **Removing the Cerbos wiring** — #1316 keeps and reuses it, as the issue states.
+
+## Functional Requirements
+
+1. Every existing approved-admin route maps to a `(resource, action)` pair on the
+   `accounts-admin` matrix and is checked before the usecase runs.
+2. The check adds **zero extra datastore reads** per request beyond what
+   `RequireApproved` already does: the caller's role is already on the `AdminUser`
+   loaded into the echo context, so the checker builds the Cerbos principal from
+   that role without any `permittable`-style lookup. It adds exactly **one Cerbos
+   `CheckResources` gRPC call** per protected request.
+3. Latency budget: the added Cerbos `CheckResources` gRPC call should add
+   **< ~15 ms p95** to admin requests. Admin traffic is very low volume (a
+   handful of Eukarya staff), so throughput is not a concern.
+4. Local development must be unaffected. With Cerbos unconfigured (local dev,
+   `CERBOS_HOST` empty), checks must continue to **fail open** exactly as
+   `provideCerbosClient` / `Checker` already do (nil client ⇒ allow).
+5. The bootstrap admin(s) (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`) must always
+   resolve to the super-admin role, even on a brand-new database.
+6. Backward compatibility: existing approved admins retain full access after the
+   migration (their `role` field is backfilled to super-admin per the rollout
+   plan).
+
+## Solution Options
+
+The design breaks into eight questions. The core decisions are now **final**:
+**Design Question 2** documents the *selected* storage model for the role (a
+field on the `AdminUser` aggregate) versus a demoted deferred alternative; and
+**Design Question 3** documents the *selected* enforcement style (**Cerbos**),
+with the in-process static check preserved as a considered-but-rejected
+alternative. The other questions have a single recommended approach with
+rationale.
+
+### Design question 1 — Role model for admins
+
+**DECIDED: two admin role *types* for V1 (`system_admin`, `viewer`), a small,
+fixed enum modelled exactly like the existing `adminuser.Status` enum.**
+
+| Role type | Role name (enum value) | Intended holders | Capabilities |
+|---|---|---|---|
+| System admin (super-admin) | `system_admin` | Eukarya platform operators, bootstrap admins | Everything: manage admins (approve/reject/revoke), assign roles, read + (future) mutate all resources |
+| Viewer (read-only) | `viewer` | Support / read-only staff | List/read users, workspaces, members, admin-users. No approve/reject, no mutations, no role assignment |
+
+These are the values of a new `role` enum **field on `adminuser.AdminUser`**
+(see Design Question 2 for the field and the enum type). The enum is modelled on
+the existing `adminuser.Status` enum in `server/pkg/adminuser/enum.go` (a
+`type Role string`, a fixed slice of valid values, a `Valid()` method, and a
+`RoleFrom(string)` parse/validate function).
+
+Rationale:
+- **DECIDED — rename** the existing single Cerbos role `"admin"` →
+  `system_admin` (see Migration for the string-compatibility note). Starting with
+  exactly two roles satisfies the issue ("a first-class system-admin role and any
+  additional admin roles we need") while keeping the matrix tiny.
+- A fixed enum (mirroring the `adminuser.Status` pattern in `enum.go`) is
+  preferable to arbitrary user-defined admin roles for V1: the set of admin
+  capabilities is small and closed, and a fixed enum keeps the role→action
+  matrix a compile-time constant in `internal/admin/rbac/definitions.go`, from
+  which `cmd/policy-generator` compiles the `accounts-admin` Cerbos policy.
+- A third role (e.g. `user_admin` who may approve admins but not touch
+  workspaces) is easy to add later by extending the enum + the matrix; it is
+  called out as an open question rather than built now.
+
+### Design question 2 — Where the admin's role lives (SELECTED: field on the aggregate)
+
+**Selected design: a single `role` enum field directly on the
+`adminuser.AdminUser` aggregate, plus a Mongo/Postgres migration adding the
+field/column.** An admin has **exactly one** role. This is the simplest storage
+change and it is now the primary model (it was previously written up as a
+"rejected preface"; that judgement is reversed — see the deferred alternative
+below for the multi-role design and why it is deferred rather than chosen).
+
+The role is modelled exactly like the existing `adminuser.Status` enum
+(`server/pkg/adminuser/enum.go`): a `type Role string`, a fixed set of valid
+values, a `Valid()` method, and a `RoleFrom(string)` parse/validate helper.
+
+```go
+// server/pkg/adminuser/enum.go  (illustrative addition, mirroring Status)
+var (
+    RoleSystemAdmin = Role("system_admin")
+    RoleViewer      = Role("viewer")
+
+    roles = []Role{
+        RoleSystemAdmin,
+        RoleViewer,
+    }
+
+    ErrInvalidRole = errors.New("invalid role")
+)
+
+type Role string
+
+func (r Role) Valid() bool   { return slices.Contains(roles, r) }
+func (r Role) String() string { return string(r) }
+
+func RoleFrom(s string) (Role, error) {
+    role := Role(strings.ToLower(s))
+    if role.Valid() {
+        return role, nil
+    }
+    return role, ErrInvalidRole
+}
+```
+
+The `role` field is added to the aggregate alongside `status`, with a getter and
+a domain mutator, mirroring the existing `status` field and `Approve(by ID)`
+method:
+
+```go
+// server/pkg/adminuser/adminuser.go  (illustrative additions)
+type AdminUser struct {
+    // ... existing fields ...
+    role   Role   // NEW: the admin's single role
+    status Status
+    // ...
+}
+
+func (u *AdminUser) Role() Role {
+    if u == nil {
+        return ""
+    }
+    return u.role
+}
+
+// SetRole changes the admin's role. Caller-side guards (zero/last system_admin
+// protection) live in the usecase — see Design Question 5.
+func (u *AdminUser) SetRole(r Role) {
+    if u == nil {
+        return
+    }
+    u.role = r
+    u.updatedAt = time.Now()
+}
+
+// IsSystemAdmin is a convenience helper (e.g. for the zero/last-system_admin guard).
+func (u *AdminUser) IsSystemAdmin() bool {
+    return u != nil && u.role == RoleSystemAdmin
+}
+```
+
+```go
+// server/pkg/adminuser/builder.go  (illustrative addition, mirroring Status)
+func (b *Builder) Role(role Role) *Builder {
+    b.u.role = role
+    return b
+}
+// Build() defaults an unset role to RoleSystemAdmin only where appropriate
+// (e.g. bootstrap); otherwise a role should be set explicitly. See Q6/Q7.
+```
+
+Storage: the `role` field is added to the existing admin-user document/row via a
+Mongo/Postgres migration (see Design Question 7). **No new collection or table.**
+The `adminuser` repositories (`internal/infrastructure/{mongo,postgres,memory}/`)
+gain the new field in their document mapping; `adminUserRepo.Save` persists it.
+
+**Why this is the selected model**
+- **Minimal change.** One field + one getter + one mutator + one builder method +
+  one additive migration. No new aggregate, no new repo interface, no new infra
+  across three backends.
+- **No ID-space confusion.** The role lives on the admin aggregate in its own ID
+  space (`adminuser.ID`); there is no `permittable`-style binding keyed by
+  `user.ID`, so the crux problem simply does not arise.
+- **Simplifies the Cerbos check (Design Question 3).** Because `RequireApproved`
+  already loads the `AdminUser` into the echo context, the middleware reads the
+  role directly and hands it to the `authz.Checker` as the Cerbos principal role —
+  **no `permittable`-style repo lookup and no extra datastore read** are needed to
+  resolve the principal.
+- **Single-role is sufficient for V1.** The two roles are mutually exclusive
+  privilege tiers; nothing in the endpoint matrix needs a role *list*.
+
+**Trade-off accepted:** an admin is limited to exactly one role. If a genuine
+need for multiple roles per admin ever appears, migrate to the deferred
+alternative below. This is explicitly listed as a (now-decided) Open Question:
+single-role is chosen for V1.
+
+---
+
+#### Deferred alternative (if multi-role per admin becomes necessary)
+
+*Revisit only if multi-role per admin is ever needed.* The earlier design
+introduced a **new** binding aggregate, `pkg/adminpermittable` (name TBD),
+binding `adminuser.ID` → `[]role.ID` and reusing the existing `pkg/role`
+aggregate for role definitions, with its own `admin_permittables` collection/
+table mirroring `pkg/permittable` across the mongo/postgres/memory backends, plus
+a migration seeding role rows and backfilling bindings. The dormant
+`authz.Checker` would be re-typed to take an `adminuser.ID` and a
+`FindByAdminUserID` repo, resolving role IDs → role names → a Cerbos principal
+with a role *list*.
+
+Its advantages were: support for **multiple roles per admin**, reuse of the
+well-understood `permittable → roles → Cerbos principal` pattern, and clean
+bounded-context separation. Its cost — a new aggregate + repo implementations
+across three backends + a new collection/table + a migration — is real, and its
+sole distinguishing advantage (multiple roles per admin) is not needed for V1
+(single-role is sufficient). It is therefore **deferred, not deleted**: the
+reasoning is preserved here so the path is available if requirements change.
+(Note: even under this alternative, enforcement would still be Cerbos-based; the
+only difference is where the role binding lives.)
+
+> A rejected sub-alternative was reusing the *existing* `pkg/permittable`
+> collection for admins by casting `adminuser.ID` into `user.ID`. That is a
+> non-starter: it collides two distinct ULID ID spaces in one `user.ID`-typed,
+> `user.ID`-indexed collection that end-user authorization
+> (`internal/usecase/interactor/cerbos.go`) also reads, risking cross-context
+> data bleed. It is recorded only to note it was considered and rejected.
+
+### Design question 3 — Enforcement (SELECTED: Cerbos)
+
+Enforcement is a **permission middleware** applied per route/group: it maps the
+matched route to a `(resource, action)` pair and checks before the handler. This
+keeps the check declarative and colocated with the routing table in
+`internal/admin/presentation/router.go`, and the admin user is already loaded
+into the echo context by `RequireApproved` (`internal.GetAdminUser(c)`), so the
+middleware has everything it needs without threading anything through every
+usecase constructor.
+
+#### SELECTED — Cerbos-based check
+
+The `RequirePermission` middleware reads the caller's single role from the
+already-loaded `AdminUser` and hands it to the admin `authz.Checker`, which does a
+Cerbos `CheckResources` against the `accounts-admin` service policy for the
+route's `(resource, action)`. The principal's role is the admin's single role.
+Because the role is on the aggregate, the checker is **re-typed to accept the
+admin principal** — the loaded `adminuser.Role` (or the `adminuser.ID` + a cheap
+`AdminUser` load) — **not** a `user.ID`, and needs **no** `permittable` repo
+lookup.
+
+```go
+// illustrative — presentation/middleware/require_permission.go (SELECTED: Cerbos)
+func RequirePermission(chk *authz.Checker, resource, action string) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            u, err := internal.GetAdminUser(c) // set by RequireApproved; role already loaded
+            if err != nil {
+                return echo.NewHTTPError(http.StatusUnauthorized)
+            }
+            // Checker re-typed to take the admin principal's role / adminuser.ID
+            // (NOT user.ID); builds the Cerbos principal from the loaded role.
+            ok, err := chk.Allowed(c.Request().Context(), u.Role(), resource, action)
+            if err != nil {
+                return echo.NewHTTPError(http.StatusInternalServerError)
+            }
+            if !ok {
+                return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+            }
+            return next(c)
+        }
+    }
+}
+```
+
+Why Cerbos was chosen:
+- **Consistency with the end-user `accounts` authorization model.** The admin
+  service enforces authorization the same way the rest of the platform does
+  (`internal/usecase/interactor/cerbos.go`), rather than introducing a second,
+  divergent in-process enforcement style.
+- **Consumes the existing (dormant) machinery** (`internal/admin/rbac`,
+  `internal/admin/usecase/authz`, `provideCerbosClient`) rather than leaving it
+  unused — honoring the "keep Cerbos" directive by actually using it.
+- **Fail-open in local dev is already handled** — a nil Cerbos client (no
+  `CERBOS_HOST`) allows, so local development needs no external dependency.
+
+Required fix (now in scope): the checker's `user.ID`-vs-`adminuser.ID` typing bug
+must be reconciled — re-type `authz.Checker.Allowed` to take the admin principal
+(role / `adminuser.ID`) and update its provider-set signature in
+`internal/admin/di`. See the critical-distinction note above.
+
+#### Considered alternative (rejected for V1) — in-process static check
+
+An alternative was to have `RequirePermission` read the caller's role from the
+already-loaded `AdminUser` and check it against the static role→action matrix
+in-process — the same `resourceRules` data in `internal/admin/rbac/definitions.go`,
+exposed via a small helper (e.g. `rbac.Allowed(role, resource, action) bool`) —
+with **no Cerbos gRPC call, no permittable repo, and no extra datastore read**.
+
+```go
+// illustrative — REJECTED alternative: in-process static check
+func RequirePermission(resource, action string) echo.MiddlewareFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            u, err := internal.GetAdminUser(c)
+            if err != nil { return echo.NewHTTPError(http.StatusUnauthorized) }
+            if !rbac.Allowed(u.Role().String(), resource, action) { // static matrix lookup
+                return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+            }
+            return next(c)
+        }
+    }
+}
+```
+
+Its trade-offs (preserved for the record): it was **simpler** — no external
+dependency, no per-request Cerbos call, zero added latency, and it would have made
+the checker's `user.ID` typing bug moot by not using the checker at all. **Why it
+was rejected:** the team chose Cerbos for **consistency with the end-user
+`accounts` authorization model**; running two different enforcement mechanisms in
+one codebase was judged the larger long-term cost. This path remains available if
+the Cerbos policy-distribution dependency (Design Question 4) ever proves
+prohibitive.
+
+**Endpoint → resource/action mapping** (existing routes from `router.go`, plus
+near-future mutations). This table drives the `accounts-admin` Cerbos policy
+(generated from the matrix in `internal/admin/rbac/definitions.go`):
+
+| Method / Path | Resource | Action | Min role |
+|---|---|---|---|
+| `GET /api/v1/admin-users` | `admin_user` | `list` | viewer |
+| `POST /api/v1/admin-users/:id/approve` | `admin_user` | `approve` | system_admin |
+| `POST /api/v1/admin-users/:id/reject` | `admin_user` | `reject` | system_admin |
+| `GET /api/v1/users` | `user` | `list` | viewer |
+| `GET /api/v1/users/:id` | `user` | `read` | viewer |
+| `GET /api/v1/users/:id/workspaces` | `user` | `read` | viewer |
+| `GET /api/v1/workspaces` | `workspace` | `list` | viewer |
+| `GET /api/v1/workspaces/:id` | `workspace` | `read` | viewer |
+| `GET /api/v1/workspaces/:id/members` | `workspace` | `read_member` | viewer |
+| *(future)* `PATCH/DELETE users/workspaces` | resp. | `edit` / `delete` | system_admin |
+| `PUT /api/v1/admin-users/:id/roles` (see Q5) | `admin_user` | `assign_role` | system_admin |
+
+Notes:
+- `/api/v1/me`, `/api/v1/auth/*` stay public / session-only (no permission check)
+  — they are the pending/rejected screens' lifeline and must work for any status.
+- `approve`/`reject` are **new actions** not present in today's
+  `resourceRules` (which only has `list/read/edit/delete`). Making
+  approve/reject their own actions (rather than folding into `edit`) is what lets
+  a viewer read the admin-user list while only system_admin can act on it.
+- A new resource `admin_user` is added (distinct from the existing `user`
+  resource, which refers to *end-users* the admin inspects).
+- "Min role" is enforced via Cerbos: the matrix is compiled into the
+  `accounts-admin` Cerbos policy, and the checker evaluates `CheckResources`
+  against it for each `(resource, action)`.
+
+### Design question 4 — The role→action matrix and the `accounts-admin` Cerbos policy (REQUIRED for V1)
+
+`internal/admin/rbac/definitions.go` evolves from single-role to multi-role by
+(1) adding role-name constants, (2) adding the `admin_user` resource and the
+`approve`/`reject` actions, and (3) listing multiple roles per action.
+**`resourceRules` is the single source of truth for the matrix**, and it is
+**compiled into the `accounts-admin` Cerbos policy** — the checker evaluates that
+policy at runtime. Generating and landing this policy is **required for V1**.
+
+```go
+// illustrative evolution of definitions.go
+const (
+    roleSystemAdmin = "system_admin"
+    roleViewer      = "viewer"
+)
+const (
+    ResourceAdminUser = "admin_user"
+    // ResourceUser, ResourceWorkspace unchanged
+)
+const (
+    ActionApprove    = "approve"
+    ActionReject     = "reject"
+    ActionAssignRole = "assign_role"
+    /* + existing list/read/edit/delete */
+)
+
+var resourceRules = []ResourceRule{
+    {Resource: ResourceAdminUser, Actions: map[string][]string{
+        ActionList:       {roleSystemAdmin, roleViewer},
+        ActionApprove:    {roleSystemAdmin},
+        ActionReject:     {roleSystemAdmin},
+        ActionAssignRole: {roleSystemAdmin},
+    }},
+    {Resource: ResourceUser, Actions: map[string][]string{
+        ActionList: {roleSystemAdmin, roleViewer},
+        ActionRead: {roleSystemAdmin, roleViewer},
+        ActionEdit: {roleSystemAdmin}, ActionDelete: {roleSystemAdmin},
+    }},
+    {Resource: ResourceWorkspace, Actions: map[string][]string{
+        ActionList: {roleSystemAdmin, roleViewer},
+        ActionRead: {roleSystemAdmin, roleViewer},
+        ActionEdit: {roleSystemAdmin}, ActionDelete: {roleSystemAdmin},
+        // plus read_member for members endpoint
+    }},
+}
+```
+
+`DefineResources` (the loop that turns `resourceRules` into
+`generator.ResourceDefinition`s) needs no structural change — it already iterates
+actions→roles generically; only the data grows. This one matrix definition is the
+source from which the `accounts-admin` Cerbos policy is generated.
+
+**Cerbos generation & load path — REQUIRED for V1:**
+- Policies are generated by `server/cmd/policy-generator/main.go`, which iterates
+  a `policySet` list — one entry for the main `accounts` service
+  (`internal/rbac`) and one for `accounts-admin` (`internal/admin/rbac`) — and
+  calls `reearthx`'s `generator.GeneratePolicies(serviceName, defineResources,
+  outputDir)`, writing YAML into the `policies` dir (`PolicyFileDir = "policies"`
+  for both). It is invoked via `make gen-policies` (`go run ./cmd/policy-generator`).
+- The concrete deliverable for V1: regenerate the `accounts-admin` policy with
+  `make gen-policies` and land the updated YAML through whatever path the
+  `accounts` policy already uses.
+
+> **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.** The
+> repo's `policies/` directory (repo root) contains checked-in policy YAML (e.g.
+> `service_resource.yaml`, `dashboard_*.yaml`), and Cerbos loads a policy set at
+> runtime. **The exact mechanism by which the generated `accounts-admin` YAML
+> reaches the running Cerbos instance is not evidenced in this repo.** CLAUDE.md
+> states other services' definitions are "synced to GCS via GitHub Actions", but
+> **no such workflow exists** under this repo's `.github/workflows/`. Because
+> enforcement is now Cerbos-based, the policy MUST reach the running Cerbos
+> instance for the check to work — if it does not load, protected endpoints will
+> fail. **This must be confirmed with the platform/Cerbos owner before rollout**
+> and is the single remaining open dependency for the feature (see Open
+> Questions).
+
+### Design question 5 — Role assignment flow
+
+**Who may assign/change admin roles:** system_admin only (action
+`admin_user:assign_role`, enforced by the same middleware/matrix).
+
+**How:** the assignment **mutates the `role` field on the target
+`adminuser.AdminUser`** (via the domain method `SetRole` from Design Question 2)
+and persists it with `adminUserRepo.Save`. There is no separate binding to
+create.
+
+1. **On approval.** When a system_admin approves a pending admin
+   (`adminuseruc/approve.go`), the newly approved admin's `role` field is set to
+   the **default role = `viewer`**. This makes least-privilege the default: new
+   admins can look but not act until explicitly elevated. (Bootstrap admins are
+   the exception — see Q6.)
+2. **Explicit change.** A new endpoint sets the role:
+
+   | Method / Path | Auth | Description |
+   |---|---|---|
+   | `PUT /api/v1/admin-users/:id/roles` | system_admin | Set the target admin's single role. Body: `{ "role": "viewer" }`. The usecase loads the target AdminUser, calls `SetRole`, and `adminUserRepo.Save`s it. |
+
+   Guards mirror the existing self-modification / lock-out rules in
+   `adminuseruc`: an admin cannot demote their **own** last `system_admin` role,
+   and the system must never reach **zero** `system_admin`s (count admins whose
+   `role == system_admin` before persisting a demotion) — analogous to the
+   existing "last approved admin cannot be rejected" rule in the approve/reject
+   usecases.
+
+The UI for this endpoint is a separate follow-up (non-goal). For V1 the endpoint
++ guards are sufficient; role changes can be driven by API/script until the UI
+lands. (The path is kept plural `/roles` for URL stability, but the body carries
+a single `role`.)
+
+### Design question 6 — Bootstrap
+
+The bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`, already handled
+at sign-in in `authuc` where a bootstrap email is auto-approved instead of
+pending) must receive **`system_admin`**, otherwise the very first admin could
+approve others but not do anything privileged, and on a fresh DB nobody could
+ever gain `system_admin`.
+
+Mechanism: at the point a bootstrap email is auto-approved (sign-in upsert in
+`authuc`), also ensure the admin's `role` field is set to `system_admin`
+(idempotent create-or-elevate: set it on create; on an existing record elevate to
+`system_admin` but **never downgrade** an already-`system_admin`). This runs on
+every bootstrap sign-in, so re-adding an email to the env var can re-grant
+`system_admin` if it was lost — a deliberate safety valve. Because it is keyed
+off config, it avoids both the chicken-and-egg problem and the unsafe "first
+login wins" pattern (consistent with the epic's bootstrap philosophy).
+
+### Design question 7 — Migration / rollout / backward-compat
+
+**Data migration (add + backfill the `role` field):**
+1. Add the `role` field/column to the admin-user documents/rows (Mongo: add the
+   field to `adminuser` docs; Postgres: `ALTER TABLE ... ADD COLUMN role`).
+   **No new collection or table.**
+2. Backfill: set `role = system_admin` for every existing `adminuser` with
+   `status == approved` (the **default backfill role**, chosen for a zero-lockout
+   deploy). Idempotent on re-run.
+
+**Rollout ordering (fail-open → fail-closed) — the key to not locking anyone out:**
+
+- **Step A (deploy, checks effectively no-op):** land the `accounts-admin` Cerbos
+  policy (see Q4) and ship the migration that adds and backfills the `role` field
+  = **`system_admin`** for all currently-approved admins. Ship the
+  `RequirePermission` middleware. It is *effectively permissive* by virtue of
+  every existing admin holding `system_admin` (so every Cerbos check ALLOWs) —
+  **no feature flag is required** (an env-var flag is available only as an
+  optional extra safety valve). Result: identical behavior to today; nobody loses
+  access.
+- **Step B (enable enforcement):** the middleware is active and calling Cerbos;
+  confirm the `accounts-admin` policy is loaded by the running Cerbos instance
+  (the distribution dependency from Q4). All existing admins still pass because
+  they hold `system_admin`.
+- **Step C (tighten):** a system_admin demotes the admins who should be read-only
+  to `viewer` via the Q5 endpoint (setting their `role` field). New admins default
+  to `viewer` on approval from this point. This is a data/operations step, not a
+  deploy.
+
+This ordering means the risky transition (all-equal → scoped) happens as a
+deliberate, reversible **data** change (Step C), long after the code is safely
+deployed.
+
+**Backward compatibility:** paths and response shapes are unchanged; the only new
+behavior is `403` for an under-privileged caller, which cannot occur until Step C
+demotes someone. The migration is additive (one new field/column, backfilled); no
+existing field is altered and no collection/table is added.
+
+### Design question 8 — Test plan
+
+Covered in the **Test Plan** section below.
+
+## Design
+
+### Request flow (per protected admin endpoint)
+
+```mermaid
+sequenceDiagram
+    participant Browser as admin/ frontend
+    participant MW as RequireApproved MW
+    participant PMW as RequirePermission MW
+    participant Chk as authz.Checker (admin)
+    participant Cerbos
+    participant UC as Usecase (e.g. adminuseruc.Approve)
+
+    Browser->>MW: request + admin_session cookie
+    MW->>MW: parse session, load AdminUser (incl. role), assert approved
+    MW->>PMW: ctx has AdminUser (internal.SetAdminUser)
+    Note over PMW: role is already on the AdminUser — no extra read
+    PMW->>Chk: Allowed(ctx, adminUser.Role(), resource, action)
+    Note over Chk: re-typed to admin principal (role / adminuser.ID), NOT user.ID
+    alt Cerbos client nil (local dev, no CERBOS_HOST)
+        Chk-->>PMW: allow (fail-open)
+    else Cerbos configured
+        Chk->>Cerbos: CheckResources(principal[role], accounts-admin:resource, action)
+        Cerbos-->>Chk: ALLOW / DENY
+        Chk-->>PMW: bool
+    end
+    alt allowed
+        PMW->>UC: next(handler)
+        UC-->>Browser: 200 + data
+    else denied
+        PMW-->>Browser: 403 forbidden
+    end
+```
+
+### Role assignment / bootstrap flow
+
+```mermaid
+sequenceDiagram
+    participant Google
+    participant Auth as authuc (sign-in)
+    participant Repo as adminUserRepo
+    participant SA as system_admin (human)
+
+    Note over Auth: Bootstrap email path
+    Google->>Auth: verified id_token (bootstrap email)
+    Auth->>Auth: upsert AdminUser status=approved, ensure role=system_admin (never downgrade)
+    Auth->>Repo: Save(AdminUser with role=system_admin)
+
+    Note over SA: Normal approval path
+    SA->>Auth: POST /admin-users/:id/approve (needs admin_user:approve)
+    Auth->>Auth: Approve + SetRole(viewer) (default least-priv)
+    Auth->>Repo: Save(approved AdminUser, role=viewer)
+    SA->>Auth: PUT /admin-users/:id/roles {role:"system_admin"} (needs admin_user:assign_role)
+    Auth->>Auth: SetRole(system_admin), guard against zero system_admins
+    Auth->>Repo: Save(AdminUser with new role)
+```
+
+## Potential Impact
+
+1. **Storage.** No new collection/table — just one added `role` field/column on
+   the existing admin-user documents/rows. Negligible size/CPU impact.
+2. **Latency.** +1 Cerbos `CheckResources` gRPC call per protected request. The
+   role is already loaded by `RequireApproved` (no extra datastore read to resolve
+   the principal). Admin traffic is very low volume, so the added call's impact is
+   immaterial.
+3. **New failure mode.** If Cerbos is configured but the `accounts-admin` policy
+   fails to load (or is never distributed — see Q4), checks could deny legitimate
+   admins and return `500` on protected endpoints (fail-closed under error).
+   Mitigated by the fail-open nil-client path in dev, Step A/B rollout
+   verification, and confirming the policy-distribution path before rollout.
+4. **Cross-context safety.** The admin role lives on the admin aggregate in its
+   own ID space; there is zero risk to end-user (`accounts`) authorization.
+5. **Lock-out risk** if the zero-`system_admin` guard or bootstrap grant is
+   buggy — explicitly tested (below) and mitigated by the re-grantable bootstrap
+   env var.
+
+## Test Plan
+
+1. **Unit — the `Role` enum** in `server/pkg/adminuser/enum_test.go` (mirroring
+   the existing `Status` enum tests): `RoleSystemAdmin`/`RoleViewer` are `Valid()`;
+   an unknown value is invalid; `RoleFrom` parses/normalizes case and rejects junk.
+2. **Unit — the role→action matrix** in `internal/admin/rbac` (the data compiled
+   into the `accounts-admin` policy) and the **admin `authz.Checker`**:
+   - `system_admin` allowed for `admin_user:approve`, `admin_user:assign_role`,
+     `user:edit`, `workspace:list`.
+   - `viewer` allowed for `*:list`/`*:read`, denied for `admin_user:approve`,
+     `user:edit`, `admin_user:assign_role`.
+   - unknown role ⇒ deny.
+   - `authz.Checker` (re-typed to the admin principal) allow/deny per role with a
+     mock/stub Cerbos; nil Cerbos client ⇒ allow (fail-open) preserved.
+3. **Unit — domain role setter + assignment guards** in `pkg/adminuser` and
+   `adminuseruc`:
+   - `SetRole` updates the field and `updatedAt`.
+   - approve sets the default `viewer` role.
+   - cannot demote the last `system_admin` (self or global).
+   - bootstrap ensure-role is idempotent and never downgrades an existing
+     `system_admin`.
+4. **Endpoint — 403 behavior** (handler tests, mirroring existing
+   `handler_test.go` files): a `viewer` session gets `403` on
+   `POST /admin-users/:id/approve` and `200` on `GET /users`; a `system_admin`
+   gets `200` on both. Verify paths/response shapes are unchanged for allowed
+   calls (backward-compat assertion). Use a mock/stub Cerbos checker so these
+   handler tests need no live Cerbos.
+5. **Migration / backfill** (integration, `make test-integration`, mongo +
+   postgres): after running the migration on a DB with N approved admins, every
+   approved admin has `role == system_admin`; the migration is idempotent on
+   re-run and adds the field/column without altering existing data.
+6. **Policy generation**: `make gen-policies` produces a valid `accounts-admin`
+   policy containing the new resources/actions/roles; a golden-file or Cerbos
+   `compile` check in CI. Required for V1.
+
+## Deployment Plan
+
+1. **Backward compatible?** Yes, if rolled out per Steps A→B→C. Code deploy alone
+   (Step A) is behavior-preserving because all existing admins are backfilled to
+   `system_admin`.
+2. **Partial deployment?** Yes. The admin API is a separate binary
+   (`cmd/reearth-accounts-admin`); this changes only the admin path. The check
+   can additionally sit behind an optional feature flag for a staged enable, but
+   the backfill (everyone `system_admin` until demoted) already makes Step A/B
+   safe without one.
+3. **Land the `accounts-admin` Cerbos policy.** The generated policy (Q4) MUST
+   reach the running Cerbos instance **before/at Step A**, via the (to-be-
+   confirmed) distribution path. This is a hard launch dependency — if the policy
+   is not loaded, protected endpoints fail. Confirm the mechanism with the
+   platform/Cerbos owner first.
+4. **Who to notify?** The admin operators (their capabilities may narrow at Step
+   C) and the platform/Cerbos owner (policy generation + distribution path —
+   see Q4).
+5. **Config changes?** `CERBOS_HOST` must be set in prod for the admin service
+   (already required by `provideCerbosClient`); locally it may be empty (checks
+   fail open). Confirm `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` is set so the
+   bootstrap role grant works. Optional feature-flag env var if we choose to gate
+   Step B (not required).
+6. **DDL/DML before deploy?** Yes — the additive migration that adds the `role`
+   field/column and backfills it (no new table/collection). Runs via the existing
+   migration frameworks (mongo `internal/infrastructure/mongo/migration`, postgres
+   `internal/infrastructure/postgres/migration`). Note: admin API's DI does *not*
+   run migrations (it "only connects"); the migration must be owned by the main
+   service startup or a migration job, consistent with the existing split.
+
+## Rollback Plan
+
+1. Notify the admin channel on Slack.
+2. **Toggle the optional feature flag off** (only if one was added) — reverts to
+   all-approved-equal instantly, no redeploy. Not present by default.
+3. If no flag (the default): **redeploy the previous admin-API image** — the permission
+   middleware disappears; `RequireApproved` alone gates again. The added `role`
+   field is inert when unused, so no data rollback is needed.
+4. If Step C demotions caused a lock-out: **re-grant `system_admin`** to a locked
+   -out operator via the (idempotent, re-runnable) bootstrap env var — add their
+   email to `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` and have them re-sign-in.
+5. The migration is additive; it does not need reverting. The added `role`
+   field/column is simply ignored by the previous image. If truly necessary, a
+   script can drop the column/field.
+
+## Post Deployment
+
+- **Checklist**
+  - Verify a `system_admin` can approve/reject and read everything (GUI).
+  - Verify a `viewer` can read lists/details but gets `403` on approve/reject and
+    role assignment.
+  - Verify a freshly approved admin defaults to `viewer`.
+  - Verify at least one `system_admin` always exists (zero-guard) — attempt to
+    demote the last one and confirm it is refused.
+  - Verify local dev (no `CERBOS_HOST`) still fails open.
+- **Metrics**
+  - `403` rate on admin endpoints (spike ⇒ mis-scoped role or policy bug).
+  - `500` rate on protected endpoints (Cerbos reachability / policy load).
+  - Cerbos check latency (p50/p95) on the admin service.
+- **Logging (in lieu of a full audit collection):** log role assignments and
+  approve/reject with actor + target admin IDs (no PII, per epic constraint), so
+  privilege changes are traceable.
+- **Alerting**
+  - Protected-endpoint success rate: Warning `< 99%`, Danger `<= 95%`.
+  - Cerbos check errors (`500`s): Warning `>= 5 min` sustained, Danger `>= 1 h`.
+  - Zero `system_admin` accounts: Danger (immediate) — indicates lock-out risk.
+
+## Open Questions
+
+**Decided in this revision:**
+
+- **DECIDED — Enforcement path: Cerbos.** The `RequirePermission` middleware calls
+  the admin `authz.Checker`, which evaluates the `accounts-admin` Cerbos policy
+  (chosen for consistency with the end-user `accounts` authorization model). The
+  in-process static check was considered and **rejected** for V1 (Design Question
+  3). The checker's `user.ID`-vs-`adminuser.ID` typing bug is now **in scope** and
+  must be fixed (re-type `authz.Checker.Allowed` + its provider-set signature in
+  `internal/admin/di`).
+- **DECIDED — Single-role vs. multi-role per admin: single-role.** An admin has
+  exactly one role. The multi-role `pkg/adminpermittable` design is demoted to a
+  deferred alternative (Design Question 2), to be revisited only if multi-role
+  becomes necessary.
+- **DECIDED — Where the role lives: a `role` enum field on the
+  `adminuser.AdminUser` aggregate** (+ additive migration). No separate binding
+  aggregate, no new collection/table. This also settles the old "reuse `pkg/role`
+  vs. `pkg/adminrole`" question — neither is used; the role is a plain enum on the
+  admin aggregate.
+- **DECIDED — How many roles for V1: two** (`system_admin`, `viewer`).
+- **DECIDED — Rename the existing `"admin"` role to `system_admin`.** Today's
+  single Cerbos role is the literal `"admin"` (in `rbac/definitions.go`); it is
+  renamed to `system_admin`. Confirm no external policy still references `admin`
+  when the regenerated `accounts-admin` policy is distributed.
+- **DECIDED — Backfill role: `system_admin`.** Existing approved admins are
+  backfilled to `system_admin` for a zero-lockout deploy, then demoted to `viewer`
+  in the Step C data operation. New admins default to `viewer` on approval.
+- **DECIDED — Feature flag: none.** The deploy is made safe by the backfill
+  (everyone is `system_admin` until demoted), not by a flag. An env-var flag
+  remains available only as an optional extra safety valve.
+
+**Still open (launch dependency):**
+
+1. **Runtime policy distribution — a launch dependency.** Because enforcement is
+   Cerbos-based, the generated `accounts-admin` YAML MUST reach the running Cerbos
+   instance for the check to work. The exact path from generated YAML to the
+   running Cerbos instance is **not evidenced** in this repo's workflows (CLAUDE.md
+   mentions GCS sync via GitHub Actions, but no such workflow exists here). **This
+   must be confirmed with the platform/Cerbos owner before rollout** (see Design
+   Question 4 and the Deployment Plan). This is the single remaining open item
+   blocking launch.
+
+**Deferred (revisit later):**
+
+2. **A third `user_admin` role** (e.g. may approve admins but not touch
+   workspaces) — easy to add later by extending the enum + matrix; deferred, not
+   built for V1.
+
+## Reviewed by
+
+- Technical Architect: [pending]
+- Technical Leader: [pending]
+- Peers: [pending]

--- a/server/docs/usecase/admin-role-permittable.md
+++ b/server/docs/usecase/admin-role-permittable.md
@@ -1,26 +1,13 @@
 # Admin Role (Granular Admin Permissions)
 
-> **Status: DRAFT for review.** This is a design document (options + trade-offs +
-> recommendation) for reearth-dashboard#1316. It is not an implementation. Code
-> snippets are illustrative pseudocode only. Items that are genuinely undecided
-> are listed under **Open Questions**.
->
-> **Selected model (this revision):** an admin has **exactly one role**, stored
-> as a `role` enum field **directly on the `adminuser.AdminUser` aggregate**
-> (plus a Mongo/Postgres migration adding the field/column) — *not* a separate
-> binding aggregate. Enforcement is **Cerbos-based**: the admin's single `role`
-> (loaded by `RequireApproved`) becomes the Cerbos principal role, and a
-> `RequirePermission` middleware calls the admin `authz.Checker`, which does a
-> Cerbos `CheckResources` against the **`accounts-admin`** service policy for the
-> route's `(resource, action)`. Because the role lives on the aggregate, the
-> checker takes the **already-loaded role / `adminuser.ID`** (not a `user.ID`) and
-> needs **no** `permittable`-style repo lookup. This consumes the existing (until
-> now dormant) Cerbos admin machinery. An **in-process static check** against the
-> role→action matrix in `internal/admin/rbac/definitions.go` was considered but
-> **not chosen** for V1 (see Design Question 3): the team chose Cerbos for
-> consistency with the end-user `accounts` authorization model. The earlier
-> multi-role / separate-binding design (`pkg/adminpermittable`) is retained only
-> as a **deferred alternative** (see Design Question 2).
+> **Status: DRAFT for review** (reearth-dashboard#1316). An admin has **exactly
+> one `role`** enum (`system_admin` | `viewer`) stored **directly on the
+> `adminuser.AdminUser` aggregate** (additive Mongo/Postgres migration; no new
+> collection/table/aggregate). Enforcement is **Cerbos-based**: a
+> `RequirePermission` middleware (layered on `RequireApproved`) reads the
+> already-loaded role and calls the admin `authz.Checker` → Cerbos
+> `CheckResources` against the `accounts-admin` policy. One open launch
+> dependency remains: runtime policy distribution (see Open Questions).
 
 ## Document Signature
 
@@ -33,357 +20,159 @@
 
 ## Background / Problem Statement
 
-The admin application (`reearth-dashboard-admin-api`, implemented in this repo
-under `server/internal/admin/`) currently treats **every approved admin as
-equal**. The only authorization gate is the `RequireApproved` middleware
+The admin application (`server/internal/admin/`) currently treats **every
+approved admin as equal**. The only gate is `RequireApproved`
 (`internal/admin/presentation/middleware/require_approved.go`): once an
-`adminuser.AdminUser` has `status == approved`, it can call every admin
-endpoint — list/read users, list/read workspaces and members, and
-approve/reject/revoke *other* admins.
+`adminuser.AdminUser` has `status == approved`, it can call every admin endpoint
+(list/read users, workspaces, members; approve/reject/revoke *other* admins).
+This was a deliberate V1 non-goal of the ADMIN-AUTH epic (reearth-dashboard#1233);
+#1316 is the follow-up. Problems:
 
-This was a deliberate V1 non-goal of the ADMIN-AUTH epic (reearth-dashboard#1233):
-
-> Role-based permissions inside admin (V1 treats every approved admin as equal).
-> Roles are a follow-up if needed.
-
-#1316 is that follow-up. The problem it solves:
-
-1. **No least-privilege.** A read-only operator (e.g. support staff who only
-   inspect users/workspaces) is indistinguishable from a super-admin who can
-   approve new admins and, in future, mutate/delete data. This is fact: all
-   approved-admin routes are grouped under a single `requireApproved` middleware
-   in `internal/admin/presentation/router.go` with no per-action check.
-2. **Approve/reject of admins is a high-privilege action** currently available
-   to any approved admin. Granting or revoking admin access should itself be
-   restricted.
+1. **No least-privilege.** A read-only operator is indistinguishable from a
+   super-admin; all approved-admin routes sit under one `requireApproved`
+   middleware in `router.go` with no per-action check.
+2. **Approve/reject of admins is high-privilege** yet available to any approved
+   admin; granting/revoking admin access should itself be restricted.
 3. **The enforcement machinery already exists but is dormant.** The admin Cerbos
    `Checker` (`internal/admin/usecase/authz/checker.go`), the RBAC definitions
    (`internal/admin/rbac/definitions.go`, service `accounts-admin`, single role
-   `admin`), and the Cerbos client provider (`internal/admin/di/config.go`,
-   `provideCerbosClient`, marked `//nolint:unused` and explicitly retained "for
-   reearth-dashboard#1316") are wired but not consumed by any usecase. The
-   preceding endpoint work deliberately kept this wiring so that #1316 is a
-   *purely additive* change, not a rework. The selected design **consumes** this
-   machinery: the `RequirePermission` middleware calls the admin `authz.Checker`,
-   which evaluates the `accounts-admin` Cerbos policy. This honors the issue's
-   "keep Cerbos" directive by actually using the wiring rather than deleting it.
+   `admin`), and the Cerbos client provider (`provideCerbosClient`,
+   `//nolint:unused` "for reearth-dashboard#1316") are wired but unused. The
+   selected design **consumes** this machinery.
 
-**Fact vs. opinion.** Facts: the current single-role model, the dormant checker,
-the ID-space mismatch described below. Opinions/recommendations: the specific
-role set, the choice to store the role on the aggregate, the Cerbos enforcement
-path, and the rollout ordering.
+### Two ID spaces
 
-### A critical distinction to make explicit
+There are two separate authorization worlds and #1316 must not conflate them:
+end-users (`pkg/user`, `user.ID`, service `accounts`) vs. admins (`pkg/adminuser`,
+`adminuser.ID`, service `accounts-admin`). `pkg/permittable` binds `user.ID` →
+roles for the `accounts` service; admins live in a different ID space. The
+selected design sidesteps this entirely by storing the role on the
+`adminuser.AdminUser` aggregate itself — no `permittable`-style lookup.
 
-There are **two separate identity + authorization worlds** in this repository,
-and #1316 must not conflate them:
-
-| | End-user world (`accounts`) | Admin world (`accounts-admin`) |
+|  | End-user (`accounts`) | Admin (`accounts-admin`) |
 |---|---|---|
-| Identity aggregate | `pkg/user` (`user.ID`) | `pkg/adminuser` (`adminuser.ID` = `id.AdminUserID`) |
-| Cerbos service name | `accounts` (`internal/rbac`) | `accounts-admin` (`internal/admin/rbac`) |
-| Role binding today | `pkg/permittable` binds `user.ID` → `role.ID` (+ workspace roles) | none — every approved admin is equal |
-| Roles today | `role.RoleOwner/Maintainer/Writer/Reader/Self` | single string `"admin"` |
+| Identity | `user.ID` | `adminuser.ID` |
+| Roles today | Owner/Maintainer/Writer/Reader/Self | single `"admin"` |
 
-The existing `pkg/permittable` binds **end-users** to **workspace roles** for the
-**`accounts`** service. It is keyed by `user.ID`
-(`permittable.Repo.FindByUserID(ctx, user.ID)`). Admin users live in a
-**different ID space** (`adminuser.ID`). The **selected design sidesteps this
-mismatch entirely**: the admin's role is stored on the `adminuser.AdminUser`
-aggregate itself (its own ID space), so no `permittable`-style binding keyed by
-`user.ID` is involved at all.
-
-There is a latent bug in the (until now dormant) checker that is now **in scope
-and MUST be fixed**, because the selected design consumes the checker: today
-`authz.Checker.Allowed(ctx, caller user.ID, …)` takes a `user.ID`, but the admin
-principal is an `adminuser.ID`. The checker was written against the end-user
-permittable repo and never exercised. The fix is to **re-type `Allowed` to take
-the admin principal** — the already-loaded `role` (or an `adminuser.ID` + a cheap
-`AdminUser` load) — not `user.ID`, and to update the provider-set signature in
-`internal/admin/di` accordingly. Because the role lives on the aggregate, the
-checker does **not** need a `permittable` repo lookup at all.
+This surfaces a latent, in-scope bug: today `authz.Checker.Allowed(ctx, caller
+user.ID, …)` takes a `user.ID`, but the admin principal is an `adminuser.ID`. It
+must be **re-typed to take the admin principal** (the already-loaded `role` /
+`adminuser.ID`), with the DI provider-set signature in `internal/admin/di`
+updated accordingly.
 
 ## Goals
 
-1. Approved admins are **no longer all-equal**: each admin endpoint's access is
-   decided by the caller's single admin **role**, checked via **Cerbos**
-   (`accounts-admin` service policy) by a `RequirePermission` middleware layered
-   on top of `RequireApproved`.
-2. Define a first-class **super-admin role** plus at least one lower-privilege
-   role, with a clear default, so no existing approved admin is locked out on
-   rollout.
-3. Store the admin's role on the `adminuser.AdminUser` aggregate (a `role` enum
-   field), including how the role is granted at/after approval and how the
-   bootstrap admin(s) obtain the highest role.
-4. Keep the `accounts-admin` role→action matrix (`resourceRules` in
-   `internal/admin/rbac/definitions.go`) as the single source of truth for what
-   each role may do. It is compiled into the `accounts-admin` Cerbos policy via
-   the policy generation path (`cmd/policy-generator`, Makefile `gen-policies`),
-   which the checker evaluates at runtime.
-5. Enforce the check on the admin resource endpoints **additively** — no change
-   to paths or response shapes; only new `403` outcomes for under-privileged
-   callers.
-6. Rollout is safe: the migration backfills existing approved admins to the
-   default (super-admin) role, and the check can be enabled in a
-   fail-open → fail-closed order so nobody is locked out mid-deploy.
-
-**Impact when reached:** support-tier admins can be given read-only access;
-approve/reject/revoke and (future) mutations require super-admin; the security
-posture moves from all-or-nothing to least-privilege without touching end-user
-authorization.
+1. Approved admins are no longer all-equal: each endpoint's access is decided by
+   the caller's single admin **role**, checked via Cerbos (`accounts-admin`
+   policy) by `RequirePermission` layered on `RequireApproved`.
+2. Define a first-class super-admin role plus a lower-privilege role, with a
+   default that locks nobody out on rollout.
+3. Store the role on the `adminuser.AdminUser` aggregate (a `role` enum field),
+   including how it is granted at/after approval and how bootstrap admins obtain
+   the highest role.
+4. Keep the `accounts-admin` role→action matrix (`internal/admin/rbac`) as the
+   single source of truth, compiled into the Cerbos policy via `cmd/policy-generator`.
+5. Enforce **additively** — no path/response changes; only new `403` outcomes.
+6. Rollout is safe: migration backfills existing approved admins to super-admin,
+   enabled fail-open → fail-closed so nobody is locked out mid-deploy.
 
 ## Non-Goals
 
-1. **Admin UI for managing roles** — a separate frontend follow-up. This doc
-   specifies the *server* endpoint(s) for role assignment but not the UI.
-2. **Changing end-user (`accounts`) authorization** — `pkg/user`,
-   `pkg/permittable` end-user bindings, and the `accounts` Cerbos policy are
-   untouched.
-3. **A general audit-log** for role changes beyond what already exists
-   (`approvedBy`/`approvedAt` on the admin user). A dedicated `admin_actions`
-   collection remains out of scope (matching the epic's non-goal), though role
-   changes SHOULD be logged (see Post Deployment).
-4. **Fine-grained per-resource-instance rules** (e.g. "admin X may only see
-   workspaces in region Y"). V1 is per-action/per-resource-type, not
-   per-instance.
-5. **Removing the Cerbos wiring** — #1316 keeps and reuses it, as the issue states.
+1. **Admin UI for managing roles** — a separate frontend follow-up.
+2. **Changing end-user (`accounts`) authorization** — untouched.
+3. **A general audit-log** for role changes beyond existing
+   `approvedBy`/`approvedAt` (role changes SHOULD still be logged — see Post
+   Deployment).
+4. **Per-resource-instance rules** — V1 is per-action/per-resource-type.
+5. **Removing the Cerbos wiring** — #1316 keeps and reuses it.
 
 ## Functional Requirements
 
-1. Every existing approved-admin route maps to a `(resource, action)` pair on the
-   `accounts-admin` matrix and is checked before the usecase runs.
-2. The check adds **zero extra datastore reads** per request beyond what
-   `RequireApproved` already does: the caller's role is already on the `AdminUser`
-   loaded into the echo context, so the checker builds the Cerbos principal from
-   that role without any `permittable`-style lookup. It adds exactly **one Cerbos
+1. Every approved-admin route maps to a `(resource, action)` pair on the
+   `accounts-admin` matrix, checked before the usecase runs.
+2. **Zero extra datastore reads** per request: the role is already on the
+   `AdminUser` in the echo context; the checker adds exactly **one Cerbos
    `CheckResources` gRPC call** per protected request.
-3. Latency budget: the added Cerbos `CheckResources` gRPC call should add
-   **< ~15 ms p95** to admin requests. Admin traffic is very low volume (a
-   handful of Eukarya staff), so throughput is not a concern.
-4. Local development must be unaffected. With Cerbos unconfigured (local dev,
-   `CERBOS_HOST` empty), checks must continue to **fail open** exactly as
-   `provideCerbosClient` / `Checker` already do (nil client ⇒ allow).
-5. The bootstrap admin(s) (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`) must always
-   resolve to the super-admin role, even on a brand-new database.
-6. Backward compatibility: existing approved admins retain full access after the
-   migration (their `role` field is backfilled to super-admin per the rollout
-   plan).
+3. Latency budget: < ~15 ms p95 added. Admin traffic is very low volume.
+4. Local dev unaffected: with `CERBOS_HOST` empty, a nil Cerbos client **fails
+   open** (allow), as it already does today.
+5. Bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`) always resolve to
+   super-admin, even on a brand-new database.
+6. Backward compatible: existing approved admins retain full access post-migration
+   (role backfilled to super-admin).
 
 ## Solution Options
 
-The design breaks into eight questions. The core decisions are now **final**:
-**Design Question 2** documents the *selected* storage model for the role (a
-field on the `AdminUser` aggregate) versus a demoted deferred alternative; and
-**Design Question 3** documents the *selected* enforcement style (**Cerbos**),
-with the in-process static check preserved as a considered-but-rejected
-alternative. The other questions have a single recommended approach with
-rationale.
+Seven design questions. The core storage and enforcement decisions are final;
+the rest have a single recommended approach.
 
-### Design question 1 — Role model for admins
+### Q1 — Role model
 
-**DECIDED: two admin role *types* for V1 (`system_admin`, `viewer`), a small,
-fixed enum modelled exactly like the existing `adminuser.Status` enum.**
+**DECIDED: two role types for V1**, a small fixed enum modelled on the existing
+`adminuser.Status` enum.
 
-| Role type | Role name (enum value) | Intended holders | Capabilities |
-|---|---|---|---|
-| System admin (super-admin) | `system_admin` | Eukarya platform operators, bootstrap admins | Everything: manage admins (approve/reject/revoke), assign roles, read + (future) mutate all resources |
-| Viewer (read-only) | `viewer` | Support / read-only staff | List/read users, workspaces, members, admin-users. No approve/reject, no mutations, no role assignment |
+| Role (enum value) | Holders | Capabilities |
+|---|---|---|
+| `system_admin` | Platform operators, bootstrap admins | Everything: manage admins (approve/reject/revoke), assign roles, read + (future) mutate all resources |
+| `viewer` | Support / read-only staff | List/read users, workspaces, members, admin-users. No approve/reject, no mutations, no role assignment |
 
-These are the values of a new `role` enum **field on `adminuser.AdminUser`**
-(see Design Question 2 for the field and the enum type). The enum is modelled on
-the existing `adminuser.Status` enum in `server/pkg/adminuser/enum.go` (a
-`type Role string`, a fixed slice of valid values, a `Valid()` method, and a
-`RoleFrom(string)` parse/validate function).
+The existing single Cerbos role `"admin"` is **renamed** to `system_admin`. A
+fixed enum keeps the matrix a compile-time constant. A third role (e.g.
+`user_admin`) is easy to add later and is deferred (Open Questions).
 
-Rationale:
-- **DECIDED — rename** the existing single Cerbos role `"admin"` →
-  `system_admin` (see Migration for the string-compatibility note). Starting with
-  exactly two roles satisfies the issue ("a first-class system-admin role and any
-  additional admin roles we need") while keeping the matrix tiny.
-- A fixed enum (mirroring the `adminuser.Status` pattern in `enum.go`) is
-  preferable to arbitrary user-defined admin roles for V1: the set of admin
-  capabilities is small and closed, and a fixed enum keeps the role→action
-  matrix a compile-time constant in `internal/admin/rbac/definitions.go`, from
-  which `cmd/policy-generator` compiles the `accounts-admin` Cerbos policy.
-- A third role (e.g. `user_admin` who may approve admins but not touch
-  workspaces) is easy to add later by extending the enum + the matrix; it is
-  called out as an open question rather than built now.
+### Q2 — Where the role lives (SELECTED: field on the aggregate)
 
-### Design question 2 — Where the admin's role lives (SELECTED: field on the aggregate)
+**Selected: a single `role` enum field directly on the `adminuser.AdminUser`
+aggregate, plus an additive Mongo/Postgres migration. No new collection, table,
+or aggregate.** An admin has exactly one role.
 
-**Selected design: a single `role` enum field directly on the
-`adminuser.AdminUser` aggregate, plus a Mongo/Postgres migration adding the
-field/column.** An admin has **exactly one** role. This is the simplest storage
-change and it is now the primary model (it was previously written up as a
-"rejected preface"; that judgement is reversed — see the deferred alternative
-below for the multi-role design and why it is deferred rather than chosen).
+The enum mirrors the existing `adminuser.Status` pattern in
+`server/pkg/adminuser/enum.go` (`type Role string`, valid-values slice,
+`Valid()`, `RoleFrom(string)`), with a getter, a `SetRole` mutator, and a builder
+method on the aggregate — this is already implemented in PR #282. The
+`adminuser` repos (`mongo`/`postgres`/`memory`) gain the field in their mappings;
+`adminUserRepo.Save` persists it.
 
-The role is modelled exactly like the existing `adminuser.Status` enum
-(`server/pkg/adminuser/enum.go`): a `type Role string`, a fixed set of valid
-values, a `Valid()` method, and a `RoleFrom(string)` parse/validate helper.
+Why: minimal change (one field + accessors + one additive migration); no ID-space
+confusion (role lives in the admin's own ID space); simplifies the Cerbos check
+because `RequireApproved` already loads the role; single-role is sufficient for
+V1 (the two roles are mutually exclusive privilege tiers).
 
-```go
-// server/pkg/adminuser/enum.go  (illustrative addition, mirroring Status)
-var (
-    RoleSystemAdmin = Role("system_admin")
-    RoleViewer      = Role("viewer")
+**Trade-off:** exactly one role per admin. If multi-role is ever needed, migrate
+to the deferred alternative below.
 
-    roles = []Role{
-        RoleSystemAdmin,
-        RoleViewer,
-    }
+**Deferred alternative (multi-role).** A new binding aggregate
+`pkg/adminpermittable` (name TBD) binding `adminuser.ID` → `[]role.ID`, reusing
+`pkg/role`, with its own collection/table across three backends and a seeding
+migration; the checker would take an `adminuser.ID` + a `FindByAdminUserID` repo.
+Its only distinguishing advantage — multiple roles per admin — is not needed for
+V1, so it is deferred, not deleted. (A sub-alternative — reusing the *existing*
+`pkg/permittable` by casting `adminuser.ID` into `user.ID` — is rejected outright:
+it collides two distinct ULID ID spaces in one `user.ID`-indexed collection that
+end-user authz also reads.)
 
-    ErrInvalidRole = errors.New("invalid role")
-)
+### Q3 — Enforcement (SELECTED: Cerbos)
 
-type Role string
+A per-route/group **permission middleware** maps the matched route to a
+`(resource, action)` pair and checks before the handler, keeping the check
+declarative and colocated with `router.go`. The admin user is already in the echo
+context (`internal.GetAdminUser(c)`).
 
-func (r Role) Valid() bool   { return slices.Contains(roles, r) }
-func (r Role) String() string { return string(r) }
-
-func RoleFrom(s string) (Role, error) {
-    role := Role(strings.ToLower(s))
-    if role.Valid() {
-        return role, nil
-    }
-    return role, ErrInvalidRole
-}
-```
-
-The `role` field is added to the aggregate alongside `status`, with a getter and
-a domain mutator, mirroring the existing `status` field and `Approve(by ID)`
-method:
+`RequirePermission` reads the caller's role from the loaded `AdminUser` and hands
+it to the admin `authz.Checker`, which does a Cerbos `CheckResources` against the
+`accounts-admin` policy for the route's `(resource, action)`. The checker is
+re-typed to take the admin principal (role / `adminuser.ID`), not `user.ID`, and
+needs no `permittable` lookup.
 
 ```go
-// server/pkg/adminuser/adminuser.go  (illustrative additions)
-type AdminUser struct {
-    // ... existing fields ...
-    role   Role   // NEW: the admin's single role
-    status Status
-    // ...
-}
-
-func (u *AdminUser) Role() Role {
-    if u == nil {
-        return ""
-    }
-    return u.role
-}
-
-// SetRole changes the admin's role. Caller-side guards (zero/last system_admin
-// protection) live in the usecase — see Design Question 5.
-func (u *AdminUser) SetRole(r Role) {
-    if u == nil {
-        return
-    }
-    u.role = r
-    u.updatedAt = time.Now()
-}
-
-// IsSystemAdmin is a convenience helper (e.g. for the zero/last-system_admin guard).
-func (u *AdminUser) IsSystemAdmin() bool {
-    return u != nil && u.role == RoleSystemAdmin
-}
-```
-
-```go
-// server/pkg/adminuser/builder.go  (illustrative addition, mirroring Status)
-func (b *Builder) Role(role Role) *Builder {
-    b.u.role = role
-    return b
-}
-// Build() defaults an unset role to RoleSystemAdmin only where appropriate
-// (e.g. bootstrap); otherwise a role should be set explicitly. See Q6/Q7.
-```
-
-Storage: the `role` field is added to the existing admin-user document/row via a
-Mongo/Postgres migration (see Design Question 7). **No new collection or table.**
-The `adminuser` repositories (`internal/infrastructure/{mongo,postgres,memory}/`)
-gain the new field in their document mapping; `adminUserRepo.Save` persists it.
-
-**Why this is the selected model**
-- **Minimal change.** One field + one getter + one mutator + one builder method +
-  one additive migration. No new aggregate, no new repo interface, no new infra
-  across three backends.
-- **No ID-space confusion.** The role lives on the admin aggregate in its own ID
-  space (`adminuser.ID`); there is no `permittable`-style binding keyed by
-  `user.ID`, so the crux problem simply does not arise.
-- **Simplifies the Cerbos check (Design Question 3).** Because `RequireApproved`
-  already loads the `AdminUser` into the echo context, the middleware reads the
-  role directly and hands it to the `authz.Checker` as the Cerbos principal role —
-  **no `permittable`-style repo lookup and no extra datastore read** are needed to
-  resolve the principal.
-- **Single-role is sufficient for V1.** The two roles are mutually exclusive
-  privilege tiers; nothing in the endpoint matrix needs a role *list*.
-
-**Trade-off accepted:** an admin is limited to exactly one role. If a genuine
-need for multiple roles per admin ever appears, migrate to the deferred
-alternative below. This is explicitly listed as a (now-decided) Open Question:
-single-role is chosen for V1.
-
----
-
-#### Deferred alternative (if multi-role per admin becomes necessary)
-
-*Revisit only if multi-role per admin is ever needed.* The earlier design
-introduced a **new** binding aggregate, `pkg/adminpermittable` (name TBD),
-binding `adminuser.ID` → `[]role.ID` and reusing the existing `pkg/role`
-aggregate for role definitions, with its own `admin_permittables` collection/
-table mirroring `pkg/permittable` across the mongo/postgres/memory backends, plus
-a migration seeding role rows and backfilling bindings. The dormant
-`authz.Checker` would be re-typed to take an `adminuser.ID` and a
-`FindByAdminUserID` repo, resolving role IDs → role names → a Cerbos principal
-with a role *list*.
-
-Its advantages were: support for **multiple roles per admin**, reuse of the
-well-understood `permittable → roles → Cerbos principal` pattern, and clean
-bounded-context separation. Its cost — a new aggregate + repo implementations
-across three backends + a new collection/table + a migration — is real, and its
-sole distinguishing advantage (multiple roles per admin) is not needed for V1
-(single-role is sufficient). It is therefore **deferred, not deleted**: the
-reasoning is preserved here so the path is available if requirements change.
-(Note: even under this alternative, enforcement would still be Cerbos-based; the
-only difference is where the role binding lives.)
-
-> A rejected sub-alternative was reusing the *existing* `pkg/permittable`
-> collection for admins by casting `adminuser.ID` into `user.ID`. That is a
-> non-starter: it collides two distinct ULID ID spaces in one `user.ID`-typed,
-> `user.ID`-indexed collection that end-user authorization
-> (`internal/usecase/interactor/cerbos.go`) also reads, risking cross-context
-> data bleed. It is recorded only to note it was considered and rejected.
-
-### Design question 3 — Enforcement (SELECTED: Cerbos)
-
-Enforcement is a **permission middleware** applied per route/group: it maps the
-matched route to a `(resource, action)` pair and checks before the handler. This
-keeps the check declarative and colocated with the routing table in
-`internal/admin/presentation/router.go`, and the admin user is already loaded
-into the echo context by `RequireApproved` (`internal.GetAdminUser(c)`), so the
-middleware has everything it needs without threading anything through every
-usecase constructor.
-
-#### SELECTED — Cerbos-based check
-
-The `RequirePermission` middleware reads the caller's single role from the
-already-loaded `AdminUser` and hands it to the admin `authz.Checker`, which does a
-Cerbos `CheckResources` against the `accounts-admin` service policy for the
-route's `(resource, action)`. The principal's role is the admin's single role.
-Because the role is on the aggregate, the checker is **re-typed to accept the
-admin principal** — the loaded `adminuser.Role` (or the `adminuser.ID` + a cheap
-`AdminUser` load) — **not** a `user.ID`, and needs **no** `permittable` repo
-lookup.
-
-```go
-// illustrative — presentation/middleware/require_permission.go (SELECTED: Cerbos)
+// presentation/middleware/require_permission.go (SELECTED: Cerbos)
 func RequirePermission(chk *authz.Checker, resource, action string) echo.MiddlewareFunc {
     return func(next echo.HandlerFunc) echo.HandlerFunc {
         return func(c echo.Context) error {
-            u, err := internal.GetAdminUser(c) // set by RequireApproved; role already loaded
+            u, err := internal.GetAdminUser(c) // set by RequireApproved; role loaded
             if err != nil {
                 return echo.NewHTTPError(http.StatusUnauthorized)
             }
-            // Checker re-typed to take the admin principal's role / adminuser.ID
-            // (NOT user.ID); builds the Cerbos principal from the loaded role.
             ok, err := chk.Allowed(c.Request().Context(), u.Role(), resource, action)
             if err != nil {
                 return echo.NewHTTPError(http.StatusInternalServerError)
@@ -397,58 +186,20 @@ func RequirePermission(chk *authz.Checker, resource, action string) echo.Middlew
 }
 ```
 
-Why Cerbos was chosen:
-- **Consistency with the end-user `accounts` authorization model.** The admin
-  service enforces authorization the same way the rest of the platform does
-  (`internal/usecase/interactor/cerbos.go`), rather than introducing a second,
-  divergent in-process enforcement style.
-- **Consumes the existing (dormant) machinery** (`internal/admin/rbac`,
-  `internal/admin/usecase/authz`, `provideCerbosClient`) rather than leaving it
-  unused — honoring the "keep Cerbos" directive by actually using it.
-- **Fail-open in local dev is already handled** — a nil Cerbos client (no
-  `CERBOS_HOST`) allows, so local development needs no external dependency.
+**Why Cerbos:** consistency with the end-user `accounts` authorization model
+(`internal/usecase/interactor/cerbos.go`), consuming the existing dormant
+machinery rather than adding a second enforcement style, and fail-open in local
+dev is already handled.
 
-Required fix (now in scope): the checker's `user.ID`-vs-`adminuser.ID` typing bug
-must be reconciled — re-type `authz.Checker.Allowed` to take the admin principal
-(role / `adminuser.ID`) and update its provider-set signature in
-`internal/admin/di`. See the critical-distinction note above.
+**Rejected for V1 — in-process static check.** `RequirePermission` could instead
+check the role against the static matrix in-process (`rbac.Allowed(role,
+resource, action)`), with no Cerbos call, no extra latency, and it would sidestep
+the checker's typing bug. It was rejected to avoid running two divergent
+enforcement mechanisms; it remains available if the Cerbos policy-distribution
+dependency (Q4) ever proves prohibitive.
 
-#### Considered alternative (rejected for V1) — in-process static check
-
-An alternative was to have `RequirePermission` read the caller's role from the
-already-loaded `AdminUser` and check it against the static role→action matrix
-in-process — the same `resourceRules` data in `internal/admin/rbac/definitions.go`,
-exposed via a small helper (e.g. `rbac.Allowed(role, resource, action) bool`) —
-with **no Cerbos gRPC call, no permittable repo, and no extra datastore read**.
-
-```go
-// illustrative — REJECTED alternative: in-process static check
-func RequirePermission(resource, action string) echo.MiddlewareFunc {
-    return func(next echo.HandlerFunc) echo.HandlerFunc {
-        return func(c echo.Context) error {
-            u, err := internal.GetAdminUser(c)
-            if err != nil { return echo.NewHTTPError(http.StatusUnauthorized) }
-            if !rbac.Allowed(u.Role().String(), resource, action) { // static matrix lookup
-                return echo.NewHTTPError(http.StatusForbidden, "forbidden")
-            }
-            return next(c)
-        }
-    }
-}
-```
-
-Its trade-offs (preserved for the record): it was **simpler** — no external
-dependency, no per-request Cerbos call, zero added latency, and it would have made
-the checker's `user.ID` typing bug moot by not using the checker at all. **Why it
-was rejected:** the team chose Cerbos for **consistency with the end-user
-`accounts` authorization model**; running two different enforcement mechanisms in
-one codebase was judged the larger long-term cost. This path remains available if
-the Cerbos policy-distribution dependency (Design Question 4) ever proves
-prohibitive.
-
-**Endpoint → resource/action mapping** (existing routes from `router.go`, plus
-near-future mutations). This table drives the `accounts-admin` Cerbos policy
-(generated from the matrix in `internal/admin/rbac/definitions.go`):
+**Endpoint → resource/action mapping** (existing routes + near-future
+mutations). This drives the `accounts-admin` Cerbos policy:
 
 | Method / Path | Resource | Action | Min role |
 |---|---|---|---|
@@ -465,185 +216,113 @@ near-future mutations). This table drives the `accounts-admin` Cerbos policy
 | `PUT /api/v1/admin-users/:id/roles` (see Q5) | `admin_user` | `assign_role` | system_admin |
 
 Notes:
-- `/api/v1/me`, `/api/v1/auth/*` stay public / session-only (no permission check)
-  — they are the pending/rejected screens' lifeline and must work for any status.
-- `approve`/`reject` are **new actions** not present in today's
-  `resourceRules` (which only has `list/read/edit/delete`). Making
-  approve/reject their own actions (rather than folding into `edit`) is what lets
-  a viewer read the admin-user list while only system_admin can act on it.
-- A new resource `admin_user` is added (distinct from the existing `user`
-  resource, which refers to *end-users* the admin inspects).
-- "Min role" is enforced via Cerbos: the matrix is compiled into the
-  `accounts-admin` Cerbos policy, and the checker evaluates `CheckResources`
-  against it for each `(resource, action)`.
+- `/api/v1/me` and `/api/v1/auth/*` stay public / session-only (no permission
+  check) — they are the pending/rejected screens' lifeline and must work for any
+  status.
+- `approve`/`reject` are **new actions** not in today's `resourceRules` (which has
+  only `list/read/edit/delete`). Making them distinct actions is what lets a
+  viewer read the admin-user list while only system_admin can act on it.
+- A new resource `admin_user` is added (distinct from `user`, which refers to the
+  end-users the admin inspects).
+- "Min role" is enforced via Cerbos against the compiled `accounts-admin` policy.
 
-### Design question 4 — The role→action matrix and the `accounts-admin` Cerbos policy (REQUIRED for V1)
+### Q4 — Role→action matrix and the `accounts-admin` policy (REQUIRED for V1)
 
-`internal/admin/rbac/definitions.go` evolves from single-role to multi-role by
-(1) adding role-name constants, (2) adding the `admin_user` resource and the
-`approve`/`reject` actions, and (3) listing multiple roles per action.
-**`resourceRules` is the single source of truth for the matrix**, and it is
-**compiled into the `accounts-admin` Cerbos policy** — the checker evaluates that
-policy at runtime. Generating and landing this policy is **required for V1**.
+`internal/admin/rbac/definitions.go` evolves from single- to multi-role by adding
+role-name constants, the `admin_user` resource, the `approve`/`reject`/`assign_role`
+actions, and listing multiple roles per action. `resourceRules` remains the single
+source of truth and is compiled into the `accounts-admin` Cerbos policy.
 
-```go
-// illustrative evolution of definitions.go
-const (
-    roleSystemAdmin = "system_admin"
-    roleViewer      = "viewer"
-)
-const (
-    ResourceAdminUser = "admin_user"
-    // ResourceUser, ResourceWorkspace unchanged
-)
-const (
-    ActionApprove    = "approve"
-    ActionReject     = "reject"
-    ActionAssignRole = "assign_role"
-    /* + existing list/read/edit/delete */
-)
+| Resource | Action | Roles |
+|---|---|---|
+| `admin_user` | `list` | system_admin, viewer |
+| `admin_user` | `approve` / `reject` / `assign_role` | system_admin |
+| `user` | `list` / `read` | system_admin, viewer |
+| `user` | `edit` / `delete` | system_admin |
+| `workspace` | `list` / `read` / `read_member` | system_admin, viewer |
+| `workspace` | `edit` / `delete` | system_admin |
 
-var resourceRules = []ResourceRule{
-    {Resource: ResourceAdminUser, Actions: map[string][]string{
-        ActionList:       {roleSystemAdmin, roleViewer},
-        ActionApprove:    {roleSystemAdmin},
-        ActionReject:     {roleSystemAdmin},
-        ActionAssignRole: {roleSystemAdmin},
-    }},
-    {Resource: ResourceUser, Actions: map[string][]string{
-        ActionList: {roleSystemAdmin, roleViewer},
-        ActionRead: {roleSystemAdmin, roleViewer},
-        ActionEdit: {roleSystemAdmin}, ActionDelete: {roleSystemAdmin},
-    }},
-    {Resource: ResourceWorkspace, Actions: map[string][]string{
-        ActionList: {roleSystemAdmin, roleViewer},
-        ActionRead: {roleSystemAdmin, roleViewer},
-        ActionEdit: {roleSystemAdmin}, ActionDelete: {roleSystemAdmin},
-        // plus read_member for members endpoint
-    }},
-}
-```
+`DefineResources` needs no structural change — it already iterates actions→roles
+generically; only the data grows. Policies are generated by
+`server/cmd/policy-generator/main.go` (one entry per service: `accounts` and
+`accounts-admin`), invoked via `make gen-policies`. The V1 deliverable:
+regenerate the `accounts-admin` policy and land the updated YAML.
 
-`DefineResources` (the loop that turns `resourceRules` into
-`generator.ResourceDefinition`s) needs no structural change — it already iterates
-actions→roles generically; only the data grows. This one matrix definition is the
-source from which the `accounts-admin` Cerbos policy is generated.
-
-**Cerbos generation & load path — REQUIRED for V1:**
-- Policies are generated by `server/cmd/policy-generator/main.go`, which iterates
-  a `policySet` list — one entry for the main `accounts` service
-  (`internal/rbac`) and one for `accounts-admin` (`internal/admin/rbac`) — and
-  calls `reearthx`'s `generator.GeneratePolicies(serviceName, defineResources,
-  outputDir)`, writing YAML into the `policies` dir (`PolicyFileDir = "policies"`
-  for both). It is invoked via `make gen-policies` (`go run ./cmd/policy-generator`).
-- The concrete deliverable for V1: regenerate the `accounts-admin` policy with
-  `make gen-policies` and land the updated YAML through whatever path the
-  `accounts` policy already uses.
-
-> **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.** The
-> repo's `policies/` directory (repo root) contains checked-in policy YAML (e.g.
-> `service_resource.yaml`, `dashboard_*.yaml`), and Cerbos loads a policy set at
-> runtime. **The exact mechanism by which the generated `accounts-admin` YAML
-> reaches the running Cerbos instance is not evidenced in this repo.** CLAUDE.md
-> states other services' definitions are "synced to GCS via GitHub Actions", but
-> **no such workflow exists** under this repo's `.github/workflows/`. Because
-> enforcement is now Cerbos-based, the policy MUST reach the running Cerbos
-> instance for the check to work — if it does not load, protected endpoints will
-> fail. **This must be confirmed with the platform/Cerbos owner before rollout**
-> and is the single remaining open dependency for the feature (see Open
+> **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.**
+> Policies are generated locally into the **gitignored** `server/policies/`
+> directory (`PolicyFileDir = "policies"` relative to `server/`; `/policies` is in
+> `server/.gitignore`). **Nothing is checked in** — there is no `policies/`
+> directory at the repo root and no policy YAML committed anywhere. **The
+> mechanism by which the generated `accounts-admin` YAML reaches the running
+> Cerbos instance is unknown.** CLAUDE.md mentions a GCS sync via GitHub Actions,
+> but **no such workflow exists** under `.github/workflows/`. Because enforcement
+> is Cerbos-based, the policy MUST reach the running Cerbos instance or protected
+> endpoints will fail. **This must be confirmed with the platform/Cerbos owner
+> before rollout** — it is the single remaining open dependency (see Open
 > Questions).
 
-### Design question 5 — Role assignment flow
+### Q5 — Role assignment flow
 
-**Who may assign/change admin roles:** system_admin only (action
-`admin_user:assign_role`, enforced by the same middleware/matrix).
+**Who:** system_admin only (`admin_user:assign_role`, enforced by the same
+middleware/matrix).
 
-**How:** the assignment **mutates the `role` field on the target
-`adminuser.AdminUser`** (via the domain method `SetRole` from Design Question 2)
-and persists it with `adminUserRepo.Save`. There is no separate binding to
-create.
+**How:** the assignment mutates the `role` field on the target `AdminUser` (via
+`SetRole`) and persists with `adminUserRepo.Save`. No separate binding.
 
-1. **On approval.** When a system_admin approves a pending admin
-   (`adminuseruc/approve.go`), the newly approved admin's `role` field is set to
-   the **default role = `viewer`**. This makes least-privilege the default: new
-   admins can look but not act until explicitly elevated. (Bootstrap admins are
-   the exception — see Q6.)
-2. **Explicit change.** A new endpoint sets the role:
+1. **On approval.** When a system_admin approves a pending admin, the new admin's
+   role is set to the **default `viewer`** (least-privilege by default). Bootstrap
+   admins are the exception (Q6).
+2. **Explicit change:**
 
    | Method / Path | Auth | Description |
    |---|---|---|
-   | `PUT /api/v1/admin-users/:id/roles` | system_admin | Set the target admin's single role. Body: `{ "role": "viewer" }`. The usecase loads the target AdminUser, calls `SetRole`, and `adminUserRepo.Save`s it. |
+   | `PUT /api/v1/admin-users/:id/roles` | system_admin | Set the target's single role. Body: `{ "role": "viewer" }`. Loads the target, `SetRole`, `Save`. |
 
-   Guards mirror the existing self-modification / lock-out rules in
-   `adminuseruc`: an admin cannot demote their **own** last `system_admin` role,
-   and the system must never reach **zero** `system_admin`s (count admins whose
-   `role == system_admin` before persisting a demotion) — analogous to the
-   existing "last approved admin cannot be rejected" rule in the approve/reject
-   usecases.
+**Guards:** an admin cannot demote their **own last** `system_admin`, and the
+system must never reach **zero** `system_admin`s (count `role == system_admin`
+before persisting a demotion) — analogous to the existing "last approved admin
+cannot be rejected" rule. Path stays plural `/roles` for URL stability though the
+body carries a single role. UI is a non-goal; the endpoint + guards suffice for
+V1 (drive via API/script until the UI lands).
 
-The UI for this endpoint is a separate follow-up (non-goal). For V1 the endpoint
-+ guards are sufficient; role changes can be driven by API/script until the UI
-lands. (The path is kept plural `/roles` for URL stability, but the body carries
-a single `role`.)
+### Q6 — Bootstrap
 
-### Design question 6 — Bootstrap
+Bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`, already auto-approved
+at sign-in in `authuc`) must receive **`system_admin`**, otherwise on a fresh DB
+nobody could ever gain it. At the sign-in upsert, also ensure `role =
+system_admin` (idempotent: set on create; elevate an existing record but **never
+downgrade** an already-`system_admin`). Because it is keyed off config, re-adding
+an email to the env var re-grants `system_admin` if lost — a deliberate recovery
+safety valve, avoiding the chicken-and-egg problem.
 
-The bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`, already handled
-at sign-in in `authuc` where a bootstrap email is auto-approved instead of
-pending) must receive **`system_admin`**, otherwise the very first admin could
-approve others but not do anything privileged, and on a fresh DB nobody could
-ever gain `system_admin`.
+### Q7 — Migration / rollout / backward-compat
 
-Mechanism: at the point a bootstrap email is auto-approved (sign-in upsert in
-`authuc`), also ensure the admin's `role` field is set to `system_admin`
-(idempotent create-or-elevate: set it on create; on an existing record elevate to
-`system_admin` but **never downgrade** an already-`system_admin`). This runs on
-every bootstrap sign-in, so re-adding an email to the env var can re-grant
-`system_admin` if it was lost — a deliberate safety valve. Because it is keyed
-off config, it avoids both the chicken-and-egg problem and the unsafe "first
-login wins" pattern (consistent with the epic's bootstrap philosophy).
+**Data migration (additive):**
+1. Add the `role` field/column to admin-user docs/rows (Mongo: add field;
+   Postgres: `ALTER TABLE ... ADD COLUMN role`). No new collection/table.
+2. Backfill `role = system_admin` for every `adminuser` with `status ==
+   approved` (zero-lockout default). Idempotent on re-run.
 
-### Design question 7 — Migration / rollout / backward-compat
+**Rollout ordering (fail-open → fail-closed):**
+- **Step A (deploy, effectively permissive):** land the `accounts-admin` policy
+  (Q4), ship the migration (backfill = `system_admin`), and ship
+  `RequirePermission`. Every existing admin holds `system_admin`, so every check
+  ALLOWs — identical behavior to today; nobody loses access. **No feature flag
+  required** (an env-var flag is available only as an optional extra safety valve).
+- **Step B (enforcement live):** the middleware is calling Cerbos; verify the
+  `accounts-admin` policy is loaded by the running Cerbos instance (the Q4
+  dependency). All existing admins still pass.
+- **Step C (tighten):** a system_admin demotes read-only operators to `viewer`
+  via the Q5 endpoint. New admins default to `viewer` on approval from here. This
+  is a data/operations step, not a deploy.
 
-**Data migration (add + backfill the `role` field):**
-1. Add the `role` field/column to the admin-user documents/rows (Mongo: add the
-   field to `adminuser` docs; Postgres: `ALTER TABLE ... ADD COLUMN role`).
-   **No new collection or table.**
-2. Backfill: set `role = system_admin` for every existing `adminuser` with
-   `status == approved` (the **default backfill role**, chosen for a zero-lockout
-   deploy). Idempotent on re-run.
+The risky transition (all-equal → scoped) happens as a deliberate, reversible
+**data** change (Step C), long after code is safely deployed.
 
-**Rollout ordering (fail-open → fail-closed) — the key to not locking anyone out:**
-
-- **Step A (deploy, checks effectively no-op):** land the `accounts-admin` Cerbos
-  policy (see Q4) and ship the migration that adds and backfills the `role` field
-  = **`system_admin`** for all currently-approved admins. Ship the
-  `RequirePermission` middleware. It is *effectively permissive* by virtue of
-  every existing admin holding `system_admin` (so every Cerbos check ALLOWs) —
-  **no feature flag is required** (an env-var flag is available only as an
-  optional extra safety valve). Result: identical behavior to today; nobody loses
-  access.
-- **Step B (enable enforcement):** the middleware is active and calling Cerbos;
-  confirm the `accounts-admin` policy is loaded by the running Cerbos instance
-  (the distribution dependency from Q4). All existing admins still pass because
-  they hold `system_admin`.
-- **Step C (tighten):** a system_admin demotes the admins who should be read-only
-  to `viewer` via the Q5 endpoint (setting their `role` field). New admins default
-  to `viewer` on approval from this point. This is a data/operations step, not a
-  deploy.
-
-This ordering means the risky transition (all-equal → scoped) happens as a
-deliberate, reversible **data** change (Step C), long after the code is safely
-deployed.
-
-**Backward compatibility:** paths and response shapes are unchanged; the only new
-behavior is `403` for an under-privileged caller, which cannot occur until Step C
-demotes someone. The migration is additive (one new field/column, backfilled); no
-existing field is altered and no collection/table is added.
-
-### Design question 8 — Test plan
-
-Covered in the **Test Plan** section below.
+**Backward compatibility:** paths/response shapes unchanged; the only new
+behavior is `403` for an under-privileged caller, which cannot occur until Step C.
+The migration is additive; no existing field is altered. Renaming the Cerbos role
+literal `"admin"` → `system_admin` happens in the regenerated policy.
 
 ## Design
 
@@ -679,198 +358,114 @@ sequenceDiagram
     end
 ```
 
-### Role assignment / bootstrap flow
-
-```mermaid
-sequenceDiagram
-    participant Google
-    participant Auth as authuc (sign-in)
-    participant Repo as adminUserRepo
-    participant SA as system_admin (human)
-
-    Note over Auth: Bootstrap email path
-    Google->>Auth: verified id_token (bootstrap email)
-    Auth->>Auth: upsert AdminUser status=approved, ensure role=system_admin (never downgrade)
-    Auth->>Repo: Save(AdminUser with role=system_admin)
-
-    Note over SA: Normal approval path
-    SA->>Auth: POST /admin-users/:id/approve (needs admin_user:approve)
-    Auth->>Auth: Approve + SetRole(viewer) (default least-priv)
-    Auth->>Repo: Save(approved AdminUser, role=viewer)
-    SA->>Auth: PUT /admin-users/:id/roles {role:"system_admin"} (needs admin_user:assign_role)
-    Auth->>Auth: SetRole(system_admin), guard against zero system_admins
-    Auth->>Repo: Save(AdminUser with new role)
-```
-
 ## Potential Impact
 
-1. **Storage.** No new collection/table — just one added `role` field/column on
-   the existing admin-user documents/rows. Negligible size/CPU impact.
-2. **Latency.** +1 Cerbos `CheckResources` gRPC call per protected request. The
-   role is already loaded by `RequireApproved` (no extra datastore read to resolve
-   the principal). Admin traffic is very low volume, so the added call's impact is
-   immaterial.
+1. **Storage.** No new collection/table — one added `role` field/column.
+   Negligible.
+2. **Latency.** +1 Cerbos `CheckResources` gRPC call per protected request; role
+   already loaded (no extra datastore read). Immaterial at admin traffic volumes.
 3. **New failure mode.** If Cerbos is configured but the `accounts-admin` policy
-   fails to load (or is never distributed — see Q4), checks could deny legitimate
-   admins and return `500` on protected endpoints (fail-closed under error).
-   Mitigated by the fail-open nil-client path in dev, Step A/B rollout
-   verification, and confirming the policy-distribution path before rollout.
-4. **Cross-context safety.** The admin role lives on the admin aggregate in its
-   own ID space; there is zero risk to end-user (`accounts`) authorization.
-5. **Lock-out risk** if the zero-`system_admin` guard or bootstrap grant is
-   buggy — explicitly tested (below) and mitigated by the re-grantable bootstrap
-   env var.
+   fails to load (or is never distributed — Q4), protected endpoints could `500`
+   or deny legitimate admins. Mitigated by the dev fail-open path, Step A/B
+   verification, and confirming distribution before rollout.
+4. **Cross-context safety.** The role lives in the admin's own ID space; zero risk
+   to end-user (`accounts`) authorization.
+5. **Lock-out risk** if the zero-`system_admin` guard or bootstrap grant is buggy
+   — explicitly tested and mitigated by the re-grantable bootstrap env var.
 
 ## Test Plan
 
-1. **Unit — the `Role` enum** in `server/pkg/adminuser/enum_test.go` (mirroring
-   the existing `Status` enum tests): `RoleSystemAdmin`/`RoleViewer` are `Valid()`;
-   an unknown value is invalid; `RoleFrom` parses/normalizes case and rejects junk.
-2. **Unit — the role→action matrix** in `internal/admin/rbac` (the data compiled
-   into the `accounts-admin` policy) and the **admin `authz.Checker`**:
-   - `system_admin` allowed for `admin_user:approve`, `admin_user:assign_role`,
-     `user:edit`, `workspace:list`.
-   - `viewer` allowed for `*:list`/`*:read`, denied for `admin_user:approve`,
-     `user:edit`, `admin_user:assign_role`.
-   - unknown role ⇒ deny.
-   - `authz.Checker` (re-typed to the admin principal) allow/deny per role with a
-     mock/stub Cerbos; nil Cerbos client ⇒ allow (fail-open) preserved.
-3. **Unit — domain role setter + assignment guards** in `pkg/adminuser` and
-   `adminuseruc`:
-   - `SetRole` updates the field and `updatedAt`.
-   - approve sets the default `viewer` role.
-   - cannot demote the last `system_admin` (self or global).
-   - bootstrap ensure-role is idempotent and never downgrades an existing
-     `system_admin`.
-4. **Endpoint — 403 behavior** (handler tests, mirroring existing
-   `handler_test.go` files): a `viewer` session gets `403` on
-   `POST /admin-users/:id/approve` and `200` on `GET /users`; a `system_admin`
-   gets `200` on both. Verify paths/response shapes are unchanged for allowed
-   calls (backward-compat assertion). Use a mock/stub Cerbos checker so these
-   handler tests need no live Cerbos.
-5. **Migration / backfill** (integration, `make test-integration`, mongo +
-   postgres): after running the migration on a DB with N approved admins, every
-   approved admin has `role == system_admin`; the migration is idempotent on
-   re-run and adds the field/column without altering existing data.
+1. **Unit — `Role` enum** (`enum_test.go`, mirroring `Status` tests): valid values
+   pass, junk rejected, `RoleFrom` normalizes case.
+2. **Unit — matrix + checker** (`internal/admin/rbac`, `authz.Checker`):
+   `system_admin` allowed for approve/assign_role/edit/list; `viewer` allowed for
+   `*:list`/`*:read`, denied for approve/edit/assign_role; unknown role ⇒ deny;
+   nil Cerbos client ⇒ allow (fail-open) preserved.
+3. **Unit — domain setter + guards** (`pkg/adminuser`, `adminuseruc`): `SetRole`
+   updates field + `updatedAt`; approve sets default `viewer`; cannot demote the
+   last `system_admin` (self or global); bootstrap ensure-role idempotent and
+   never downgrades.
+4. **Endpoint — 403 behavior** (handler tests, stub Cerbos): `viewer` gets `403`
+   on approve and `200` on `GET /users`; `system_admin` gets `200` on both;
+   paths/shapes unchanged for allowed calls.
+5. **Migration / backfill** (integration, mongo + postgres): after migration on a
+   DB with N approved admins, all have `role == system_admin`; idempotent on
+   re-run; no existing data altered.
 6. **Policy generation**: `make gen-policies` produces a valid `accounts-admin`
-   policy containing the new resources/actions/roles; a golden-file or Cerbos
-   `compile` check in CI. Required for V1.
+   policy with the new resources/actions/roles; golden-file or Cerbos `compile`
+   check in CI. Required for V1.
 
 ## Deployment Plan
 
-1. **Backward compatible?** Yes, if rolled out per Steps A→B→C. Code deploy alone
-   (Step A) is behavior-preserving because all existing admins are backfilled to
-   `system_admin`.
-2. **Partial deployment?** Yes. The admin API is a separate binary
-   (`cmd/reearth-accounts-admin`); this changes only the admin path. The check
-   can additionally sit behind an optional feature flag for a staged enable, but
-   the backfill (everyone `system_admin` until demoted) already makes Step A/B
-   safe without one.
-3. **Land the `accounts-admin` Cerbos policy.** The generated policy (Q4) MUST
-   reach the running Cerbos instance **before/at Step A**, via the (to-be-
-   confirmed) distribution path. This is a hard launch dependency — if the policy
-   is not loaded, protected endpoints fail. Confirm the mechanism with the
+1. **Backward compatible?** Yes if rolled out A→B→C; Step A alone is
+   behavior-preserving (all admins backfilled to `system_admin`).
+2. **Partial deployment?** Yes — admin API is a separate binary
+   (`cmd/reearth-accounts-admin`); this touches only the admin path. An optional
+   feature flag can stage the enable, but the backfill already makes A/B safe.
+3. **Land the `accounts-admin` policy** before/at Step A via the to-be-confirmed
+   distribution path (Q4). Hard launch dependency — confirm with the
    platform/Cerbos owner first.
-4. **Who to notify?** The admin operators (their capabilities may narrow at Step
-   C) and the platform/Cerbos owner (policy generation + distribution path —
-   see Q4).
-5. **Config changes?** `CERBOS_HOST` must be set in prod for the admin service
-   (already required by `provideCerbosClient`); locally it may be empty (checks
-   fail open). Confirm `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` is set so the
-   bootstrap role grant works. Optional feature-flag env var if we choose to gate
-   Step B (not required).
-6. **DDL/DML before deploy?** Yes — the additive migration that adds the `role`
-   field/column and backfills it (no new table/collection). Runs via the existing
-   migration frameworks (mongo `internal/infrastructure/mongo/migration`, postgres
-   `internal/infrastructure/postgres/migration`). Note: admin API's DI does *not*
-   run migrations (it "only connects"); the migration must be owned by the main
-   service startup or a migration job, consistent with the existing split.
+4. **Notify** the admin operators (capabilities narrow at Step C) and the
+   platform/Cerbos owner.
+5. **Config:** `CERBOS_HOST` must be set in prod for the admin service (locally it
+   may be empty ⇒ fail open). Confirm `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`
+   is set. Optional feature-flag env var if gating Step B (not required).
+6. **DDL/DML before deploy?** Yes — the additive migration (add + backfill `role`;
+   no new table/collection). Note: the admin API's DI does *not* run migrations
+   ("only connects"); the migration must be owned by the **main service startup**
+   (or a migration job), consistent with the existing split.
 
 ## Rollback Plan
 
-1. Notify the admin channel on Slack.
-2. **Toggle the optional feature flag off** (only if one was added) — reverts to
-   all-approved-equal instantly, no redeploy. Not present by default.
-3. If no flag (the default): **redeploy the previous admin-API image** — the permission
-   middleware disappears; `RequireApproved` alone gates again. The added `role`
-   field is inert when unused, so no data rollback is needed.
-4. If Step C demotions caused a lock-out: **re-grant `system_admin`** to a locked
-   -out operator via the (idempotent, re-runnable) bootstrap env var — add their
-   email to `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` and have them re-sign-in.
-5. The migration is additive; it does not need reverting. The added `role`
-   field/column is simply ignored by the previous image. If truly necessary, a
-   script can drop the column/field.
+1. Notify the admin Slack channel.
+2. **Toggle the optional feature flag off** (only if added) — reverts to
+   all-equal instantly, no redeploy. Not present by default.
+3. Default (no flag): **redeploy the previous admin-API image** — the permission
+   middleware disappears, `RequireApproved` alone gates. The `role` field is inert
+   when unused; no data rollback needed.
+4. If Step C demotions caused a lock-out: **re-grant `system_admin`** by adding
+   the email to `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` (idempotent) and
+   re-signing-in.
+5. The migration is additive and needs no reverting; a script can drop the
+   field/column if truly necessary.
 
 ## Post Deployment
 
-- **Checklist**
-  - Verify a `system_admin` can approve/reject and read everything (GUI).
-  - Verify a `viewer` can read lists/details but gets `403` on approve/reject and
-    role assignment.
-  - Verify a freshly approved admin defaults to `viewer`.
-  - Verify at least one `system_admin` always exists (zero-guard) — attempt to
-    demote the last one and confirm it is refused.
-  - Verify local dev (no `CERBOS_HOST`) still fails open.
-- **Metrics**
-  - `403` rate on admin endpoints (spike ⇒ mis-scoped role or policy bug).
-  - `500` rate on protected endpoints (Cerbos reachability / policy load).
-  - Cerbos check latency (p50/p95) on the admin service.
-- **Logging (in lieu of a full audit collection):** log role assignments and
-  approve/reject with actor + target admin IDs (no PII, per epic constraint), so
-  privilege changes are traceable.
-- **Alerting**
-  - Protected-endpoint success rate: Warning `< 99%`, Danger `<= 95%`.
-  - Cerbos check errors (`500`s): Warning `>= 5 min` sustained, Danger `>= 1 h`.
-  - Zero `system_admin` accounts: Danger (immediate) — indicates lock-out risk.
+- **Checklist:** verify a `system_admin` can approve/reject and read everything; a
+  `viewer` can read but gets `403` on approve/reject and role assignment; a freshly
+  approved admin defaults to `viewer`; the last `system_admin` cannot be demoted
+  (zero-guard); local dev (no `CERBOS_HOST`) still fails open.
+- **Metrics:** `403` rate on admin endpoints (spike ⇒ mis-scoped role/policy bug);
+  `500` rate on protected endpoints (Cerbos reachability / policy load); Cerbos
+  check latency (p50/p95).
+- **Logging** (in lieu of a full audit collection): log role assignments and
+  approve/reject with actor + target admin IDs (no PII), so privilege changes are
+  traceable.
+- **Alerting:** protected-endpoint success rate Warning `< 99%`, Danger `<= 95%`;
+  Cerbos errors (`500`s) Warning `>= 5 min`, Danger `>= 1 h`; **zero
+  `system_admin` accounts: Danger (immediate)** — lock-out risk.
 
 ## Open Questions
 
-**Decided in this revision:**
-
-- **DECIDED — Enforcement path: Cerbos.** The `RequirePermission` middleware calls
-  the admin `authz.Checker`, which evaluates the `accounts-admin` Cerbos policy
-  (chosen for consistency with the end-user `accounts` authorization model). The
-  in-process static check was considered and **rejected** for V1 (Design Question
-  3). The checker's `user.ID`-vs-`adminuser.ID` typing bug is now **in scope** and
-  must be fixed (re-type `authz.Checker.Allowed` + its provider-set signature in
-  `internal/admin/di`).
-- **DECIDED — Single-role vs. multi-role per admin: single-role.** An admin has
-  exactly one role. The multi-role `pkg/adminpermittable` design is demoted to a
-  deferred alternative (Design Question 2), to be revisited only if multi-role
-  becomes necessary.
-- **DECIDED — Where the role lives: a `role` enum field on the
-  `adminuser.AdminUser` aggregate** (+ additive migration). No separate binding
-  aggregate, no new collection/table. This also settles the old "reuse `pkg/role`
-  vs. `pkg/adminrole`" question — neither is used; the role is a plain enum on the
-  admin aggregate.
-- **DECIDED — How many roles for V1: two** (`system_admin`, `viewer`).
-- **DECIDED — Rename the existing `"admin"` role to `system_admin`.** Today's
-  single Cerbos role is the literal `"admin"` (in `rbac/definitions.go`); it is
-  renamed to `system_admin`. Confirm no external policy still references `admin`
-  when the regenerated `accounts-admin` policy is distributed.
-- **DECIDED — Backfill role: `system_admin`.** Existing approved admins are
-  backfilled to `system_admin` for a zero-lockout deploy, then demoted to `viewer`
-  in the Step C data operation. New admins default to `viewer` on approval.
-- **DECIDED — Feature flag: none.** The deploy is made safe by the backfill
-  (everyone is `system_admin` until demoted), not by a flag. An env-var flag
-  remains available only as an optional extra safety valve.
+**Decided in this revision:** enforcement path = Cerbos (checker `Allowed`
+re-typed to the admin principal + DI signature updated); single-role per admin;
+role stored as a `role` enum field on the `adminuser.AdminUser` aggregate (no
+separate binding, no new collection/table); two roles for V1 (`system_admin`,
+`viewer`); rename Cerbos role `"admin"` → `system_admin`; backfill existing
+approved admins to `system_admin`, new admins default to `viewer`; no feature flag.
 
 **Still open (launch dependency):**
 
-1. **Runtime policy distribution — a launch dependency.** Because enforcement is
-   Cerbos-based, the generated `accounts-admin` YAML MUST reach the running Cerbos
-   instance for the check to work. The exact path from generated YAML to the
-   running Cerbos instance is **not evidenced** in this repo's workflows (CLAUDE.md
-   mentions GCS sync via GitHub Actions, but no such workflow exists here). **This
-   must be confirmed with the platform/Cerbos owner before rollout** (see Design
-   Question 4 and the Deployment Plan). This is the single remaining open item
-   blocking launch.
+1. **Runtime policy distribution.** The generated `accounts-admin` YAML MUST reach
+   the running Cerbos instance for the check to work, but nothing is checked in and
+   the distribution mechanism is not evidenced in this repo (see Q4). **Confirm
+   with the platform/Cerbos owner before rollout** — the single item blocking
+   launch.
 
 **Deferred (revisit later):**
 
-2. **A third `user_admin` role** (e.g. may approve admins but not touch
-   workspaces) — easy to add later by extending the enum + matrix; deferred, not
-   built for V1.
+2. **A third `user_admin` role** (may approve admins but not touch workspaces) —
+   easy to add via the enum + matrix; deferred, not built for V1.
 
 ## Reviewed by
 

--- a/server/docs/usecase/admin-role-permittable.md
+++ b/server/docs/usecase/admin-role-permittable.md
@@ -1,171 +1,52 @@
 # Admin Role (Granular Admin Permissions)
 
-> **Status: DRAFT for review** (reearth-dashboard#1316). An admin has **exactly
-> one `role`** enum (`system_admin` | `viewer`) stored **directly on the
-> `adminuser.AdminUser` aggregate** (additive Mongo/Postgres migration; no new
-> collection/table/aggregate). Enforcement is **Cerbos-based**: a
-> `RequirePermission` middleware (layered on `RequireApproved`) reads the
-> already-loaded role and calls the admin `authz.Checker` → Cerbos
-> `CheckResources` against the `accounts-admin` policy. One open launch
-> dependency remains: runtime policy distribution (see Open Questions).
+> **Status: DRAFT** (reearth-dashboard#1316). An admin has **exactly one `role`**
+> enum stored **directly on the `adminuser.AdminUser` aggregate**. Enforcement is
+> **Cerbos-based** via a `RequirePermission` middleware (layered on
+> `RequireApproved`). One open launch dependency remains: runtime policy
+> distribution (see Open Questions).
 
-## Document Signature
+## Roles
 
-|           |                                                        |
-|-----------|--------------------------------------------------------|
-| Creator   | [author]                                               |
-| Leader    | [pending]                                              |
-| Task Link | reearth-dashboard#1316 (part of epic reearth-dashboard#1233) |
-| Developer | [pending]                                              |
-
-## Background / Problem Statement
-
-The admin application (`server/internal/admin/`) currently treats **every
-approved admin as equal**. The only gate is `RequireApproved`
-(`internal/admin/presentation/middleware/require_approved.go`): once an
-`adminuser.AdminUser` has `status == approved`, it can call every admin endpoint
-(list/read users, workspaces, members; approve/reject/revoke *other* admins).
-This was a deliberate V1 non-goal of the ADMIN-AUTH epic (reearth-dashboard#1233);
-#1316 is the follow-up. Problems:
-
-1. **No least-privilege.** A read-only operator is indistinguishable from a
-   super-admin; all approved-admin routes sit under one `requireApproved`
-   middleware in `router.go` with no per-action check.
-2. **Approve/reject of admins is high-privilege** yet available to any approved
-   admin; granting/revoking admin access should itself be restricted.
-3. **The enforcement machinery already exists but is dormant.** The admin Cerbos
-   `Checker` (`internal/admin/usecase/authz/checker.go`), the RBAC definitions
-   (`internal/admin/rbac/definitions.go`, service `accounts-admin`, single role
-   `admin`), and the Cerbos client provider (`provideCerbosClient`,
-   `//nolint:unused` "for reearth-dashboard#1316") are wired but unused. The
-   selected design **consumes** this machinery.
-
-### Two ID spaces
-
-There are two separate authorization worlds and #1316 must not conflate them:
-end-users (`pkg/user`, `user.ID`, service `accounts`) vs. admins (`pkg/adminuser`,
-`adminuser.ID`, service `accounts-admin`). `pkg/permittable` binds `user.ID` →
-roles for the `accounts` service; admins live in a different ID space. The
-selected design sidesteps this entirely by storing the role on the
-`adminuser.AdminUser` aggregate itself — no `permittable`-style lookup.
-
-|  | End-user (`accounts`) | Admin (`accounts-admin`) |
-|---|---|---|
-| Identity | `user.ID` | `adminuser.ID` |
-| Roles today | Owner/Maintainer/Writer/Reader/Self | single `"admin"` |
-
-This surfaces a latent, in-scope bug: today `authz.Checker.Allowed(ctx, caller
-user.ID, …)` takes a `user.ID`, but the admin principal is an `adminuser.ID`. It
-must be **re-typed to take the admin principal** (the already-loaded `role` /
-`adminuser.ID`), with the DI provider-set signature in `internal/admin/di`
-updated accordingly.
-
-## Goals
-
-1. Approved admins are no longer all-equal: each endpoint's access is decided by
-   the caller's single admin **role**, checked via Cerbos (`accounts-admin`
-   policy) by `RequirePermission` layered on `RequireApproved`.
-2. Define a first-class super-admin role plus a lower-privilege role, with a
-   default that locks nobody out on rollout.
-3. Store the role on the `adminuser.AdminUser` aggregate (a `role` enum field),
-   including how it is granted at/after approval and how bootstrap admins obtain
-   the highest role.
-4. Keep the `accounts-admin` role→action matrix (`internal/admin/rbac`) as the
-   single source of truth, compiled into the Cerbos policy via `cmd/policy-generator`.
-5. Enforce **additively** — no path/response changes; only new `403` outcomes.
-6. Rollout is safe: migration backfills existing approved admins to super-admin,
-   enabled fail-open → fail-closed so nobody is locked out mid-deploy.
-
-## Non-Goals
-
-1. **Admin UI for managing roles** — a separate frontend follow-up.
-2. **Changing end-user (`accounts`) authorization** — untouched.
-3. **A general audit-log** for role changes beyond existing
-   `approvedBy`/`approvedAt` (role changes SHOULD still be logged — see Post
-   Deployment).
-4. **Per-resource-instance rules** — V1 is per-action/per-resource-type.
-5. **Removing the Cerbos wiring** — #1316 keeps and reuses it.
-
-## Functional Requirements
-
-1. Every approved-admin route maps to a `(resource, action)` pair on the
-   `accounts-admin` matrix, checked before the usecase runs.
-2. **Zero extra datastore reads** per request: the role is already on the
-   `AdminUser` in the echo context; the checker adds exactly **one Cerbos
-   `CheckResources` gRPC call** per protected request.
-3. Latency budget: < ~15 ms p95 added. Admin traffic is very low volume.
-4. Local dev unaffected: with `CERBOS_HOST` empty, a nil Cerbos client **fails
-   open** (allow), as it already does today.
-5. Bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`) always resolve to
-   super-admin, even on a brand-new database.
-6. Backward compatible: existing approved admins retain full access post-migration
-   (role backfilled to super-admin).
-
-## Solution Options
-
-Seven design questions. The core storage and enforcement decisions are final;
-the rest have a single recommended approach.
-
-### Q1 — Role model
-
-**DECIDED: two role types for V1**, a small fixed enum modelled on the existing
-`adminuser.Status` enum.
+Two roles for V1, a small fixed enum.
 
 | Role (enum value) | Holders | Capabilities |
 |---|---|---|
 | `system_admin` | Platform operators, bootstrap admins | Everything: manage admins (approve/reject/revoke), assign roles, read + (future) mutate all resources |
 | `viewer` | Support / read-only staff | List/read users, workspaces, members, admin-users. No approve/reject, no mutations, no role assignment |
 
-The existing single Cerbos role `"admin"` is **renamed** to `system_admin`. A
-fixed enum keeps the matrix a compile-time constant. A third role (e.g.
-`user_admin`) is easy to add later and is deferred (Open Questions).
+The existing single Cerbos role literal `"admin"` is **renamed** to `system_admin`;
+a third role (e.g. `user_admin`) is deferred (Open Questions). The enum mirrors the
+existing `adminuser.Status` pattern in `server/pkg/adminuser/enum.go` and is already
+implemented in PR #282.
 
-### Q2 — Where the role lives (SELECTED: field on the aggregate)
+## Storage
 
-**Selected: a single `role` enum field directly on the `adminuser.AdminUser`
-aggregate, plus an additive Mongo/Postgres migration. No new collection, table,
-or aggregate.** An admin has exactly one role.
+**A single `role` enum field directly on the `adminuser.AdminUser` aggregate**,
+plus an additive Mongo/Postgres migration (Mongo: add field; Postgres:
+`ALTER TABLE ... ADD COLUMN role`) that backfills `role = system_admin` for every
+approved admin (idempotent on re-run). **No new collection, table, or aggregate.**
+The `adminuser` repos (`mongo`/`postgres`/`memory`) gain the field in their
+mappings; `adminUserRepo.Save` persists it.
 
-The enum mirrors the existing `adminuser.Status` pattern in
-`server/pkg/adminuser/enum.go` (`type Role string`, valid-values slice,
-`Valid()`, `RoleFrom(string)`), with a getter, a `SetRole` mutator, and a builder
-method on the aggregate — this is already implemented in PR #282. The
-`adminuser` repos (`mongo`/`postgres`/`memory`) gain the field in their mappings;
-`adminUserRepo.Save` persists it.
+Why this shape: minimal change; no `user.ID`-vs-`adminuser.ID` confusion (the role
+lives in the admin's own ID space, so there is no `permittable`-style lookup); the
+role is already loaded by `RequireApproved`, so the check needs **zero extra reads**;
+and a single role suffices for V1. The deferred multi-role alternative (a binding
+aggregate mapping `adminuser.ID` → `[]role.ID`) is documented in git history and
+revisited only if multi-role is ever needed.
 
-Why: minimal change (one field + accessors + one additive migration); no ID-space
-confusion (role lives in the admin's own ID space); simplifies the Cerbos check
-because `RequireApproved` already loads the role; single-role is sufficient for
-V1 (the two roles are mutually exclusive privilege tiers).
+## Enforcement (Cerbos)
 
-**Trade-off:** exactly one role per admin. If multi-role is ever needed, migrate
-to the deferred alternative below.
-
-**Deferred alternative (multi-role).** A new binding aggregate
-`pkg/adminpermittable` (name TBD) binding `adminuser.ID` → `[]role.ID`, reusing
-`pkg/role`, with its own collection/table across three backends and a seeding
-migration; the checker would take an `adminuser.ID` + a `FindByAdminUserID` repo.
-Its only distinguishing advantage — multiple roles per admin — is not needed for
-V1, so it is deferred, not deleted. (A sub-alternative — reusing the *existing*
-`pkg/permittable` by casting `adminuser.ID` into `user.ID` — is rejected outright:
-it collides two distinct ULID ID spaces in one `user.ID`-indexed collection that
-end-user authz also reads.)
-
-### Q3 — Enforcement (SELECTED: Cerbos)
-
-A per-route/group **permission middleware** maps the matched route to a
-`(resource, action)` pair and checks before the handler, keeping the check
-declarative and colocated with `router.go`. The admin user is already in the echo
-context (`internal.GetAdminUser(c)`).
-
-`RequirePermission` reads the caller's role from the loaded `AdminUser` and hands
-it to the admin `authz.Checker`, which does a Cerbos `CheckResources` against the
-`accounts-admin` policy for the route's `(resource, action)`. The checker is
-re-typed to take the admin principal (role / `adminuser.ID`), not `user.ID`, and
-needs no `permittable` lookup.
+A per-route `RequirePermission` middleware, layered on `RequireApproved`, reads the
+already-loaded role from the `AdminUser` in the echo context and hands it to the
+admin `authz.Checker`, which does a Cerbos `CheckResources` against the
+`accounts-admin` policy for the route's `(resource, action)`. This is **exactly one
+Cerbos gRPC call per protected request**. When the Cerbos client is nil (local dev,
+no `CERBOS_HOST`), the check **fails open** (allow), as it does today.
 
 ```go
-// presentation/middleware/require_permission.go (SELECTED: Cerbos)
+// presentation/middleware/require_permission.go
 func RequirePermission(chk *authz.Checker, resource, action string) echo.MiddlewareFunc {
     return func(next echo.HandlerFunc) echo.HandlerFunc {
         return func(c echo.Context) error {
@@ -186,20 +67,16 @@ func RequirePermission(chk *authz.Checker, resource, action string) echo.Middlew
 }
 ```
 
-**Why Cerbos:** consistency with the end-user `accounts` authorization model
-(`internal/usecase/interactor/cerbos.go`), consuming the existing dormant
-machinery rather than adding a second enforcement style, and fail-open in local
-dev is already handled.
+**Required fix:** re-type `authz.Checker.Allowed` to take the admin principal
+(role / `adminuser.ID`), **not** `user.ID`, and update the DI provider-set
+signature accordingly.
 
-**Rejected for V1 — in-process static check.** `RequirePermission` could instead
-check the role against the static matrix in-process (`rbac.Allowed(role,
-resource, action)`), with no Cerbos call, no extra latency, and it would sidestep
-the checker's typing bug. It was rejected to avoid running two divergent
-enforcement mechanisms; it remains available if the Cerbos policy-distribution
-dependency (Q4) ever proves prohibitive.
+Cerbos is chosen for consistency with the end-user `accounts` authz model and to
+consume the existing dormant machinery. An in-process static check was rejected to
+avoid two divergent enforcement mechanisms, but remains a fallback if policy
+distribution proves prohibitive.
 
-**Endpoint → resource/action mapping** (existing routes + near-future
-mutations). This drives the `accounts-admin` Cerbos policy:
+## Endpoint → resource/action mapping
 
 | Method / Path | Resource | Action | Min role |
 |---|---|---|---|
@@ -213,7 +90,7 @@ mutations). This drives the `accounts-admin` Cerbos policy:
 | `GET /api/v1/workspaces/:id` | `workspace` | `read` | viewer |
 | `GET /api/v1/workspaces/:id/members` | `workspace` | `read_member` | viewer |
 | *(future)* `PATCH/DELETE users/workspaces` | resp. | `edit` / `delete` | system_admin |
-| `PUT /api/v1/admin-users/:id/roles` (see Q5) | `admin_user` | `assign_role` | system_admin |
+| `PUT /api/v1/admin-users/:id/roles` | `admin_user` | `assign_role` | system_admin |
 
 Notes:
 - `/api/v1/me` and `/api/v1/auth/*` stay public / session-only (no permission
@@ -226,12 +103,7 @@ Notes:
   end-users the admin inspects).
 - "Min role" is enforced via Cerbos against the compiled `accounts-admin` policy.
 
-### Q4 — Role→action matrix and the `accounts-admin` policy (REQUIRED for V1)
-
-`internal/admin/rbac/definitions.go` evolves from single- to multi-role by adding
-role-name constants, the `admin_user` resource, the `approve`/`reject`/`assign_role`
-actions, and listing multiple roles per action. `resourceRules` remains the single
-source of truth and is compiled into the `accounts-admin` Cerbos policy.
+## Role→action matrix
 
 | Resource | Action | Roles |
 |---|---|---|
@@ -242,11 +114,9 @@ source of truth and is compiled into the `accounts-admin` Cerbos policy.
 | `workspace` | `list` / `read` / `read_member` | system_admin, viewer |
 | `workspace` | `edit` / `delete` | system_admin |
 
-`DefineResources` needs no structural change — it already iterates actions→roles
-generically; only the data grows. Policies are generated by
-`server/cmd/policy-generator/main.go` (one entry per service: `accounts` and
-`accounts-admin`), invoked via `make gen-policies`. The V1 deliverable:
-regenerate the `accounts-admin` policy and land the updated YAML.
+`resourceRules` in `internal/admin/rbac/definitions.go` is the single source of
+truth, compiled into the `accounts-admin` Cerbos policy via `make gen-policies`
+(`cmd/policy-generator`).
 
 > **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.**
 > Policies are generated locally into the **gitignored** `server/policies/`
@@ -261,72 +131,46 @@ regenerate the `accounts-admin` policy and land the updated YAML.
 > before rollout** — it is the single remaining open dependency (see Open
 > Questions).
 
-### Q5 — Role assignment flow
+## Role assignment & bootstrap
 
 **Who:** system_admin only (`admin_user:assign_role`, enforced by the same
-middleware/matrix).
+middleware/matrix). Assignment mutates the `role` field on the target `AdminUser`
+(via `SetRole`) and persists with `adminUserRepo.Save`.
 
-**How:** the assignment mutates the `role` field on the target `AdminUser` (via
-`SetRole`) and persists with `adminUserRepo.Save`. No separate binding.
+- **On approval.** A newly approved admin defaults to `viewer` (least-privilege).
+  Bootstrap admins are the exception (below).
+- **Explicit change:** `PUT /api/v1/admin-users/:id/roles` with body
+  `{ "role": "viewer" }` — loads the target, `SetRole`, `Save`. The path stays
+  plural `/roles` for URL stability though the body carries a single role.
 
-1. **On approval.** When a system_admin approves a pending admin, the new admin's
-   role is set to the **default `viewer`** (least-privilege by default). Bootstrap
-   admins are the exception (Q6).
-2. **Explicit change:**
+**Guards:** an admin cannot demote their own last `system_admin`, and the system
+must never reach **zero** `system_admin`s (count `role == system_admin` before
+persisting a demotion) — analogous to the existing "last approved admin cannot be
+rejected" rule.
 
-   | Method / Path | Auth | Description |
-   |---|---|---|
-   | `PUT /api/v1/admin-users/:id/roles` | system_admin | Set the target's single role. Body: `{ "role": "viewer" }`. Loads the target, `SetRole`, `Save`. |
+**Bootstrap.** Bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`,
+already auto-approved at sign-in) receive `system_admin` at the sign-in upsert,
+otherwise a fresh DB could never gain one. It is idempotent (set on create, elevate
+an existing record) and **never downgrades** an already-`system_admin`. Re-adding an
+email to the env var re-grants `system_admin` — the deliberate lock-out recovery
+valve.
 
-**Guards:** an admin cannot demote their **own last** `system_admin`, and the
-system must never reach **zero** `system_admin`s (count `role == system_admin`
-before persisting a demotion) — analogous to the existing "last approved admin
-cannot be rejected" rule. Path stays plural `/roles` for URL stability though the
-body carries a single role. UI is a non-goal; the endpoint + guards suffice for
-V1 (drive via API/script until the UI lands).
+## Rollout
 
-### Q6 — Bootstrap
+- **A — deploy.** Land the `accounts-admin` policy, ship the additive migration
+  (backfill = `system_admin`) and `RequirePermission`. Every existing admin holds
+  `system_admin`, so every check ALLOWs — behavior identical to today, effectively
+  permissive; **no feature flag required**.
+- **B — verify.** Confirm the `accounts-admin` policy is loaded by the running
+  Cerbos instance (the launch-blocker dependency). All existing admins still pass.
+- **C — tighten.** A system_admin demotes read-only operators to `viewer` via the
+  role endpoint. This is a reversible data operation, not a deploy.
 
-Bootstrap admins (`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`, already auto-approved
-at sign-in in `authuc`) must receive **`system_admin`**, otherwise on a fresh DB
-nobody could ever gain it. At the sign-in upsert, also ensure `role =
-system_admin` (idempotent: set on create; elevate an existing record but **never
-downgrade** an already-`system_admin`). Because it is keyed off config, re-adding
-an email to the env var re-grants `system_admin` if lost — a deliberate recovery
-safety valve, avoiding the chicken-and-egg problem.
+Rollback = redeploy the previous admin-API image; the `role` field is inert when
+unused, so no data rollback is needed. If locked out, re-grant via
+`REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`.
 
-### Q7 — Migration / rollout / backward-compat
-
-**Data migration (additive):**
-1. Add the `role` field/column to admin-user docs/rows (Mongo: add field;
-   Postgres: `ALTER TABLE ... ADD COLUMN role`). No new collection/table.
-2. Backfill `role = system_admin` for every `adminuser` with `status ==
-   approved` (zero-lockout default). Idempotent on re-run.
-
-**Rollout ordering (fail-open → fail-closed):**
-- **Step A (deploy, effectively permissive):** land the `accounts-admin` policy
-  (Q4), ship the migration (backfill = `system_admin`), and ship
-  `RequirePermission`. Every existing admin holds `system_admin`, so every check
-  ALLOWs — identical behavior to today; nobody loses access. **No feature flag
-  required** (an env-var flag is available only as an optional extra safety valve).
-- **Step B (enforcement live):** the middleware is calling Cerbos; verify the
-  `accounts-admin` policy is loaded by the running Cerbos instance (the Q4
-  dependency). All existing admins still pass.
-- **Step C (tighten):** a system_admin demotes read-only operators to `viewer`
-  via the Q5 endpoint. New admins default to `viewer` on approval from here. This
-  is a data/operations step, not a deploy.
-
-The risky transition (all-equal → scoped) happens as a deliberate, reversible
-**data** change (Step C), long after code is safely deployed.
-
-**Backward compatibility:** paths/response shapes unchanged; the only new
-behavior is `403` for an under-privileged caller, which cannot occur until Step C.
-The migration is additive; no existing field is altered. Renaming the Cerbos role
-literal `"admin"` → `system_admin` happens in the regenerated policy.
-
-## Design
-
-### Request flow (per protected admin endpoint)
+## Request flow
 
 ```mermaid
 sequenceDiagram
@@ -358,117 +202,11 @@ sequenceDiagram
     end
 ```
 
-## Potential Impact
+## Open questions
 
-1. **Storage.** No new collection/table — one added `role` field/column.
-   Negligible.
-2. **Latency.** +1 Cerbos `CheckResources` gRPC call per protected request; role
-   already loaded (no extra datastore read). Immaterial at admin traffic volumes.
-3. **New failure mode.** If Cerbos is configured but the `accounts-admin` policy
-   fails to load (or is never distributed — Q4), protected endpoints could `500`
-   or deny legitimate admins. Mitigated by the dev fail-open path, Step A/B
-   verification, and confirming distribution before rollout.
-4. **Cross-context safety.** The role lives in the admin's own ID space; zero risk
-   to end-user (`accounts`) authorization.
-5. **Lock-out risk** if the zero-`system_admin` guard or bootstrap grant is buggy
-   — explicitly tested and mitigated by the re-grantable bootstrap env var.
-
-## Test Plan
-
-1. **Unit — `Role` enum** (`enum_test.go`, mirroring `Status` tests): valid values
-   pass, junk rejected, `RoleFrom` normalizes case.
-2. **Unit — matrix + checker** (`internal/admin/rbac`, `authz.Checker`):
-   `system_admin` allowed for approve/assign_role/edit/list; `viewer` allowed for
-   `*:list`/`*:read`, denied for approve/edit/assign_role; unknown role ⇒ deny;
-   nil Cerbos client ⇒ allow (fail-open) preserved.
-3. **Unit — domain setter + guards** (`pkg/adminuser`, `adminuseruc`): `SetRole`
-   updates field + `updatedAt`; approve sets default `viewer`; cannot demote the
-   last `system_admin` (self or global); bootstrap ensure-role idempotent and
-   never downgrades.
-4. **Endpoint — 403 behavior** (handler tests, stub Cerbos): `viewer` gets `403`
-   on approve and `200` on `GET /users`; `system_admin` gets `200` on both;
-   paths/shapes unchanged for allowed calls.
-5. **Migration / backfill** (integration, mongo + postgres): after migration on a
-   DB with N approved admins, all have `role == system_admin`; idempotent on
-   re-run; no existing data altered.
-6. **Policy generation**: `make gen-policies` produces a valid `accounts-admin`
-   policy with the new resources/actions/roles; golden-file or Cerbos `compile`
-   check in CI. Required for V1.
-
-## Deployment Plan
-
-1. **Backward compatible?** Yes if rolled out A→B→C; Step A alone is
-   behavior-preserving (all admins backfilled to `system_admin`).
-2. **Partial deployment?** Yes — admin API is a separate binary
-   (`cmd/reearth-accounts-admin`); this touches only the admin path. An optional
-   feature flag can stage the enable, but the backfill already makes A/B safe.
-3. **Land the `accounts-admin` policy** before/at Step A via the to-be-confirmed
-   distribution path (Q4). Hard launch dependency — confirm with the
-   platform/Cerbos owner first.
-4. **Notify** the admin operators (capabilities narrow at Step C) and the
-   platform/Cerbos owner.
-5. **Config:** `CERBOS_HOST` must be set in prod for the admin service (locally it
-   may be empty ⇒ fail open). Confirm `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS`
-   is set. Optional feature-flag env var if gating Step B (not required).
-6. **DDL/DML before deploy?** Yes — the additive migration (add + backfill `role`;
-   no new table/collection). Note: the admin API's DI does *not* run migrations
-   ("only connects"); the migration must be owned by the **main service startup**
-   (or a migration job), consistent with the existing split.
-
-## Rollback Plan
-
-1. Notify the admin Slack channel.
-2. **Toggle the optional feature flag off** (only if added) — reverts to
-   all-equal instantly, no redeploy. Not present by default.
-3. Default (no flag): **redeploy the previous admin-API image** — the permission
-   middleware disappears, `RequireApproved` alone gates. The `role` field is inert
-   when unused; no data rollback needed.
-4. If Step C demotions caused a lock-out: **re-grant `system_admin`** by adding
-   the email to `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` (idempotent) and
-   re-signing-in.
-5. The migration is additive and needs no reverting; a script can drop the
-   field/column if truly necessary.
-
-## Post Deployment
-
-- **Checklist:** verify a `system_admin` can approve/reject and read everything; a
-  `viewer` can read but gets `403` on approve/reject and role assignment; a freshly
-  approved admin defaults to `viewer`; the last `system_admin` cannot be demoted
-  (zero-guard); local dev (no `CERBOS_HOST`) still fails open.
-- **Metrics:** `403` rate on admin endpoints (spike ⇒ mis-scoped role/policy bug);
-  `500` rate on protected endpoints (Cerbos reachability / policy load); Cerbos
-  check latency (p50/p95).
-- **Logging** (in lieu of a full audit collection): log role assignments and
-  approve/reject with actor + target admin IDs (no PII), so privilege changes are
-  traceable.
-- **Alerting:** protected-endpoint success rate Warning `< 99%`, Danger `<= 95%`;
-  Cerbos errors (`500`s) Warning `>= 5 min`, Danger `>= 1 h`; **zero
-  `system_admin` accounts: Danger (immediate)** — lock-out risk.
-
-## Open Questions
-
-**Decided in this revision:** enforcement path = Cerbos (checker `Allowed`
-re-typed to the admin principal + DI signature updated); single-role per admin;
-role stored as a `role` enum field on the `adminuser.AdminUser` aggregate (no
-separate binding, no new collection/table); two roles for V1 (`system_admin`,
-`viewer`); rename Cerbos role `"admin"` → `system_admin`; backfill existing
-approved admins to `system_admin`, new admins default to `viewer`; no feature flag.
-
-**Still open (launch dependency):**
-
-1. **Runtime policy distribution.** The generated `accounts-admin` YAML MUST reach
-   the running Cerbos instance for the check to work, but nothing is checked in and
-   the distribution mechanism is not evidenced in this repo (see Q4). **Confirm
-   with the platform/Cerbos owner before rollout** — the single item blocking
-   launch.
-
-**Deferred (revisit later):**
-
+1. **Runtime policy distribution** (launch blocker). The generated `accounts-admin`
+   YAML MUST reach the running Cerbos instance for the check to work, but nothing is
+   checked in and the distribution mechanism is not evidenced in this repo. Confirm
+   with the platform/Cerbos owner before rollout.
 2. **A third `user_admin` role** (may approve admins but not touch workspaces) —
    easy to add via the enum + matrix; deferred, not built for V1.
-
-## Reviewed by
-
-- Technical Architect: [pending]
-- Technical Leader: [pending]
-- Peers: [pending]

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -54,7 +54,7 @@ func RequirePermission(chk *authz.Checker, resource, action string) echo.Middlew
         return func(c echo.Context) error {
             u, err := internal.GetAdminUser(c) // set by RequireApproved; role loaded
             if err != nil {
-                return echo.NewHTTPError(http.StatusUnauthorized)
+                return err // already an echo.HTTPError(401)
             }
             ok, err := chk.Allowed(c.Request().Context(), u.Role(), resource, action)
             if err != nil {

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -93,7 +93,7 @@ distribution proves prohibitive.
 | `GET /api/v1/workspaces/:id/members` | `workspace` | `read_member` | viewer |
 | *(future)* `PATCH /api/v1/users/:id`, `DELETE /api/v1/users/:id` | `user` | `edit` / `delete` | system_admin |
 | *(future)* `PATCH /api/v1/workspaces/:id`, `DELETE /api/v1/workspaces/:id` | `workspace` | `edit` / `delete` | system_admin |
-| `PUT /api/v1/admin-users/:id/roles` | `admin_user` | `assign_role` | system_admin |
+| *(future)* `PUT /api/v1/admin-users/:id/roles` | `admin_user` | `assign_role` | system_admin |
 
 Notes:
 - `/api/v1/me` and `/api/v1/auth/*` stay public / session-only (no permission

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -118,8 +118,9 @@ Notes:
 | `workspace` | `edit` / `delete` | system_admin |
 
 `resourceRules` in `server/internal/admin/rbac/definitions.go` is the single source of
-truth, compiled into the `accounts-admin` Cerbos policy via `make gen-policies`
-(`cmd/policy-generator`).
+truth, compiled into the `accounts-admin` Cerbos policy via
+`(cd server && make gen-policies)` (the target lives in `server/Makefile`; it runs
+`cmd/policy-generator`).
 
 > **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.**
 > Generated policies are written locally into the **gitignored** `server/policies/`
@@ -162,12 +163,15 @@ valve.
 
 ## Rollout
 
-- **A — deploy.** Land the `accounts-admin` policy, ship the additive migration
-  (backfill = `system_admin`) and `RequirePermission`. Every existing admin holds
-  `system_admin`, so every check ALLOWs — behavior identical to today, effectively
-  permissive; **no feature flag required**.
-- **B — verify.** Confirm the `accounts-admin` policy is loaded by the running
-  Cerbos instance (the launch-blocker dependency). All existing admins still pass.
+- **A — distribute & verify policy.** Land the `accounts-admin` policy and
+  **confirm it is loaded by the running Cerbos instance** (the launch-blocker
+  dependency) *before* any enforcement code goes live. This must happen first:
+  once `RequirePermission` calls Cerbos, a missing/unloaded policy would deny or
+  error even for system_admins.
+- **B — deploy enforcement.** Ship the additive migration (backfill =
+  `system_admin`) and `RequirePermission`. Because step A verified the policy is
+  loaded and every existing admin holds `system_admin`, every check ALLOWs —
+  behavior identical to today, effectively permissive; **no feature flag required**.
 - **C — tighten.** A system_admin demotes read-only operators to `viewer` via the
   role endpoint. This is a reversible data operation, not a deploy.
 
@@ -179,7 +183,7 @@ unused, so no data rollback is needed. If locked out, re-grant via
 
 ```mermaid
 sequenceDiagram
-    participant Browser as admin/ frontend
+    participant Browser as admin frontend
     participant MW as RequireApproved MW
     participant PMW as RequirePermission MW
     participant Chk as authz.Checker (admin)

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -17,8 +17,8 @@ Two roles, a small fixed enum.
 
 The existing single Cerbos role literal `"admin"` is **renamed** to `system_admin`;
 a third role (e.g. `user_admin`) is deferred (Open Questions). The enum mirrors the
-existing `adminuser.Status` pattern in `server/pkg/adminuser/enum.go` and is already
-implemented in PR #282.
+existing `adminuser.Status` pattern in `server/pkg/adminuser/enum.go`; the
+implementation is in reearth/reearth-accounts#282 (in review).
 
 ## Storage
 
@@ -42,11 +42,13 @@ A per-route `RequirePermission` middleware, layered on `RequireApproved`, reads 
 already-loaded role from the `AdminUser` in the echo context and hands it to the
 admin `authz.Checker`, which does a Cerbos `CheckResources` against the
 `accounts-admin` policy for the route's `(resource, action)`. This is **exactly one
-Cerbos gRPC call per protected request**. When the Cerbos client is nil (local dev,
-no `CERBOS_HOST`), the check **fails open** (allow), as it does today.
+Cerbos gRPC call per protected request**. When the Cerbos client is nil
+(`CERBOS_HOST` unset), the check **fails open** (allow) — but only outside
+production: `provideCerbosClient` fails fast at startup when `CERBOS_HOST` is
+unset in production, so admin authorization cannot be silently disabled there.
 
 ```go
-// presentation/middleware/require_permission.go
+// server/internal/admin/presentation/middleware/require_permission.go
 func RequirePermission(chk *authz.Checker, resource, action string) echo.MiddlewareFunc {
     return func(next echo.HandlerFunc) echo.HandlerFunc {
         return func(c echo.Context) error {
@@ -89,7 +91,8 @@ distribution proves prohibitive.
 | `GET /api/v1/workspaces` | `workspace` | `list` | viewer |
 | `GET /api/v1/workspaces/:id` | `workspace` | `read` | viewer |
 | `GET /api/v1/workspaces/:id/members` | `workspace` | `read_member` | viewer |
-| *(future)* `PATCH/DELETE users/workspaces` | resp. | `edit` / `delete` | system_admin |
+| *(future)* `PATCH /api/v1/users/:id`, `DELETE /api/v1/users/:id` | `user` | `edit` / `delete` | system_admin |
+| *(future)* `PATCH /api/v1/workspaces/:id`, `DELETE /api/v1/workspaces/:id` | `workspace` | `edit` / `delete` | system_admin |
 | `PUT /api/v1/admin-users/:id/roles` | `admin_user` | `assign_role` | system_admin |
 
 Notes:
@@ -114,7 +117,7 @@ Notes:
 | `workspace` | `list` / `read` / `read_member` | system_admin, viewer |
 | `workspace` | `edit` / `delete` | system_admin |
 
-`resourceRules` in `internal/admin/rbac/definitions.go` is the single source of
+`resourceRules` in `server/internal/admin/rbac/definitions.go` is the single source of
 truth, compiled into the `accounts-admin` Cerbos policy via `make gen-policies`
 (`cmd/policy-generator`).
 
@@ -124,7 +127,7 @@ truth, compiled into the `accounts-admin` Cerbos policy via `make gen-policies`
 > `server/.gitignore`). **Nothing is checked in** — there is no `policies/`
 > directory at the repo root and no policy YAML committed anywhere. **The
 > mechanism by which the generated `accounts-admin` YAML reaches the running
-> Cerbos instance is unknown.** CLAUDE.md mentions a GCS sync via GitHub Actions,
+> Cerbos instance is unknown.** `server/CLAUDE.md` mentions a GCS sync via GitHub Actions,
 > but **no such workflow exists** under `.github/workflows/`. Because enforcement
 > is Cerbos-based, the policy MUST reach the running Cerbos instance or protected
 > endpoints will fail. **This must be confirmed with the platform/Cerbos owner

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -172,7 +172,7 @@ valve.
   error even for system_admins.
 - **B — deploy enforcement.** Ship the additive migration (backfill =
   `system_admin`) and `RequirePermission`. Because step A verified the policy is
-  loaded and every existing admin holds `system_admin`, every check ALLOWs —
+  loaded and every existing admin holds `system_admin`, every check returns ALLOW —
   behavior identical to today, effectively permissive; **no feature flag required**.
 - **C — tighten.** A system_admin demotes read-only operators to `viewer` via the
   role endpoint. This is a reversible data operation, not a deploy.

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -122,12 +122,14 @@ truth, compiled into the `accounts-admin` Cerbos policy via `make gen-policies`
 (`cmd/policy-generator`).
 
 > **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.**
-> Policies are generated locally into the **gitignored** `server/policies/`
+> Generated policies are written locally into the **gitignored** `server/policies/`
 > directory (`PolicyFileDir = "policies"` relative to `server/`; `/policies` is in
-> `server/.gitignore`). **Nothing is checked in** — there is no `policies/`
-> directory at the repo root and no policy YAML committed anywhere. **The
-> mechanism by which the generated `accounts-admin` YAML reaches the running
-> Cerbos instance is unknown.** `server/CLAUDE.md` mentions a GCS sync via GitHub Actions,
+> `server/.gitignore`). **No generated `accounts-admin` policy YAML is checked in**
+> — the only committed policy YAML is the Cerbos e2e fixtures under
+> `server/e2e/testdata/policies/` (e.g. `service_resource.yaml`), which are test
+> data, not the runtime policy source. **The mechanism by which the generated
+> `accounts-admin` YAML reaches the running Cerbos instance is unknown.**
+> `server/CLAUDE.md` mentions a GCS sync via GitHub Actions,
 > but **no such workflow exists** under `.github/workflows/`. Because enforcement
 > is Cerbos-based, the policy MUST reach the running Cerbos instance or protected
 > endpoints will fail. **This must be confirmed with the platform/Cerbos owner

--- a/server/docs/usecase/admin-role.md
+++ b/server/docs/usecase/admin-role.md
@@ -125,15 +125,17 @@ truth, compiled into the `accounts-admin` Cerbos policy via
 > **⚠ Dependency / Risk (launch blocker) — runtime policy distribution.**
 > Generated policies are written locally into the **gitignored** `server/policies/`
 > directory (`PolicyFileDir = "policies"` relative to `server/`; `/policies` is in
-> `server/.gitignore`). **No generated `accounts-admin` policy YAML is checked in**
-> — the only committed policy YAML is the Cerbos e2e fixtures under
-> `server/e2e/testdata/policies/` (e.g. `service_resource.yaml`), which are test
-> data, not the runtime policy source. **The mechanism by which the generated
-> `accounts-admin` YAML reaches the running Cerbos instance is unknown.**
-> `server/CLAUDE.md` mentions a GCS sync via GitHub Actions,
-> but **no such workflow exists** under `.github/workflows/`. Because enforcement
-> is Cerbos-based, the policy MUST reach the running Cerbos instance or protected
-> endpoints will fail. **This must be confirmed with the platform/Cerbos owner
+> `server/.gitignore`). **No generated `accounts-admin` policy YAML is checked in.**
+> For **local dev / e2e** only, hand-maintained fixtures under
+> `server/e2e/testdata/policies/` (e.g. `service_resource.yaml`, `.cerbos.yaml`)
+> are mounted into the Cerbos container as `/policies` by `docker-compose.yml` /
+> `docker-compose.dev.yml` (`server --config=/policies/.cerbos.yaml`) — so any new
+> `accounts-admin` rules must be reflected there for local testing. **But the
+> mechanism by which the generated `accounts-admin` YAML reaches the *deployed*
+> Cerbos instance is unknown.** `server/CLAUDE.md` mentions a GCS sync via GitHub
+> Actions, but **no such workflow exists** under `.github/workflows/`. Because
+> enforcement is Cerbos-based, the policy MUST reach the deployed Cerbos instance
+> or protected endpoints will fail. **This must be confirmed with the platform/Cerbos owner
 > before rollout** — it is the single remaining open dependency (see Open
 > Questions).
 


### PR DESCRIPTION
## Why

Design document for **granular admin permissions** (reearth-dashboard#1316), the follow-up to the ADMIN-AUTH epic's V1 non-goal ("every approved admin is equal; roles are a follow-up").

## Decided design (see doc for full rationale)

- **Storage**: a single `role` enum field on the `adminuser.AdminUser` aggregate (+ migration) — not a separate binding aggregate.
- **Roles (V1)**: `system_admin` and `viewer`; the existing single Cerbos role `"admin"` is renamed `system_admin`.
- **Enforcement**: Cerbos (`accounts-admin` service) via a `RequirePermission` middleware → `authz.Checker` → `CheckResources`. The dormant checker is re-typed from `user.ID` to the admin principal.
- **Assignment**: default `viewer` on approval; `PUT /admin-users/:id/roles` (system_admin only) with a last-`system_admin` lock-out guard.
- **Bootstrap**: bootstrap emails get `system_admin`.
- **Rollout**: additive migration + backfill existing approved admins to `system_admin` (zero-lockout), then demote to `viewer` as a data op. No feature flag.

## ⚠ Launch dependency

Runtime **Cerbos policy distribution** — how the generated `accounts-admin` policy reaches the running Cerbos instance is not evidenced in this repo's workflows; must be confirmed with the platform/Cerbos owner before rollout. Implementation can proceed independently (local dev fails open).

## Status

DRAFT for team review / sign-off. Implementation is starting in parallel per the agreed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)