### PR TITLE
feat(server): enforce granular admin permissions via RequirePermission (#1316)

### DIFF
--- a/server/internal/admin/di/config.go
+++ b/server/internal/admin/di/config.go
@@ -259,12 +259,9 @@ func provideRepoContainer(cfg *Config) (*repo.Container, func(), error) {
 // development. In production a missing CERBOS_HOST is a misconfiguration that
 // would silently disable all admin authorization, so we fail fast instead.
 //
-// Currently dormant: the admin API treats every approved admin as equal, so no
-// endpoint consumes the Cerbos checker yet. It is retained (together with the
-// authz/rbac packages and the wireinject provider sets) for the granular
-// admin-permissions follow-up (reearth-dashboard#1316), which will re-wire it.
-//
-//nolint:unused // retained (dormant) for reearth-dashboard#1316; see comment above
+// The client feeds the authz checker, which the per-route RequirePermission
+// middleware consumes to enforce granular admin permissions
+// (reearth-dashboard#1316).
 func provideCerbosClient(cfg *Config) (*cerbos.GRPCClient, error) {
 	if cfg.CerbosHost == "" {
 		if cfg.IsProduction() {

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -7,13 +7,14 @@ package di
 
 import (
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation"
-	adminuserhandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/adminuser"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/auth"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/user"
-	workspacehandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/workspace"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/workspace"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/useruc"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/workspaceuc"
 )
@@ -28,21 +29,19 @@ func InitializeEcho() (*Server, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	adminUserRepo := container.AdminUser
-	repo := container.User
-	workspaceRepo := container.Workspace
-	getUserUseCase := useruc.NewGetUserUseCase(repo)
-	getUserWorkspacesUseCase := useruc.NewGetUserWorkspacesUseCase(repo, workspaceRepo)
-	listUsersUseCase := useruc.NewListUsersUseCase(repo)
-	userHandler := user.NewHandler(getUserUseCase, getUserWorkspacesUseCase, listUsersUseCase)
+	repo := container.AdminUser
+	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(repo)
+	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(repo)
+	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(repo)
+	handler := adminuser.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
 	verifier, err := provideGoogleVerifier(config)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
 	googleSignInOptions := provideGoogleSignInOptions(config)
-	googleSignInUseCase := authuc.NewGoogleSignInUseCase(adminUserRepo, verifier, googleSignInOptions)
-	getMeUseCase := authuc.NewGetMeUseCase(adminUserRepo)
+	googleSignInUseCase := authuc.NewGoogleSignInUseCase(repo, verifier, googleSignInOptions)
+	getMeUseCase := authuc.NewGetMeUseCase(repo)
 	manager, err := provideSessionManager(config)
 	if err != nil {
 		cleanup()
@@ -50,17 +49,25 @@ func InitializeEcho() (*Server, func(), error) {
 	}
 	cookieSecure := provideCookieSecure(config)
 	authHandler := auth.NewHandler(googleSignInUseCase, getMeUseCase, manager, cookieSecure)
-	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(adminUserRepo)
-	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(adminUserRepo)
-	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(adminUserRepo)
-	adminUserHandler := adminuserhandler.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
+	userRepo := container.User
+	getUserUseCase := useruc.NewGetUserUseCase(userRepo)
+	workspaceRepo := container.Workspace
+	getUserWorkspacesUseCase := useruc.NewGetUserWorkspacesUseCase(userRepo, workspaceRepo)
+	listUsersUseCase := useruc.NewListUsersUseCase(userRepo)
+	userHandler := user.NewHandler(getUserUseCase, getUserWorkspacesUseCase, listUsersUseCase)
 	getWorkspaceUseCase := workspaceuc.NewGetWorkspaceUseCase(workspaceRepo)
 	listWorkspacesUseCase := workspaceuc.NewListWorkspacesUseCase(workspaceRepo)
-	listWorkspaceMembersUseCase := workspaceuc.NewListWorkspaceMembersUseCase(workspaceRepo, repo)
-	workspaceHandler := workspacehandler.NewHandler(getWorkspaceUseCase, listWorkspacesUseCase, listWorkspaceMembersUseCase)
+	listWorkspaceMembersUseCase := workspaceuc.NewListWorkspaceMembersUseCase(workspaceRepo, userRepo)
+	workspaceHandler := workspace.NewHandler(getWorkspaceUseCase, listWorkspacesUseCase, listWorkspaceMembersUseCase)
 	sessionMiddleware := middleware.NewSessionMiddleware(manager)
-	requireApprovedMiddleware := middleware.NewRequireApprovedMiddleware(manager, adminUserRepo)
-	presentationHandler := presentation.NewHandler(adminUserHandler, authHandler, userHandler, workspaceHandler, sessionMiddleware, requireApprovedMiddleware)
+	requireApprovedMiddleware := middleware.NewRequireApprovedMiddleware(manager, repo)
+	grpcClient, err := provideCerbosClient(config)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	checker := authz.NewChecker(grpcClient)
+	presentationHandler := presentation.NewHandler(handler, authHandler, userHandler, workspaceHandler, sessionMiddleware, requireApprovedMiddleware, checker)
 	appMiddlewares := presentation.NewAppMiddlewares()
 	server := NewAppEchoServer(config, presentationHandler, appMiddlewares)
 	return server, func() {

--- a/server/internal/admin/presentation/handler.go
+++ b/server/internal/admin/presentation/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/user"
 	workspacehandler "github.com/reearth/reearth-accounts/server/internal/admin/presentation/handler/workspace"
 	mw "github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
 )
 
 // Handler aggregates all resource-specific admin handlers plus the middlewares.
@@ -16,6 +17,7 @@ type Handler struct {
 	Workspace       *workspacehandler.Handler
 	SessionMw       mw.SessionMiddleware
 	RequireApproved mw.RequireApprovedMiddleware
+	Checker         *authz.Checker
 }
 
 // NewHandler is a Wire provider that assembles the top-level admin Handler.
@@ -26,6 +28,7 @@ func NewHandler(
 	workspaceHandler *workspacehandler.Handler,
 	sessionMw mw.SessionMiddleware,
 	requireApproved mw.RequireApprovedMiddleware,
+	checker *authz.Checker,
 ) *Handler {
 	return &Handler{
 		AdminUser:       adminUserHandler,
@@ -34,5 +37,6 @@ func NewHandler(
 		Workspace:       workspaceHandler,
 		SessionMw:       sessionMw,
 		RequireApproved: requireApproved,
+		Checker:         checker,
 	}
 }

--- a/server/internal/admin/presentation/middleware/require_permission.go
+++ b/server/internal/admin/presentation/middleware/require_permission.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
+	"github.com/reearth/reearthx/log"
+)
+
+// RequirePermission builds middleware that authorizes the current admin against
+// the Cerbos admin policy for a route's (resource, action). Unlike the other
+// admin middlewares it is parameterized per route, so it is a plain constructor
+// rather than a Wire-provided named type. It must be layered on top of
+// RequireApproved, which loads the AdminUser (and its role) into the context;
+// this middleware then performs exactly one Cerbos check with zero extra reads.
+func RequirePermission(chk *authz.Checker, resource, action string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			u, err := internal.GetAdminUser(c) // loaded by RequireApproved; role already in memory
+			if err != nil {
+				return err // already an echo.HTTPError(401)
+			}
+			ok, err := chk.Allowed(c.Request().Context(), u.ID(), u.Role(), resource, action)
+			if err != nil {
+				log.Errorfc(c.Request().Context(), "[admin] permission check failed: %v", err)
+				return echo.NewHTTPError(http.StatusInternalServerError)
+			}
+			if !ok {
+				return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+			}
+			return next(c)
+		}
+	}
+}

--- a/server/internal/admin/presentation/middleware/require_permission_test.go
+++ b/server/internal/admin/presentation/middleware/require_permission_test.go
@@ -1,0 +1,83 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cerbos/cerbos-sdk-go/cerbos"
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	mw "github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
+	adminrbac "github.com/reearth/reearth-accounts/server/internal/admin/rbac"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authz"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newContext(t *testing.T) (echo.Context, *bool) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	called := false
+	return c, &called
+}
+
+func next(called *bool) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		*called = true
+		return c.NoContent(http.StatusOK)
+	}
+}
+
+func TestRequirePermission_NoAdminUser_Unauthorized(t *testing.T) {
+	c, called := newContext(t)
+
+	m := mw.RequirePermission(authz.NewChecker(nil), adminrbac.ResourceUser, adminrbac.ActionList)
+	err := m(next(called))(c)
+
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+	assert.False(t, *called)
+}
+
+func TestRequirePermission_NilClient_Bypass(t *testing.T) {
+	c, called := newContext(t)
+	u := adminuser.New().NewID().
+		Email("op@eukarya.io").Name("op").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleViewer).MustBuild()
+	internal.SetAdminUser(c, u)
+
+	m := mw.RequirePermission(authz.NewChecker(nil), adminrbac.ResourceUser, adminrbac.ActionList)
+	err := m(next(called))(c)
+
+	require.NoError(t, err)
+	assert.True(t, *called)
+	assert.Equal(t, http.StatusOK, c.Response().Status)
+}
+
+func TestRequirePermission_InvalidRole_Forbidden(t *testing.T) {
+	c, called := newContext(t)
+	// A non-nil (but never-dialed) client forces the checker past the nil-client
+	// bypass; an empty role is then denied before any Cerbos call is made.
+	client, err := cerbos.New("localhost:3593", cerbos.WithPlaintext())
+	require.NoError(t, err)
+
+	u := adminuser.New().NewID().
+		Email("op@eukarya.io").Name("op").
+		Status(adminuser.StatusApproved).MustBuild()
+	internal.SetAdminUser(c, u)
+
+	m := mw.RequirePermission(authz.NewChecker(client), adminrbac.ResourceUser, adminrbac.ActionList)
+	err = m(next(called))(c)
+
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.Code)
+	assert.False(t, *called)
+}

