### PR TITLE
feat(server): add role field to AdminUser (#1316 foundation)

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260708123739_backfill_admin_user_role.go
+++ b/server/internal/infrastructure/mongo/migration/260708123739_backfill_admin_user_role.go
@@ -1,0 +1,31 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// BackfillAdminUserRole assigns role "system_admin" to every approved admin user
+// that has no role yet, so existing approved admins keep full privileges once
+// role enforcement is introduced.
+func BackfillAdminUserRole(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("adminuser")
+
+	filter := bson.M{
+		"status": "approved",
+		"$or": []bson.M{
+			{"role": bson.M{"$exists": false}},
+			{"role": ""},
+		},
+	}
+	update := bson.M{"$set": bson.M{"role": "system_admin"}}
+
+	res, err := col.UpdateMany(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to backfill adminuser.role: %w", err)
+	}
+	fmt.Printf("Backfilled adminuser.role=system_admin for %d approved users\n", res.ModifiedCount)
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -43,4 +43,5 @@ var migrations = migration.Migrations[DBClient]{
 	260701120000: ApplyAdminUserSchema,
 	260701120001: AddAdminUserEmailIndex,
 	260701120002: AddAdminUserStatusCreatedAtIndex,
+	260708123739: BackfillAdminUserRole,
 }

--- a/server/internal/infrastructure/mongo/mongodoc/adminuser.go
+++ b/server/internal/infrastructure/mongo/mongodoc/adminuser.go
@@ -12,6 +12,7 @@ type AdminUserDocument struct {
 	Email      string    `json:"email" bson:"email" jsonschema:"required,description=Admin user email address (lowercase, unique)"`
 	Name       string    `json:"name" bson:"name" jsonschema:"required,description=Admin user display name"`
 	PictureURL string    `json:"pictureurl" bson:"pictureurl" jsonschema:"description=Admin user picture URL from Google profile. Default: \"\""`
+	Role       string    `json:"role" bson:"role" jsonschema:"description=Admin user role: system_admin or viewer. Default: \"\""`
 	Status     string    `json:"status" bson:"status" jsonschema:"required,description=Admin user status: pending, approved or rejected"`
 	ApprovedBy string    `json:"approvedby" bson:"approvedby" jsonschema:"description=ID of the admin who approved this user (ULID format). Default: \"\""`
 	ApprovedAt time.Time `json:"approvedat" bson:"approvedat" jsonschema:"description=Approval timestamp"`
@@ -45,6 +46,7 @@ func NewAdminUser(u adminuser.AdminUser) (*AdminUserDocument, string) {
 		Email:      u.Email(),
 		Name:       u.Name(),
 		PictureURL: u.PictureURL(),
+		Role:       u.Role().String(),
 		Status:     u.Status().String(),
 		ApprovedBy: approvedBy,
 		ApprovedAt: u.ApprovedAt(),
@@ -76,6 +78,16 @@ func (d *AdminUserDocument) Model() (*adminuser.AdminUser, error) {
 		Status(status).
 		ApprovedAt(d.ApprovedAt).
 		UpdatedAt(d.UpdatedAt)
+
+	// Tolerate empty/absent role so pre-migration documents still load; only
+	// error on a present-but-invalid value.
+	if d.Role != "" {
+		role, err := adminuser.RoleFrom(d.Role)
+		if err != nil {
+			return nil, err
+		}
+		b = b.Role(role)
+	}
 
 	if d.ApprovedBy != "" {
 		by, err := id.AdminUserIDFrom(d.ApprovedBy)

--- a/server/internal/infrastructure/mongo/schema/ER.md
+++ b/server/internal/infrastructure/mongo/schema/ER.md
@@ -13,6 +13,7 @@ erDiagram
         string email
         string name
         string pictureurl "optional"
+        string role "optional"
         string status
         date updatedat
     }

--- a/server/internal/infrastructure/mongo/schema/adminuser.json
+++ b/server/internal/infrastructure/mongo/schema/adminuser.json
@@ -36,6 +36,10 @@
         "bsonType": "string",
         "description": "Admin user picture URL from Google profile. Default: \"\""
       },
+      "role": {
+        "bsonType": "string",
+        "description": "Admin user role: system_admin or viewer. Default: \"\""
+      },
       "status": {
         "bsonType": "string",
         "description": "Admin user status: pending, approved or rejected"

--- a/server/internal/infrastructure/postgres/adminuser.go
+++ b/server/internal/infrastructure/postgres/adminuser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/reearth/reearthx/usecasex"
 )
 
-const adminUserColumns = "id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at"
+const adminUserColumns = "id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at"
 
 type AdminUser struct {
 	c *Client
@@ -27,6 +27,7 @@ func adminUserModel(a gen.AdminUser) (*adminuser.AdminUser, error) {
 		Email:      a.Email,
 		Name:       a.Name,
 		PictureURL: a.PictureUrl,
+		Role:       a.Role,
 		Status:     a.Status,
 		ApprovedBy: a.ApprovedBy,
 		ApprovedAt: a.ApprovedAt,
@@ -154,6 +155,7 @@ func (r *AdminUser) Save(ctx context.Context, u *adminuser.AdminUser) error {
 		Email:      row.Email,
 		Name:       row.Name,
 		PictureUrl: row.PictureURL,
+		Role:       row.Role,
 		Status:     row.Status,
 		ApprovedBy: row.ApprovedBy,
 		ApprovedAt: row.ApprovedAt,
@@ -174,7 +176,7 @@ func scanAdminUsers(rows pgx.Rows) (adminuser.List, error) {
 	for rows.Next() {
 		var d pgdoc.AdminUserRow
 		if err := rows.Scan(
-			&d.ID, &d.Email, &d.Name, &d.PictureURL, &d.Status,
+			&d.ID, &d.Email, &d.Name, &d.PictureURL, &d.Role, &d.Status,
 			&d.ApprovedBy, &d.ApprovedAt, &d.CreatedAt, &d.UpdatedAt,
 		); err != nil {
 			return nil, err

--- a/server/internal/infrastructure/postgres/migration/0003_admin_user_role.down.sql
+++ b/server/internal/infrastructure/postgres/migration/0003_admin_user_role.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE admin_users DROP COLUMN IF EXISTS role;

--- a/server/internal/infrastructure/postgres/migration/0003_admin_user_role.up.sql
+++ b/server/internal/infrastructure/postgres/migration/0003_admin_user_role.up.sql
@@ -1,0 +1,5 @@
+-- admin_users.role
+ALTER TABLE admin_users ADD COLUMN role text NOT NULL DEFAULT '';
+
+-- backfill: existing approved admins keep full privileges
+UPDATE admin_users SET role = 'system_admin' WHERE status = 'approved' AND (role = '' OR role IS NULL);

--- a/server/internal/infrastructure/postgres/migration/0003_admin_user_role.up.sql
+++ b/server/internal/infrastructure/postgres/migration/0003_admin_user_role.up.sql
@@ -2,4 +2,4 @@
 ALTER TABLE admin_users ADD COLUMN role text NOT NULL DEFAULT '';
 
 -- backfill: existing approved admins keep full privileges
-UPDATE admin_users SET role = 'system_admin' WHERE status = 'approved' AND (role = '' OR role IS NULL);
+UPDATE admin_users SET role = 'system_admin' WHERE status = 'approved' AND role = '';

--- a/server/internal/infrastructure/postgres/pgdoc/adminuser.go
+++ b/server/internal/infrastructure/postgres/pgdoc/adminuser.go
@@ -12,6 +12,7 @@ type AdminUserRow struct {
 	Email      string
 	Name       string
 	PictureURL string
+	Role       string
 	Status     string
 	ApprovedBy string
 	ApprovedAt *time.Time
@@ -33,6 +34,7 @@ func NewAdminUserRow(u adminuser.AdminUser) AdminUserRow {
 		Email:      u.Email(),
 		Name:       u.Name(),
 		PictureURL: u.PictureURL(),
+		Role:       u.Role().String(),
 		Status:     u.Status().String(),
 		ApprovedBy: approvedBy,
 		ApprovedAt: approvedAt,
@@ -59,6 +61,16 @@ func (r AdminUserRow) Model() (*adminuser.AdminUser, error) {
 		PictureURL(r.PictureURL).
 		Status(status).
 		UpdatedAt(r.UpdatedAt)
+
+	// Tolerate empty/absent role so pre-migration rows still load; only error on
+	// a present-but-invalid value.
+	if r.Role != "" {
+		role, err := adminuser.RoleFrom(r.Role)
+		if err != nil {
+			return nil, err
+		}
+		b = b.Role(role)
+	}
 
 	if r.ApprovedAt != nil {
 		b = b.ApprovedAt(*r.ApprovedAt)

--- a/server/internal/infrastructure/postgres/sqlc/gen/adminuser.sql.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/adminuser.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const adminUserFindByEmail = `-- name: AdminUserFindByEmail :one
-SELECT id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE lower(email) = lower($1) LIMIT 1
+SELECT id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE lower(email) = lower($1) LIMIT 1
 `
 
 func (q *Queries) AdminUserFindByEmail(ctx context.Context, lower string) (AdminUser, error) {
@@ -22,6 +22,7 @@ func (q *Queries) AdminUserFindByEmail(ctx context.Context, lower string) (Admin
 		&i.Email,
 		&i.Name,
 		&i.PictureUrl,
+		&i.Role,
 		&i.Status,
 		&i.ApprovedBy,
 		&i.ApprovedAt,
@@ -32,7 +33,7 @@ func (q *Queries) AdminUserFindByEmail(ctx context.Context, lower string) (Admin
 }
 
 const adminUserFindByID = `-- name: AdminUserFindByID :one
-SELECT id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE id = $1
+SELECT id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE id = $1
 `
 
 func (q *Queries) AdminUserFindByID(ctx context.Context, id string) (AdminUser, error) {
@@ -43,6 +44,7 @@ func (q *Queries) AdminUserFindByID(ctx context.Context, id string) (AdminUser, 
 		&i.Email,
 		&i.Name,
 		&i.PictureUrl,
+		&i.Role,
 		&i.Status,
 		&i.ApprovedBy,
 		&i.ApprovedAt,
@@ -53,7 +55,7 @@ func (q *Queries) AdminUserFindByID(ctx context.Context, id string) (AdminUser, 
 }
 
 const adminUserFindByIDs = `-- name: AdminUserFindByIDs :many
-SELECT id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE id = ANY($1::text[]) ORDER BY id
+SELECT id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at FROM admin_users WHERE id = ANY($1::text[]) ORDER BY id
 `
 
 func (q *Queries) AdminUserFindByIDs(ctx context.Context, dollar_1 []string) ([]AdminUser, error) {
@@ -70,6 +72,7 @@ func (q *Queries) AdminUserFindByIDs(ctx context.Context, dollar_1 []string) ([]
 			&i.Email,
 			&i.Name,
 			&i.PictureUrl,
+			&i.Role,
 			&i.Status,
 			&i.ApprovedBy,
 			&i.ApprovedAt,
@@ -87,12 +90,13 @@ func (q *Queries) AdminUserFindByIDs(ctx context.Context, dollar_1 []string) ([]
 }
 
 const adminUserUpsert = `-- name: AdminUserUpsert :exec
-INSERT INTO admin_users (id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+INSERT INTO admin_users (id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 ON CONFLICT (id) DO UPDATE SET
     email=EXCLUDED.email,
     name=EXCLUDED.name,
     picture_url=EXCLUDED.picture_url,
+    role=EXCLUDED.role,
     status=EXCLUDED.status,
     approved_by=EXCLUDED.approved_by,
     approved_at=EXCLUDED.approved_at,
@@ -104,6 +108,7 @@ type AdminUserUpsertParams struct {
 	Email      string
 	Name       string
 	PictureUrl string
+	Role       string
 	Status     string
 	ApprovedBy string
 	ApprovedAt *time.Time
@@ -117,6 +122,7 @@ func (q *Queries) AdminUserUpsert(ctx context.Context, arg AdminUserUpsertParams
 		arg.Email,
 		arg.Name,
 		arg.PictureUrl,
+		arg.Role,
 		arg.Status,
 		arg.ApprovedBy,
 		arg.ApprovedAt,

--- a/server/internal/infrastructure/postgres/sqlc/gen/models.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/models.go
@@ -13,6 +13,7 @@ type AdminUser struct {
 	Email      string
 	Name       string
 	PictureUrl string
+	Role       string
 	Status     string
 	ApprovedBy string
 	ApprovedAt *time.Time

--- a/server/internal/infrastructure/postgres/sqlc/queries/adminuser.sql
+++ b/server/internal/infrastructure/postgres/sqlc/queries/adminuser.sql
@@ -1,10 +1,11 @@
 -- name: AdminUserUpsert :exec
-INSERT INTO admin_users (id, email, name, picture_url, status, approved_by, approved_at, created_at, updated_at)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+INSERT INTO admin_users (id, email, name, picture_url, role, status, approved_by, approved_at, created_at, updated_at)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 ON CONFLICT (id) DO UPDATE SET
     email=EXCLUDED.email,
     name=EXCLUDED.name,
     picture_url=EXCLUDED.picture_url,
+    role=EXCLUDED.role,
     status=EXCLUDED.status,
     approved_by=EXCLUDED.approved_by,
     approved_at=EXCLUDED.approved_at,

--- a/server/internal/infrastructure/postgres/sqlc/schema/schema.sql
+++ b/server/internal/infrastructure/postgres/sqlc/schema/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE admin_users (
     email       text NOT NULL,
     name        text NOT NULL,
     picture_url text NOT NULL DEFAULT '',
+    role        text NOT NULL DEFAULT '',
     status      text NOT NULL,
     approved_by text NOT NULL DEFAULT '',
     approved_at timestamptz,

--- a/server/pkg/adminuser/adminuser.go
+++ b/server/pkg/adminuser/adminuser.go
@@ -136,13 +136,19 @@ func (u *AdminUser) Reject() {
 	u.updatedAt = time.Now()
 }
 
-// SetRole assigns the given role to the user.
-func (u *AdminUser) SetRole(r Role) {
+// SetRole assigns the given role to the user. Invalid roles are rejected so a
+// value the mongo/postgres mappers cannot load back (they error on
+// present-but-invalid roles) is never persisted.
+func (u *AdminUser) SetRole(r Role) error {
 	if u == nil {
-		return
+		return nil
+	}
+	if !r.Valid() {
+		return ErrInvalidRole
 	}
 	u.role = r
 	u.updatedAt = time.Now()
+	return nil
 }
 
 // UpdateProfile refreshes the display name and picture from the Google profile

--- a/server/pkg/adminuser/adminuser.go
+++ b/server/pkg/adminuser/adminuser.go
@@ -22,6 +22,7 @@ type AdminUser struct {
 	id         ID
 	name       string
 	pictureURL string
+	role       Role
 	status     Status
 	updatedAt  time.Time
 }
@@ -76,6 +77,13 @@ func (u *AdminUser) PictureURL() string {
 	return u.pictureURL
 }
 
+func (u *AdminUser) Role() Role {
+	if u == nil {
+		return ""
+	}
+	return u.role
+}
+
 func (u *AdminUser) Status() Status {
 	if u == nil {
 		return ""
@@ -125,6 +133,15 @@ func (u *AdminUser) Reject() {
 		return
 	}
 	u.status = StatusRejected
+	u.updatedAt = time.Now()
+}
+
+// SetRole assigns the given role to the user.
+func (u *AdminUser) SetRole(r Role) {
+	if u == nil {
+		return
+	}
+	u.role = r
 	u.updatedAt = time.Now()
 }
 

--- a/server/pkg/adminuser/adminuser_test.go
+++ b/server/pkg/adminuser/adminuser_test.go
@@ -59,10 +59,14 @@ func TestAdminUser_SetRole(t *testing.T) {
 	u := newTestAdminUser()
 	before := u.UpdatedAt()
 
-	u.SetRole(RoleSystemAdmin)
+	assert.NoError(t, u.SetRole(RoleSystemAdmin))
 
 	assert.Equal(t, RoleSystemAdmin, u.Role())
 	assert.False(t, u.UpdatedAt().Before(before))
+
+	// an invalid role is rejected and leaves the user unchanged
+	assert.ErrorIs(t, u.SetRole(Role("bogus")), ErrInvalidRole)
+	assert.Equal(t, RoleSystemAdmin, u.Role())
 }
 
 func TestAdminUser_Approve_Idempotent(t *testing.T) {

--- a/server/pkg/adminuser/adminuser_test.go
+++ b/server/pkg/adminuser/adminuser_test.go
@@ -55,6 +55,16 @@ func TestAdminUser_Approve(t *testing.T) {
 	assert.False(t, u.UpdatedAt().Before(before))
 }
 
+func TestAdminUser_SetRole(t *testing.T) {
+	u := newTestAdminUser()
+	before := u.UpdatedAt()
+
+	u.SetRole(RoleSystemAdmin)
+
+	assert.Equal(t, RoleSystemAdmin, u.Role())
+	assert.False(t, u.UpdatedAt().Before(before))
+}
+
 func TestAdminUser_Approve_Idempotent(t *testing.T) {
 	u := newTestAdminUser()
 	first := NewID()

--- a/server/pkg/adminuser/builder.go
+++ b/server/pkg/adminuser/builder.go
@@ -97,6 +97,11 @@ func (b *Builder) PictureURL(pictureURL string) *Builder {
 	return b
 }
 
+func (b *Builder) Role(role Role) *Builder {
+	b.u.role = role
+	return b
+}
+
 func (b *Builder) Status(status Status) *Builder {
 	b.u.status = status
 	return b

--- a/server/pkg/adminuser/builder.go
+++ b/server/pkg/adminuser/builder.go
@@ -31,6 +31,12 @@ func (b *Builder) Build() (*AdminUser, error) {
 		return nil, ErrInvalidStatus
 	}
 
+	// Empty means "unset" (pre-migration records); anything else must be a
+	// known role so an unloadable value is never constructed/persisted.
+	if b.u.role != "" && !b.u.role.Valid() {
+		return nil, ErrInvalidRole
+	}
+
 	// Set default updatedAt if not explicitly set.
 	if b.u.updatedAt.IsZero() {
 		b.u.updatedAt = time.Now()

--- a/server/pkg/adminuser/builder_test.go
+++ b/server/pkg/adminuser/builder_test.go
@@ -114,6 +114,11 @@ func TestBuilder_NewID(t *testing.T) {
 	assert.False(t, u.ID().IsEmpty())
 }
 
+func TestBuilder_Role(t *testing.T) {
+	u := New().NewID().Name("Bob").Email("bob@eukarya.io").Role(RoleSystemAdmin).MustBuild()
+	assert.Equal(t, RoleSystemAdmin, u.Role())
+}
+
 func TestBuilder_MustBuild_Panics(t *testing.T) {
 	assert.Panics(t, func() {
 		New().Name("Bob").Email("bob@eukarya.io").MustBuild()

--- a/server/pkg/adminuser/builder_test.go
+++ b/server/pkg/adminuser/builder_test.go
@@ -117,6 +117,14 @@ func TestBuilder_NewID(t *testing.T) {
 func TestBuilder_Role(t *testing.T) {
 	u := New().NewID().Name("Bob").Email("bob@eukarya.io").Role(RoleSystemAdmin).MustBuild()
 	assert.Equal(t, RoleSystemAdmin, u.Role())
+
+	// empty means "unset" (pre-migration records) and still builds
+	u = New().NewID().Name("Bob").Email("bob@eukarya.io").MustBuild()
+	assert.Equal(t, Role(""), u.Role())
+
+	// an invalid role is rejected at construction time
+	_, err := New().NewID().Name("Bob").Email("bob@eukarya.io").Role(Role("bogus")).Build()
+	assert.ErrorIs(t, err, ErrInvalidRole)
 }
 
 func TestBuilder_MustBuild_Panics(t *testing.T) {

--- a/server/pkg/adminuser/enum.go
+++ b/server/pkg/adminuser/enum.go
@@ -26,6 +26,21 @@ var (
 	ErrInvalidStatus = errors.New("invalid status")
 )
 
+var (
+	// RoleSystemAdmin is a role with full administrative privileges over the
+	// admin application.
+	RoleSystemAdmin = Role("system_admin")
+	// RoleViewer is a role with read-only access to the admin application.
+	RoleViewer = Role("viewer")
+
+	roles = []Role{
+		RoleSystemAdmin,
+		RoleViewer,
+	}
+
+	ErrInvalidRole = errors.New("invalid role")
+)
+
 type Status string
 
 func (s Status) Valid() bool {
@@ -42,4 +57,22 @@ func StatusFrom(s string) (Status, error) {
 		return status, nil
 	}
 	return status, ErrInvalidStatus
+}
+
+type Role string
+
+func (r Role) Valid() bool {
+	return slices.Contains(roles, r)
+}
+
+func (r Role) String() string {
+	return string(r)
+}
+
+func RoleFrom(s string) (Role, error) {
+	role := Role(strings.ToLower(s))
+	if role.Valid() {
+		return role, nil
+	}
+	return role, ErrInvalidRole
 }

--- a/server/pkg/adminuser/enum.go
+++ b/server/pkg/adminuser/enum.go
@@ -62,10 +62,10 @@ func StatusFrom(s string) (Status, error) {
 type Role string
 
 // Valid reports whether r is one of the known roles. The empty string is NOT
-// valid: it denotes "unset" on pre-migration records and is tolerated only as
-// an absent value at load time (the mappers skip empty roles); enforcement
-// code treating an unset role as invalid — and therefore denying — is the
-// intended behavior.
+// valid: it denotes "unset" (pre-migration records). Construction and the
+// mongo/postgres mappers tolerate an empty role — the builder accepts it and
+// the mappers skip parsing it — but enforcement code treating an unset role
+// as invalid, and therefore denying, is the intended behavior.
 func (r Role) Valid() bool {
 	return slices.Contains(roles, r)
 }

--- a/server/pkg/adminuser/enum.go
+++ b/server/pkg/adminuser/enum.go
@@ -61,6 +61,11 @@ func StatusFrom(s string) (Status, error) {
 
 type Role string
 
+// Valid reports whether r is one of the known roles. The empty string is NOT
+// valid: it denotes "unset" on pre-migration records and is tolerated only as
+// an absent value at load time (the mappers skip empty roles); enforcement
+// code treating an unset role as invalid — and therefore denying — is the
+// intended behavior.
 func (r Role) Valid() bool {
 	return slices.Contains(roles, r)
 }

--- a/server/pkg/adminuser/enum_test.go
+++ b/server/pkg/adminuser/enum_test.go
@@ -44,3 +44,40 @@ func TestStatus_Valid(t *testing.T) {
 func TestStatus_String(t *testing.T) {
 	assert.Equal(t, "pending", StatusPending.String())
 }
+
+func TestRoleFrom(t *testing.T) {
+	tests := []struct {
+		Name, Input string
+		Expected    Role
+		Err         error
+	}{
+		{Name: "system_admin", Input: "system_admin", Expected: RoleSystemAdmin},
+		{Name: "viewer uppercase", Input: "VIEWER", Expected: RoleViewer},
+		{Name: "invalid", Input: "xxx", Expected: Role("xxx"), Err: ErrInvalidRole},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			res, err := RoleFrom(tt.Input)
+			if tt.Err == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.Expected, res)
+			} else {
+				assert.Equal(t, tt.Err, err)
+			}
+		})
+	}
+}
+
+func TestRole_Valid(t *testing.T) {
+	assert.True(t, RoleSystemAdmin.Valid())
+	assert.True(t, RoleViewer.Valid())
+	assert.False(t, Role("").Valid())
+	assert.False(t, Role("unknown").Valid())
+}
+
+func TestRole_String(t *testing.T) {
+	assert.Equal(t, "system_admin", RoleSystemAdmin.String())
+}


### PR DESCRIPTION
## Why

First slice of **granular admin permissions** (reearth-dashboard#1316; design in #281). Establishes the data foundation: an admin's role. This PR is **behavior-neutral** — the role is stored and round-tripped, but no endpoint enforces it yet (enforcement + assignment are follow-up PRs).

## What's included

- **Domain** (`pkg/adminuser`): a `Role` enum mirroring the existing `Status` enum — `system_admin`, `viewer` (+ `Valid`/`String`/`RoleFrom`); a `role` field on the `AdminUser` aggregate with `Role()` getter, `SetRole()` mutator (bumps `updatedAt`), and a builder setter. `SetRole` and `Build` reject invalid roles (`ErrInvalidRole`); an **empty role is treated as "unset"** — not valid for enforcement, but tolerated so pre-migration data still builds and loads.
- **Mongo**: `role` on the mongodoc (tolerates empty/absent on read, errors only on present-but-invalid); regenerated schema JSON; a backfill migration setting `role = system_admin` for existing **approved** admins.
- **Postgres**: `role` column in the sqlc schema + queries + regenerated `sqlc/gen`; pgdoc + repo mapping; runtime migration `0003` (add column + backfill approved → system_admin).
- **In-memory**: no change (stores the aggregate directly).

## Rollout note

The backfill grants **existing approved admins `system_admin`** (full privileges), so nothing changes for them — this is the zero-lockout first step of the rollout in the design doc (#281). Later PRs add enforcement and the demotion-to-`viewer` data step.

## Testing

`go build ./...`, `go vet`, `gofmt`, `make sqlc` (stable), and `go test` for `pkg/adminuser` + infra backends pass. Postgres integration files build with `-tags integration`. `mock_adminuser.go` is unchanged (Repo interface untouched).

## Checklist

- [x] Verified backward compatibility (additive field; empty role tolerated; existing approved admins backfilled to system_admin so behavior is unchanged)
- [x] Confirmed backward compatibility for migrations (additive column/field + idempotent backfill; down migration drops the column)
- [x] Verified that no PII is included in displayed values (role is an enum string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
