### PR TITLE
feat(server): initialize admin role on approval and bootstrap sign-in (#1316)

### DIFF
--- a/server/internal/admin/usecase/adminuseruc/approve.go
+++ b/server/internal/admin/usecase/adminuseruc/approve.go
@@ -43,6 +43,15 @@ func (uc *ApproveAdminUserUseCase) Execute(ctx context.Context, operatorID, targ
 	}
 
 	target.Approve(operatorID)
+	// A freshly approved admin defaults to viewer (least-privilege). A record
+	// that already carries a role — e.g. a previously-assigned admin who was
+	// rejected and is now being re-approved — keeps it; we never clobber or
+	// downgrade an existing role here.
+	if target.Role() == "" {
+		if err := target.SetRole(adminuser.RoleViewer); err != nil {
+			return nil, err
+		}
+	}
 	if err := uc.repo.Save(ctx, target); err != nil {
 		return nil, err
 	}

--- a/server/internal/admin/usecase/adminuseruc/approve_test.go
+++ b/server/internal/admin/usecase/adminuseruc/approve_test.go
@@ -28,6 +28,50 @@ func TestApprove(t *testing.T) {
 	assert.True(t, reloaded.IsApproved())
 }
 
+func TestApprove_DefaultsRoleToViewer(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io") // no role set
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, got.Role())
+
+	reloaded, err := repo.FindByID(ctx, target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, reloaded.Role())
+}
+
+func TestApprove_KeepsExistingRole(t *testing.T) {
+	ctx := context.Background()
+	operator := approved("op@eukarya.io")
+	target := pending("new@eukarya.io")
+	require.NoError(t, target.SetRole(adminuser.RoleSystemAdmin))
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID())
+	require.NoError(t, err)
+	assert.True(t, got.IsApproved())
+	assert.Equal(t, adminuser.RoleSystemAdmin, got.Role()) // not downgraded to viewer
+}
+
+func TestApprove_AlreadyApprovedDoesNotChangeRole(t *testing.T) {
+	ctx := context.Background()
+	firstApprover := adminuser.NewID()
+	target := pending("t@eukarya.io")
+	require.NoError(t, target.SetRole(adminuser.RoleSystemAdmin))
+	target.Approve(firstApprover) // pending -> approved with system_admin
+	repo := memory.NewAdminUserWith(target)
+	uc := NewApproveAdminUserUseCase(repo)
+
+	got, err := uc.Execute(ctx, adminuser.NewID(), target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleSystemAdmin, got.Role()) // idempotent path untouched
+}
+
 func TestApprove_AlreadyApprovedIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	firstApprover := adminuser.NewID()