--- a/server/internal/admin/presentation/middleware/require_permission_test.go
+++ b/server/internal/admin/presentation/middleware/require_permission_test.go
@@ -61,6 +61,25 @@ func TestRequirePermission_NilClient_Bypass(t *testing.T) {
 	assert.Equal(t, http.StatusOK, c.Response().Status)
 }
 
+func TestRequirePermission_CheckerError_InternalServerError(t *testing.T) {
+	c, called := newContext(t)
+	u := adminuser.New().NewID().
+		Email("op@eukarya.io").Name("op").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin).MustBuild()
+	internal.SetAdminUser(c, u)
+
+	// A nil checker makes Allowed fail closed with an error, exercising the
+	// middleware's 500 branch (a miswired DI would look like this).
+	var checker *authz.Checker
+	m := mw.RequirePermission(checker, adminrbac.ResourceUser, adminrbac.ActionList)
+	err := m(next(called))(c)
+
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.Code)
+	assert.False(t, *called)
+}
+
 func TestRequirePermission_InvalidRole_Forbidden(t *testing.T) {
 	c, called := newContext(t)
 	// A non-nil (but never-dialed) client forces the checker past the nil-client

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	mw "github.com/reearth/reearth-accounts/server/internal/admin/presentation/middleware"
+	adminrbac "github.com/reearth/reearth-accounts/server/internal/admin/rbac"
 )
 
 // RegisterRoutes wires the admin HTTP routes onto the Echo instance.
