### PR TITLE
feat(server): expand admin RBAC matrix and retype Cerbos checker (#1316)

### DIFF
--- a/server/internal/admin/rbac/definitions.go
+++ b/server/internal/admin/rbac/definitions.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"slices"
 
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
 	"github.com/reearth/reearthx/cerbos/generator"
 )
 
@@ -15,20 +16,29 @@ const (
 )
 
 const (
+	ResourceAdminUser = "admin_user"
 	ResourceUser      = "user"
 	ResourceWorkspace = "workspace"
 )
 
 const (
-	ActionDelete = "delete"
-	ActionEdit   = "edit"
-	ActionList   = "list"
-	ActionRead   = "read"
+	ActionApprove    = "approve"
+	ActionAssignRole = "assign_role"
+	ActionDelete     = "delete"
+	ActionEdit       = "edit"
+	ActionList       = "list"
+	ActionRead       = "read"
+	ActionReadMember = "read_member"
+	ActionReject     = "reject"
 )
 
-// roleAdmin is the role granted to Re:Earth operational staff who access the
-// internal management console. Admin operations are purely role-based.
-const roleAdmin = "admin"
+// roleSystemAdmin and roleViewer are the admin console roles. They reference the
+// domain enum in pkg/adminuser so the Cerbos principal roles and the matrix
+// roles cannot drift.
+var (
+	roleSystemAdmin = adminuser.RoleSystemAdmin.String()
+	roleViewer      = adminuser.RoleViewer.String()
+)
 
 type ResourceRule struct {
 	Resource string
@@ -37,21 +47,31 @@ type ResourceRule struct {
 
 var resourceRules = []ResourceRule{
 	{
+		Resource: ResourceAdminUser,
+		Actions: map[string][]string{
+			ActionList:       {roleSystemAdmin, roleViewer},
+			ActionApprove:    {roleSystemAdmin},
+			ActionReject:     {roleSystemAdmin},
+			ActionAssignRole: {roleSystemAdmin},
+		},
+	},
+	{
 		Resource: ResourceUser,
 		Actions: map[string][]string{
-			ActionList:   {roleAdmin},
-			ActionRead:   {roleAdmin},
-			ActionEdit:   {roleAdmin},
-			ActionDelete: {roleAdmin},
+			ActionList:   {roleSystemAdmin, roleViewer},
+			ActionRead:   {roleSystemAdmin, roleViewer},
+			ActionEdit:   {roleSystemAdmin},
+			ActionDelete: {roleSystemAdmin},
 		},
 	},
 	{
 		Resource: ResourceWorkspace,
 		Actions: map[string][]string{
-			ActionList:   {roleAdmin},
-			ActionRead:   {roleAdmin},
-			ActionEdit:   {roleAdmin},
-			ActionDelete: {roleAdmin},
+			ActionList:       {roleSystemAdmin, roleViewer},
+			ActionRead:       {roleSystemAdmin, roleViewer},
+			ActionReadMember: {roleSystemAdmin, roleViewer},
+			ActionEdit:       {roleSystemAdmin},
+			ActionDelete:     {roleSystemAdmin},
 		},
 	},
 }

--- a/server/internal/admin/usecase/authz/checker.go
+++ b/server/internal/admin/usecase/authz/checker.go
@@ -5,59 +5,42 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
 	effectv1 "github.com/cerbos/cerbos/api/genpb/cerbos/effect/v1"
 	adminrbac "github.com/reearth/reearth-accounts/server/internal/admin/rbac"
-	"github.com/reearth/reearth-accounts/server/pkg/permittable"
-	"github.com/reearth/reearth-accounts/server/pkg/role"
-	"github.com/reearth/reearth-accounts/server/pkg/user"
-	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
 )
 
-// Checker builds a Cerbos principal from the caller's permittable roles and
-// evaluates it against the admin policy set.
+// Checker builds a Cerbos principal from the admin's role and evaluates it
+// against the admin policy set. The role lives directly on the AdminUser
+// aggregate, so no repository lookup is required.
 type Checker struct {
-	client          *cerbos.GRPCClient
-	roleRepo        role.Repo
-	permittableRepo permittable.Repo
+	client *cerbos.GRPCClient
 }
 
 // NewChecker is a Wire provider for the admin authorization checker. A nil
 // client (Cerbos unconfigured) makes every check pass, for local development.
-func NewChecker(client *cerbos.GRPCClient, roleRepo role.Repo, permittableRepo permittable.Repo) *Checker {
-	return &Checker{client: client, roleRepo: roleRepo, permittableRepo: permittableRepo}
+func NewChecker(client *cerbos.GRPCClient) *Checker {
+	return &Checker{client: client}
 }
 
-// Allowed reports whether caller may perform action on resource within the
-// admin Cerbos service.
-func (c *Checker) Allowed(ctx context.Context, caller user.ID, resource, action string) (bool, error) {
+// Allowed reports whether an admin with the given role may perform action on
+// resource within the admin Cerbos service.
+func (c *Checker) Allowed(ctx context.Context, principalID adminuser.ID, role adminuser.Role, resource, action string) (bool, error) {
 	if c.client == nil {
 		return true, nil
 	}
 
-	pmt, err := c.permittableRepo.FindByUserID(ctx, caller)
-	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
-		return false, err
-	}
-	if pmt == nil {
+	// An unset or invalid role denies before any Cerbos call is made.
+	if !role.Valid() {
 		return false, nil
 	}
 
-	roles, err := c.roleRepo.FindByIDs(ctx, pmt.RoleIDs())
-	if err != nil {
-		return false, err
-	}
-	roleNames := make([]string, 0, len(roles))
-	for _, r := range roles {
-		roleNames = append(roleNames, r.Name())
-	}
-
-	principal := cerbos.NewPrincipal(caller.String(), roleNames...)
+	principal := cerbos.NewPrincipal(principalID.String(), role.String())
 	kind := fmt.Sprintf("%s:%s", adminrbac.ServiceName, resource)
-	resourceID := fmt.Sprintf("%s:%s:%s", adminrbac.ServiceName, resource, caller.String())
+	resourceID := fmt.Sprintf("%s:%s:%s", adminrbac.ServiceName, resource, principalID.String())
 
 	batch := cerbos.NewResourceBatch()
 	batch.Add(cerbos.NewResource(kind, resourceID), action)

--- a/server/internal/admin/usecase/authz/checker_test.go
+++ b/server/internal/admin/usecase/authz/checker_test.go
@@ -2,23 +2,17 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
 	adminrbac "github.com/reearth/reearth-accounts/server/internal/admin/rbac"
-	"github.com/reearth/reearth-accounts/server/pkg/id"
-	"github.com/reearth/reearth-accounts/server/pkg/permittable"
-	"github.com/reearth/reearth-accounts/server/pkg/role"
-	"github.com/reearth/reearth-accounts/server/pkg/user"
-	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 // newTestClient returns a non-nil Cerbos client. cerbos.New is lazy and does
-// not dial, so tests can drive the pre-Cerbos code paths (repo lookups) without
-// a running Cerbos server.
+// not dial, so tests can drive the pre-Cerbos code paths (e.g. role validation)
+// without a running Cerbos server.
 func newTestClient(t *testing.T) *cerbos.GRPCClient {
 	t.Helper()
 	client, err := cerbos.New("localhost:3593", cerbos.WithPlaintext())
@@ -28,109 +22,26 @@ func newTestClient(t *testing.T) *cerbos.GRPCClient {
 	return client
 }
 
-// A nil client (Cerbos unconfigured, e.g. local dev) must bypass authorization
-// and never touch the repositories.
+// A nil client (Cerbos unconfigured, e.g. local dev) must bypass authorization.
 func TestChecker_Allowed_NilClientBypasses(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	c := NewChecker(nil)
 
-	// No EXPECT() calls: gomock fails the test if either repo is touched.
-	mockRoleRepo := role.NewMockRepo(ctrl)
-	mockPermittableRepo := permittable.NewMockRepo(ctrl)
-
-	c := NewChecker(nil, mockRoleRepo, mockPermittableRepo)
-
-	allowed, err := c.Allowed(context.Background(), user.NewID(), adminrbac.ResourceUser, adminrbac.ActionList)
+	allowed, err := c.Allowed(context.Background(), adminuser.NewID(), adminuser.RoleSystemAdmin, adminrbac.ResourceUser, adminrbac.ActionList)
 	assert.NoError(t, err)
 	assert.True(t, allowed)
 }
 
-// When the caller has no permittable record, the request must be denied without
-// consulting Cerbos. A not-found error from the repo is treated as "no roles".
-func TestChecker_Allowed_NoPermittableDenies(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+// An unset or invalid role must be denied before Cerbos is ever dialed.
+func TestChecker_Allowed_InvalidRoleDenies(t *testing.T) {
+	c := NewChecker(newTestClient(t))
 
-	uid := user.NewID()
-	mockRoleRepo := role.NewMockRepo(ctrl)
-	mockPermittableRepo := permittable.NewMockRepo(ctrl)
-	mockPermittableRepo.EXPECT().
-		FindByUserID(gomock.Any(), uid).
-		Return(nil, rerror.ErrNotFound)
-
-	c := NewChecker(newTestClient(t), mockRoleRepo, mockPermittableRepo)
-
-	allowed, err := c.Allowed(context.Background(), uid, adminrbac.ResourceUser, adminrbac.ActionList)
+	// Empty role (unset) denies.
+	allowed, err := c.Allowed(context.Background(), adminuser.NewID(), adminuser.Role(""), adminrbac.ResourceUser, adminrbac.ActionList)
 	assert.NoError(t, err)
 	assert.False(t, allowed)
-}
 
-// A nil permittable with no error must also deny.
-func TestChecker_Allowed_NilPermittableDenies(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	uid := user.NewID()
-	mockRoleRepo := role.NewMockRepo(ctrl)
-	mockPermittableRepo := permittable.NewMockRepo(ctrl)
-	mockPermittableRepo.EXPECT().
-		FindByUserID(gomock.Any(), uid).
-		Return(nil, nil)
-
-	c := NewChecker(newTestClient(t), mockRoleRepo, mockPermittableRepo)
-
-	allowed, err := c.Allowed(context.Background(), uid, adminrbac.ResourceUser, adminrbac.ActionList)
+	// Unknown role value denies.
+	allowed, err = c.Allowed(context.Background(), adminuser.NewID(), adminuser.Role("bogus"), adminrbac.ResourceUser, adminrbac.ActionList)
 	assert.NoError(t, err)
-	assert.False(t, allowed)
-}
-
-// A non-not-found error from the permittable repo must be propagated, not
-// swallowed into an allow/deny decision.
-func TestChecker_Allowed_PermittableRepoErrorPropagates(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	uid := user.NewID()
-	wantErr := errors.New("db down")
-	mockRoleRepo := role.NewMockRepo(ctrl)
-	mockPermittableRepo := permittable.NewMockRepo(ctrl)
-	mockPermittableRepo.EXPECT().
-		FindByUserID(gomock.Any(), uid).
-		Return(nil, wantErr)
-
-	c := NewChecker(newTestClient(t), mockRoleRepo, mockPermittableRepo)
-
-	allowed, err := c.Allowed(context.Background(), uid, adminrbac.ResourceUser, adminrbac.ActionList)
-	assert.ErrorIs(t, err, wantErr)
-	assert.False(t, allowed)
-}
-
-// An error while resolving the caller's roles must be propagated.
-func TestChecker_Allowed_RoleRepoErrorPropagates(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	uid := user.NewID()
-	r := role.New().NewID().Name("role1").MustBuild()
-	pmt := permittable.New().
-		NewID().
-		UserID(uid).
-		RoleIDs([]id.RoleID{r.ID()}).
-		MustBuild()
-	wantErr := errors.New("db down")
-
-	mockRoleRepo := role.NewMockRepo(ctrl)
-	mockPermittableRepo := permittable.NewMockRepo(ctrl)
-	mockPermittableRepo.EXPECT().
-		FindByUserID(gomock.Any(), uid).
-		Return(pmt, nil)
-	mockRoleRepo.EXPECT().
-		FindByIDs(gomock.Any(), pmt.RoleIDs()).
-		Return(nil, wantErr)
-
-	c := NewChecker(newTestClient(t), mockRoleRepo, mockPermittableRepo)
-
-	allowed, err := c.Allowed(context.Background(), uid, adminrbac.ResourceUser, adminrbac.ActionList)
-	assert.ErrorIs(t, err, wantErr)
 	assert.False(t, allowed)
 }


### PR DESCRIPTION
## Why

Next foundation slice of **granular admin permissions** (reearth-dashboard#1316; design in #281, role field in #282). This PR expands the `accounts-admin` RBAC matrix to the two-role model and re-types the (still dormant) Cerbos checker to the admin principal.

**Behavior-neutral:** nothing consumes the checker yet — no route, middleware, or response changes. Enforcement wiring is the next PR.

## What's included

- **`internal/admin/rbac`**: add the `admin_user` resource and `approve` / `reject` / `assign_role` / `read_member` actions; replace the single `"admin"` role with the two console roles, sourced from `pkg/adminuser` (`system_admin`, `viewer`) so the Cerbos principal roles and the matrix cannot drift; build the role→action matrix from the design doc.
- **`internal/admin/usecase/authz`**: the admin role lives directly on the `AdminUser` aggregate, so drop the `permittable`/`role` repo lookups. `Checker.Allowed` now takes the admin principal (`adminuser.ID` + `adminuser.Role`) instead of a `user.ID`, denies an unset/invalid role before any Cerbos call, and keeps the nil-client local-dev bypass. Tests rewritten for the new surface.

## Notes

- `make gen-policies` regenerates the `accounts-admin` policy from the expanded matrix (output is gitignored; not committed). Runtime distribution of that policy to the deployed Cerbos instance remains the open launch dependency called out in the design doc.
- Pre-existing `make wire-admin` failure (`gatewayWire` unused) is unrelated to this change and does not affect `go build`; `wire_gen.go` is unchanged (the checker is not yet consumed).

## Checklist

- [x] Verified backward compatibility (behavior-neutral; checker still unconsumed, nil-client bypass preserved)
- [x] Confirmed backward compatibility for migrations (no migration in this PR)
- [x] Verified that no PII is included in displayed values (roles are enum strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)