--- a/server/internal/admin/usecase/authuc/signin.go
+++ b/server/internal/admin/usecase/authuc/signin.go
@@ -78,6 +78,8 @@ func (uc *GoogleSignInUseCase) Execute(ctx context.Context, idToken string) (*ad
 	}
 
 	if u != nil {
+		changed := false
+
 		// Refresh the profile from the latest Google data on each sign-in.
 		// Name and picture are updated independently, and an empty Google claim
 		// keeps the stored value (UpdateProfile requires a non-empty name).
@@ -93,6 +95,27 @@ func (uc *GoogleSignInUseCase) Execute(ctx context.Context, idToken string) (*ad
 			if err := u.UpdateProfile(name, picture); err != nil {
 				return nil, err
 			}
+			changed = true
+		}
+
+		// Reconcile bootstrap admins on every sign-in: re-adding an email to the
+		// bootstrap env var re-grants access (the lock-out recovery valve). This
+		// only ever approves/elevates; the system_admin guard means it never
+		// downgrades an already-system_admin record.
+		if uc.bootstrap[email] {
+			if !u.IsApproved() {
+				u.Approve(adminuser.ID{}) // bootstrap has no human approver
+				changed = true
+			}
+			if u.Role() != adminuser.RoleSystemAdmin {
+				if err := u.SetRole(adminuser.RoleSystemAdmin); err != nil {
+					return nil, err
+				}
+				changed = true
+			}
+		}
+
+		if changed {
 			if err := uc.repo.Save(ctx, u); err != nil {
 				return nil, err
 			}
@@ -103,7 +126,9 @@ func (uc *GoogleSignInUseCase) Execute(ctx context.Context, idToken string) (*ad
 	// new account: pending unless bootstrapped
 	b := adminuser.New().NewID().Email(email).Name(displayName(claims.Name, email)).PictureURL(claims.PictureURL)
 	if uc.bootstrap[email] {
-		b = b.Status(adminuser.StatusApproved)
+		// Bootstrap admins are auto-approved and seeded as system_admin so a
+		// fresh DB can gain its first system_admin.
+		b = b.Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin)
 	} else {
 		b = b.Status(adminuser.StatusPending)
 	}

--- a/server/internal/admin/usecase/authuc/signin_test.go
+++ b/server/internal/admin/usecase/authuc/signin_test.go
@@ -38,6 +38,7 @@ func TestGoogleSignIn_NewUser_Pending(t *testing.T) {
 	assert.Equal(t, "alice@eukarya.io", u.Email())
 	assert.Equal(t, "Alice", u.Name())
 	assert.True(t, u.IsPending())
+	assert.Equal(t, adminuser.Role(""), u.Role()) // non-bootstrap new account has no role
 
 	// persisted
 	got, err := repo.FindByEmail(context.Background(), "alice@eukarya.io")
@@ -53,6 +54,51 @@ func TestGoogleSignIn_NewUser_Bootstrapped(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, u.IsApproved())
 	assert.False(t, u.ApprovedAt().IsZero())
+	assert.Equal(t, adminuser.RoleSystemAdmin, u.Role())
+}
+
+func TestGoogleSignIn_ExistingUser_BootstrapElevatesAndApproves(t *testing.T) {
+	// A pre-existing pending viewer whose email is (re-)added to the bootstrap
+	// list is approved and elevated to system_admin on next sign-in.
+	existing := adminuser.New().NewID().Email("boss@eukarya.io").Name("Boss").Status(adminuser.StatusPending).Role(adminuser.RoleViewer).MustBuild()
+	repo := memory.NewAdminUserWith(existing)
+	v := fakeVerifier{claims: &google.Claims{Email: "boss@eukarya.io", EmailVerified: true, HD: "eukarya.io", Name: "Boss"}}
+	uc := NewGoogleSignInUseCase(repo, v, GoogleSignInOptions{AllowedDomain: "eukarya.io", BootstrapEmails: []string{"boss@eukarya.io"}})
+
+	u, err := uc.Execute(context.Background(), "tok")
+	require.NoError(t, err)
+	assert.Equal(t, existing.ID(), u.ID())
+	assert.True(t, u.IsApproved())
+	assert.Equal(t, adminuser.RoleSystemAdmin, u.Role())
+
+	got, err := repo.FindByEmail(context.Background(), "boss@eukarya.io")
+	require.NoError(t, err)
+	assert.True(t, got.IsApproved())
+	assert.Equal(t, adminuser.RoleSystemAdmin, got.Role()) // persisted
+}
+
+func TestGoogleSignIn_ExistingUser_BootstrapSystemAdminNotDowngraded(t *testing.T) {
+	existing := adminuser.New().NewID().Email("boss@eukarya.io").Name("Boss").Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin).MustBuild()
+	repo := memory.NewAdminUserWith(existing)
+	v := fakeVerifier{claims: &google.Claims{Email: "boss@eukarya.io", EmailVerified: true, HD: "eukarya.io", Name: "Boss"}}
+	uc := NewGoogleSignInUseCase(repo, v, GoogleSignInOptions{AllowedDomain: "eukarya.io", BootstrapEmails: []string{"boss@eukarya.io"}})
+
+	u, err := uc.Execute(context.Background(), "tok")
+	require.NoError(t, err)
+	assert.True(t, u.IsApproved())
+	assert.Equal(t, adminuser.RoleSystemAdmin, u.Role())
+}
+
+func TestGoogleSignIn_ExistingUser_NonBootstrapRoleUntouched(t *testing.T) {
+	existing := adminuser.New().NewID().Email("alice@eukarya.io").Name("Alice").Status(adminuser.StatusApproved).Role(adminuser.RoleViewer).MustBuild()
+	repo := memory.NewAdminUserWith(existing)
+	v := fakeVerifier{claims: &google.Claims{Email: "alice@eukarya.io", EmailVerified: true, HD: "eukarya.io", Name: "Alice"}}
+	uc := NewGoogleSignInUseCase(repo, v, GoogleSignInOptions{AllowedDomain: "eukarya.io"})
+
+	u, err := uc.Execute(context.Background(), "tok")
+	require.NoError(t, err)
+	assert.True(t, u.IsApproved())
+	assert.Equal(t, adminuser.RoleViewer, u.Role()) // not bootstrapped: role unchanged
 }
 
 func TestGoogleSignIn_ExistingUser_RefreshesProfileAndKeepsStatus(t *testing.T) {


### PR DESCRIPTION
## Why

Next slice of **granular admin permissions** (reearth-dashboard#1316; design in #281, role field in #282, RBAC matrix in #283). Initializes the `AdminUser.role` field on the two write paths that create or approve admins.

**Behavior-neutral:** the role is stored but not yet enforced (enforcement middleware is a later PR), so access is unchanged today.

## What's included

- **Approve usecase**: a freshly approved admin defaults to `viewer` (least-privilege). A record that already carries a role — e.g. a previously-assigned admin who was rejected and is now re-approved — keeps it; the role is never clobbered or downgraded, and the idempotent already-approved path is untouched.
- **Bootstrap sign-in** (`authuc`):
  - A **new** bootstrap email is seeded approved with `system_admin`, so a fresh DB can gain its first `system_admin`.
  - An **existing** bootstrap account is reconciled on every sign-in (approved if needed, elevated to `system_admin`) but **never downgraded** — re-adding an email to `REEARTH_ACCOUNTS_ADMIN_BOOTSTRAP_EMAILS` is the lock-out recovery valve from the design doc. The existing-account branch now does a single `Save` via a `changed` flag.

## Tests

New/extended unit tests in `adminuseruc` and `authuc`: approval defaults to viewer / keeps an existing role / idempotent path unchanged; new bootstrap → `system_admin`; new non-bootstrap → pending, empty role; existing account bootstrap-elevated-and-approved; existing `system_admin` not downgraded; non-bootstrap existing role untouched.

## Checklist

- [x] Verified backward compatibility (behavior-neutral; role stored, not yet enforced; existing sign-in/profile-refresh semantics preserved)
- [x] Confirmed backward compatibility for migrations (no migration in this PR; the #282 backfill already set existing approved admins to system_admin)
- [x] Verified that no PII is included in displayed values (roles are enum strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)