@@ -27,23 +29,26 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		// Current admin user (any status)
 		v1.GET("/me", h.Auth.Me, sessionMw)
 
-		// Admin-user management (requires an approved admin session)
+		// Admin-user management (requires an approved admin session). The group
+		// requireApproved loads the AdminUser (and its role) into the context;
+		// each route then adds a per-route RequirePermission that authorizes the
+		// route's (resource, action) against the admin Cerbos policy.
 		requireApproved := echo.MiddlewareFunc(h.RequireApproved)
 		adminUsers := v1.Group("/admin-users", requireApproved)
-		adminUsers.GET("", h.AdminUser.ListAdminUsers)
-		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser)
-		adminUsers.POST("/:id/reject", h.AdminUser.RejectAdminUser)
+		adminUsers.GET("", h.AdminUser.ListAdminUsers, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionList))
+		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionApprove))
+		adminUsers.POST("/:id/reject", h.AdminUser.RejectAdminUser, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionReject))
 
 		// Users (requires an approved admin session)
 		users := v1.Group("/users", requireApproved)
-		users.GET("", h.User.ListUsers)
-		users.GET("/:id", h.User.GetUser)
-		users.GET("/:id/workspaces", h.User.GetUserWorkspaces)
+		users.GET("", h.User.ListUsers, mw.RequirePermission(h.Checker, adminrbac.ResourceUser, adminrbac.ActionList))
+		users.GET("/:id", h.User.GetUser, mw.RequirePermission(h.Checker, adminrbac.ResourceUser, adminrbac.ActionRead))
+		users.GET("/:id/workspaces", h.User.GetUserWorkspaces, mw.RequirePermission(h.Checker, adminrbac.ResourceUser, adminrbac.ActionRead))
 
 		// Cross-tenant workspace listing (requires an approved admin session)
 		workspaces := v1.Group("/workspaces", requireApproved)
-		workspaces.GET("", h.Workspace.ListWorkspaces)
-		workspaces.GET("/:id", h.Workspace.GetWorkspace)
-		workspaces.GET("/:id/members", h.Workspace.GetWorkspaceMembers)
+		workspaces.GET("", h.Workspace.ListWorkspaces, mw.RequirePermission(h.Checker, adminrbac.ResourceWorkspace, adminrbac.ActionList))
+		workspaces.GET("/:id", h.Workspace.GetWorkspace, mw.RequirePermission(h.Checker, adminrbac.ResourceWorkspace, adminrbac.ActionRead))
+		workspaces.GET("/:id/members", h.Workspace.GetWorkspaceMembers, mw.RequirePermission(h.Checker, adminrbac.ResourceWorkspace, adminrbac.ActionReadMember))
 	}
 }

--- a/server/internal/admin/usecase/authz/checker.go
+++ b/server/internal/admin/usecase/authz/checker.go
@@ -5,6 +5,7 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
@@ -12,6 +13,12 @@ import (
 	adminrbac "github.com/reearth/reearth-accounts/server/internal/admin/rbac"
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
 )
+
+// ErrNilChecker is returned when Allowed is called on a nil Checker. This is a
+// wiring bug rather than a client error; callers should surface it as a 500.
+// It is returned (rather than panicking) so a misconfigured checker fails
+// closed instead of crashing the request.
+var ErrNilChecker = errors.New("authz: nil checker")
 
 // Checker builds a Cerbos principal from the admin's role and evaluates it
 // against the admin policy set. The role lives directly on the AdminUser
@@ -29,6 +36,10 @@ func NewChecker(client *cerbos.GRPCClient) *Checker {
 // Allowed reports whether an admin with the given role may perform action on
 // resource within the admin Cerbos service.
 func (c *Checker) Allowed(ctx context.Context, principalID adminuser.ID, role adminuser.Role, resource, action string) (bool, error) {
+	// A nil checker is a wiring bug; fail closed rather than panic.
+	if c == nil {
+		return false, ErrNilChecker
+	}
 	if c.client == nil {
 		return true, nil
 	}

--- a/server/internal/admin/usecase/authz/checker_test.go
+++ b/server/internal/admin/usecase/authz/checker_test.go
@@ -22,6 +22,16 @@ func newTestClient(t *testing.T) *cerbos.GRPCClient {
 	return client
 }
 
+// A nil checker (a wiring bug) must fail closed with ErrNilChecker rather than
+// panicking on the client dereference.
+func TestChecker_Allowed_NilCheckerFailsClosed(t *testing.T) {
+	var c *Checker
+
+	allowed, err := c.Allowed(context.Background(), adminuser.NewID(), adminuser.RoleSystemAdmin, adminrbac.ResourceUser, adminrbac.ActionList)
+	assert.ErrorIs(t, err, ErrNilChecker)
+	assert.False(t, allowed)
+}
+
 // A nil client (Cerbos unconfigured, e.g. local dev) must bypass authorization.
 func TestChecker_Allowed_NilClientBypasses(t *testing.T) {
 	c := NewChecker(nil)


### PR DESCRIPTION
## Why

Turns **enforcement on** for the admin API — the payoff of the granular admin permissions epic (reearth-dashboard#1316; design in #281, role field #282, RBAC matrix + checker #283, role init #284). A per-route `RequirePermission` middleware, layered on `RequireApproved`, authorizes each protected route against the `accounts-admin` Cerbos policy.

## What's included

- **`RequirePermission(chk, resource, action)`** (`presentation/middleware/require_permission.go`): reads the `AdminUser` already loaded by `RequireApproved` (role in memory → zero extra reads), runs exactly one Cerbos check, returns `403` on deny and `500` on checker error. It's a plain per-route constructor (not a Wire named type) since it's parameterized per route.
- **Router**: every protected route gains its `(resource, action)` per the design-doc mapping — admin-users `list`/`approve`/`reject`, users `list`/`read`, workspaces `list`/`read`/`read_member`. `/me`, `/auth/*`, `GET /` stay unchecked.
- **DI**: the previously-dormant Cerbos checker is now consumed by the Handler; `wire_gen.go` regenerated (this also resolves the prior `gatewayWire unused` wire failure), and the obsolete `//nolint:unused` on `provideCerbosClient` is dropped.
- **Tests**: middleware unit tests — no admin user → 401; nil client → pass (local-dev bypass); non-nil client + unset role → 403.

## Behavior change & deploy note

This is the first PR that can actually deny a request. Safeguards:
- Local dev / no `CERBOS_HOST`: checks **fail open** (unchanged).
- Existing approved admins were backfilled to `system_admin` (#282), so **no one is locked out at deploy**; new admins default to `viewer` (#284).
- **Enforcement requires the `accounts-admin` policy to be loaded by the running Cerbos instance.** Verify policy distribution before enabling in production — this is the launch dependency called out in the design doc. `CERBOS_HOST` is required in production (fail-fast at startup).

## Checklist

- [x] Verified backward compatibility (fail-open without Cerbos; all existing approved admins are system_admin so no lockout; only new 403s for under-privileged callers once policy is live)
- [x] Confirmed backward compatibility for migrations (no migration in this PR)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)