### PR TITLE
feat(server): add admin role assignment endpoint (#1316)

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -184,6 +184,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin-users/{id}/roles": {
+            "put": {
+                "description": "Assigns a role (e.g. system_admin, viewer) to the target admin user. Changing your own role is allowed, but the last system_admin cannot be demoted (the system must never reach zero system_admins).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Assign a role to an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Role to assign",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SetAdminUserRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "forbidden / cannot demote the last system admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
@@ -651,6 +716,9 @@ const docTemplate = `{
                 "pictureUrl": {
                     "type": "string"
                 },
+                "role": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string"
                 },
@@ -788,6 +856,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "SetAdminUserRoleRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
                     "type": "string"
                 }
             }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -235,7 +235,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "forbidden",
+                        "description": "not approved / forbidden",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -862,6 +862,9 @@ const docTemplate = `{
         },
         "SetAdminUserRoleRequest": {
             "type": "object",
+            "required": [
+                "role"
+            ],
             "properties": {
                 "role": {
                     "type": "string"

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -223,7 +223,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "invalid id / invalid role",
+                        "description": "invalid id / invalid role / cannot demote the last system admin",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -235,7 +235,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "forbidden / cannot demote the last system admin",
+                        "description": "forbidden",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -216,7 +216,7 @@
                         }
                     },
                     "400": {
-                        "description": "invalid id / invalid role",
+                        "description": "invalid id / invalid role / cannot demote the last system admin",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -228,7 +228,7 @@
                         }
                     },
                     "403": {
-                        "description": "forbidden / cannot demote the last system admin",
+                        "description": "forbidden",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -177,6 +177,71 @@
                 }
             }
         },
+        "/admin-users/{id}/roles": {
+            "put": {
+                "description": "Assigns a role (e.g. system_admin, viewer) to the target admin user. Changing your own role is allowed, but the last system_admin cannot be demoted (the system must never reach zero system_admins).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Assign a role to an admin user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Role to assign",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SetAdminUserRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminUser"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid id / invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "forbidden / cannot demote the last system admin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/google": {
             "post": {
                 "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
@@ -644,6 +709,9 @@
                 "pictureUrl": {
                     "type": "string"
                 },
+                "role": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string"
                 },
@@ -781,6 +849,14 @@
                     "type": "string"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "SetAdminUserRoleRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
                     "type": "string"
                 }
             }

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -228,7 +228,7 @@
                         }
                     },
                     "403": {
-                        "description": "forbidden",
+                        "description": "not approved / forbidden",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -855,6 +855,9 @@
         },
         "SetAdminUserRoleRequest": {
             "type": "object",
+            "required": [
+                "role"
+            ],
             "properties": {
                 "role": {
                     "type": "string"

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -331,7 +331,7 @@ paths:
           schema:
             $ref: '#/definitions/AdminUser'
         "400":
-          description: invalid id / invalid role
+          description: invalid id / invalid role / cannot demote the last system admin
           schema:
             $ref: '#/definitions/ErrorResponse'
         "401":
@@ -339,7 +339,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "403":
-          description: forbidden / cannot demote the last system admin
+          description: forbidden
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -341,7 +341,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "403":
-          description: forbidden
+          description: not approved / forbidden
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -114,6 +114,8 @@ definitions:
     properties:
       role:
         type: string
+    required:
+    - role
     type: object
   User:
     properties:

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -16,6 +16,8 @@ definitions:
         type: string
       pictureUrl:
         type: string
+      role:
+        type: string
       status:
         type: string
       updatedAt:
@@ -106,6 +108,11 @@ definitions:
       status:
         type: string
       updatedAt:
+        type: string
+    type: object
+  SetAdminUserRoleRequest:
+    properties:
+      role:
         type: string
     type: object
   User:
@@ -295,6 +302,51 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       summary: Reject or revoke an admin user
+      tags:
+      - admin-users
+  /admin-users/{id}/roles:
+    put:
+      consumes:
+      - application/json
+      description: Assigns a role (e.g. system_admin, viewer) to the target admin
+        user. Changing your own role is allowed, but the last system_admin cannot
+        be demoted (the system must never reach zero system_admins).
+      parameters:
+      - description: Admin user ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Role to assign
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/SetAdminUserRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminUser'
+        "400":
+          description: invalid id / invalid role
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: forbidden / cannot demote the last system admin
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Assign a role to an admin user
       tags:
       - admin-users
   /auth/google:

--- a/server/internal/admin/di/wire_gen.go
+++ b/server/internal/admin/di/wire_gen.go
@@ -33,7 +33,8 @@ func InitializeEcho() (*Server, func(), error) {
 	listAdminUsersUseCase := adminuseruc.NewListAdminUsersUseCase(repo)
 	approveAdminUserUseCase := adminuseruc.NewApproveAdminUserUseCase(repo)
 	rejectAdminUserUseCase := adminuseruc.NewRejectAdminUserUseCase(repo)
-	handler := adminuser.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase)
+	setRoleUseCase := adminuseruc.NewSetRoleUseCase(repo)
+	handler := adminuser.NewHandler(listAdminUsersUseCase, approveAdminUserUseCase, rejectAdminUserUseCase, setRoleUseCase)
 	verifier, err := provideGoogleVerifier(config)
 	if err != nil {
 		cleanup()

--- a/server/internal/admin/di/wire_usecase.go
+++ b/server/internal/admin/di/wire_usecase.go
@@ -31,6 +31,7 @@ var usecaseWire = wire.NewSet(
 	adminuseruc.NewListAdminUsersUseCase,
 	adminuseruc.NewApproveAdminUserUseCase,
 	adminuseruc.NewRejectAdminUserUseCase,
+	adminuseruc.NewSetRoleUseCase,
 
 	// cross-tenant workspace usecases
 	workspaceuc.NewGetWorkspaceUseCase,

--- a/server/internal/admin/presentation/error_handler.go
+++ b/server/internal/admin/presentation/error_handler.go
@@ -54,6 +54,8 @@ func classify(err error) (status int, code, msg string) {
 		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot modify your own admin account"
 	case errors.Is(err, adminuseruc.ErrLastApprovedAdmin):
 		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot reject the last approved admin"
+	case errors.Is(err, adminuseruc.ErrLastSystemAdmin):
+		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cannot demote the last system admin"
 	case errors.Is(err, user.ErrCursorPaginationUnsupported):
 		return http.StatusBadRequest, http.StatusText(http.StatusBadRequest), "cursor pagination is not supported"
 	case errors.Is(err, workspace.ErrCursorPaginationUnsupported):

--- a/server/internal/admin/presentation/handler/adminuser/handler.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler.go
@@ -11,6 +11,7 @@ type Handler struct {
 	list    *adminuseruc.ListAdminUsersUseCase
 	approve *adminuseruc.ApproveAdminUserUseCase
 	reject  *adminuseruc.RejectAdminUserUseCase
+	setRole *adminuseruc.SetRoleUseCase
 }
 
 // NewHandler is a Wire provider for the admin-user Handler.
@@ -18,6 +19,7 @@ func NewHandler(
 	list *adminuseruc.ListAdminUsersUseCase,
 	approve *adminuseruc.ApproveAdminUserUseCase,
 	reject *adminuseruc.RejectAdminUserUseCase,
+	setRole *adminuseruc.SetRoleUseCase,
 ) *Handler {
-	return &Handler{list: list, approve: approve, reject: reject}
+	return &Handler{list: list, approve: approve, reject: reject, setRole: setRole}
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -10,7 +10,7 @@ import (
 
 // SetAdminUserRoleRequest is the request body for assigning a role.
 type SetAdminUserRoleRequest struct {
-	Role string `json:"role"`
+	Role string `json:"role" validate:"required"`
 } // @name SetAdminUserRoleRequest
 
 // SetAdminUserRole godoc

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/adminuseruc"
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
 )
 
@@ -29,8 +30,7 @@ type SetAdminUserRoleRequest struct {
 //	@Failure		404		{object}	internal.ErrorResponse	"not found"
 //	@Router			/admin-users/{id}/roles [put]
 func (h *Handler) SetAdminUserRole(c echo.Context) error {
-	operator, err := internal.GetAdminUser(c)
-	if err != nil {
+	if _, err := internal.GetAdminUser(c); err != nil {
 		return err
 	}
 	targetID, err := adminuser.IDFrom(c.Param("id"))
@@ -50,7 +50,10 @@ func (h *Handler) SetAdminUserRole(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
 	}
 
-	u, err := h.setRole.Execute(c.Request().Context(), operator.ID(), targetID, role)
+	u, err := h.setRole.Execute(c.Request().Context(), adminuseruc.SetRoleInput{
+		TargetID: targetID,
+		Role:     role,
+	})
 	if err != nil {
 		return err
 	}

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -23,9 +23,9 @@ type SetAdminUserRoleRequest struct {
 //	@Param			id		path		string					true	"Admin user ID"
 //	@Param			body	body		SetAdminUserRoleRequest	true	"Role to assign"
 //	@Success		200		{object}	AdminUserResponse
-//	@Failure		400		{object}	internal.ErrorResponse	"invalid id / invalid role"
+//	@Failure		400		{object}	internal.ErrorResponse	"invalid id / invalid role / cannot demote the last system admin"
 //	@Failure		401		{object}	internal.ErrorResponse	"unauthorized"
-//	@Failure		403		{object}	internal.ErrorResponse	"forbidden / cannot demote the last system admin"
+//	@Failure		403		{object}	internal.ErrorResponse	"forbidden"
 //	@Failure		404		{object}	internal.ErrorResponse	"not found"
 //	@Router			/admin-users/{id}/roles [put]
 func (h *Handler) SetAdminUserRole(c echo.Context) error {

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -1,0 +1,58 @@
+package adminuser
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+)
+
+// SetAdminUserRoleRequest is the request body for assigning a role.
+type SetAdminUserRoleRequest struct {
+	Role string `json:"role"`
+} // @name SetAdminUserRoleRequest
+
+// SetAdminUserRole godoc
+//
+//	@Summary		Assign a role to an admin user
+//	@Description	Assigns a role (e.g. system_admin, viewer) to the target admin user. Changing your own role is allowed, but the last system_admin cannot be demoted (the system must never reach zero system_admins).
+//	@Tags			admin-users
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Admin user ID"
+//	@Param			body	body		SetAdminUserRoleRequest	true	"Role to assign"
+//	@Success		200		{object}	AdminUserResponse
+//	@Failure		400		{object}	internal.ErrorResponse	"invalid id / invalid role"
+//	@Failure		401		{object}	internal.ErrorResponse	"unauthorized"
+//	@Failure		403		{object}	internal.ErrorResponse	"forbidden / cannot demote the last system admin"
+//	@Failure		404		{object}	internal.ErrorResponse	"not found"
+//	@Router			/admin-users/{id}/roles [put]
+func (h *Handler) SetAdminUserRole(c echo.Context) error {
+	operator, err := internal.GetAdminUser(c)
+	if err != nil {
+		return err
+	}
+	targetID, err := adminuser.IDFrom(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	var body SetAdminUserRoleRequest
+	if err := c.Bind(&body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+	}
+	if body.Role == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+	}
+	role, err := adminuser.RoleFrom(body.Role)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+	}
+
+	u, err := h.setRole.Execute(c.Request().Context(), operator.ID(), targetID, role)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, newAdminUserResponse(u))
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -40,7 +40,7 @@ func (h *Handler) SetAdminUserRole(c echo.Context) error {
 
 	var body SetAdminUserRoleRequest
 	if err := c.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 	if body.Role == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")

--- a/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_set_role.go
@@ -26,7 +26,7 @@ type SetAdminUserRoleRequest struct {
 //	@Success		200		{object}	AdminUserResponse
 //	@Failure		400		{object}	internal.ErrorResponse	"invalid id / invalid role / cannot demote the last system admin"
 //	@Failure		401		{object}	internal.ErrorResponse	"unauthorized"
-//	@Failure		403		{object}	internal.ErrorResponse	"forbidden"
+//	@Failure		403		{object}	internal.ErrorResponse	"not approved / forbidden"
 //	@Failure		404		{object}	internal.ErrorResponse	"not found"
 //	@Router			/admin-users/{id}/roles [put]
 func (h *Handler) SetAdminUserRole(c echo.Context) error {

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -327,3 +327,32 @@ func TestSetAdminUserRole_InvalidID(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+func TestSetAdminUserRole_NotFound(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	// valid but non-existent target id -> rerror.ErrNotFound -> 404 via error handler
+	req := setRoleRequest(t, sess, op.ID(), adminuser.NewID(), `{"role":"viewer"}`)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSetAdminUserRole_LastSystemAdmin(t *testing.T) {
+	// op is the only approved system_admin; demoting it must map to 400 via the
+	// ErrLastSystemAdmin classification, not a generic 500.
+	op := approvedUser("op@eukarya.io")
+	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := setRoleRequest(t, sess, op.ID(), op.ID(), `{"role":"viewer"}`)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
 		adminuseruc.NewListAdminUsersUseCase(repo),
 		adminuseruc.NewApproveAdminUserUseCase(repo),
 		adminuseruc.NewRejectAdminUserUseCase(repo),
+		adminuseruc.NewSetRoleUseCase(repo),
 	)
 	requireApproved := echo.MiddlewareFunc(mw.NewRequireApprovedMiddleware(sess, repo))
 
@@ -42,6 +44,7 @@ func newTestEcho(repo adminuser.Repo, sess *session.Manager) *echo.Echo {
 	g.GET("", h.ListAdminUsers)
 	g.POST("/:id/approve", h.ApproveAdminUser)
 	g.POST("/:id/reject", h.RejectAdminUser)
+	g.PUT("/:id/roles", h.SetAdminUserRole)
 	return e
 }
 
@@ -259,4 +262,68 @@ func TestRejectAdminUser_NotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func setRoleRequest(t *testing.T, sess *session.Manager, opID adminuser.ID, targetID adminuser.ID, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin-users/"+targetID.String()+"/roles", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.AddCookie(cookieFor(t, sess, opID))
+	return req
+}
+
+func TestSetAdminUserRole_OK(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
+	target := approvedUser("target@eukarya.io")
+	require.NoError(t, target.SetRole(adminuser.RoleViewer))
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := setRoleRequest(t, sess, op.ID(), target.ID(), `{"role":"system_admin"}`)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	reloaded, err := repo.FindByID(req.Context(), target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleSystemAdmin, reloaded.Role())
+
+	// the response echoes the updated role
+	var body adminuserhandler.AdminUserResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, adminuser.RoleSystemAdmin.String(), body.Role)
+}
+
+func TestSetAdminUserRole_InvalidRole(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
+	target := approvedUser("target@eukarya.io")
+	require.NoError(t, target.SetRole(adminuser.RoleViewer))
+	repo := memory.NewAdminUserWith(op, target)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	for _, body := range []string{`{"role":"bogus"}`, `{"role":""}`, `{}`} {
+		req := setRoleRequest(t, sess, op.ID(), target.ID(), body)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "body %q should be 400", body)
+	}
+}
+
+func TestSetAdminUserRole_InvalidID(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin-users/not-an-id/roles", strings.NewReader(`{"role":"viewer"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -343,8 +343,7 @@ func TestSetAdminUserRole_NotFound(t *testing.T) {
 }
 
 func TestSetAdminUserRole_LastSystemAdmin(t *testing.T) {
-	// op is the only approved system_admin; demoting it must map to 400 via the
-	// ErrLastSystemAdmin classification, not a generic 500.
+	// op is the only approved system_admin; demoting it must map to 400, not 500.
 	op := approvedUser("op@eukarya.io")
 	require.NoError(t, op.SetRole(adminuser.RoleSystemAdmin))
 	repo := memory.NewAdminUserWith(op)

--- a/server/internal/admin/presentation/handler/adminuser/response.go
+++ b/server/internal/admin/presentation/handler/adminuser/response.go
@@ -12,6 +12,7 @@ type AdminUserResponse struct {
 	Email      string     `json:"email"`
 	Name       string     `json:"name"`
 	PictureURL string     `json:"pictureUrl"`
+	Role       string     `json:"role,omitempty"`
 	Status     string     `json:"status"`
 	ApprovedBy string     `json:"approvedBy,omitempty"`
 	ApprovedAt *time.Time `json:"approvedAt,omitempty"`
@@ -33,6 +34,7 @@ func newAdminUserResponse(u *adminuser.AdminUser) AdminUserResponse {
 		Email:      u.Email(),
 		Name:       u.Name(),
 		PictureURL: u.PictureURL(),
+		Role:       u.Role().String(),
 		Status:     u.Status().String(),
 		CreatedAt:  u.CreatedAt(),
 		UpdatedAt:  u.UpdatedAt(),

--- a/server/internal/admin/presentation/handler/adminuser/response.go
+++ b/server/internal/admin/presentation/handler/adminuser/response.go
@@ -12,7 +12,7 @@ type AdminUserResponse struct {
 	Email      string     `json:"email"`
 	Name       string     `json:"name"`
 	PictureURL string     `json:"pictureUrl"`
-	Role       string     `json:"role,omitempty"`
+	Role       string     `json:"role"`
 	Status     string     `json:"status"`
 	ApprovedBy string     `json:"approvedBy,omitempty"`
 	ApprovedAt *time.Time `json:"approvedAt,omitempty"`

--- a/server/internal/admin/presentation/router.go
+++ b/server/internal/admin/presentation/router.go
@@ -38,6 +38,7 @@ func RegisterRoutes(e *echo.Echo, h *Handler) {
 		adminUsers.GET("", h.AdminUser.ListAdminUsers, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionList))
 		adminUsers.POST("/:id/approve", h.AdminUser.ApproveAdminUser, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionApprove))
 		adminUsers.POST("/:id/reject", h.AdminUser.RejectAdminUser, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionReject))
+		adminUsers.PUT("/:id/roles", h.AdminUser.SetAdminUserRole, mw.RequirePermission(h.Checker, adminrbac.ResourceAdminUser, adminrbac.ActionAssignRole))
 
 		// Users (requires an approved admin session)
 		users := v1.Group("/users", requireApproved)

--- a/server/internal/admin/usecase/adminuseruc/errors.go
+++ b/server/internal/admin/usecase/adminuseruc/errors.go
@@ -12,4 +12,7 @@ var (
 	// ErrLastApprovedAdmin is returned when rejecting would remove the last
 	// approved admin.
 	ErrLastApprovedAdmin = rerror.NewE(i18n.T("cannot reject the last approved admin"))
+	// ErrLastSystemAdmin is returned when demoting would remove the last
+	// system admin.
+	ErrLastSystemAdmin = rerror.NewE(i18n.T("cannot demote the last system admin"))
 )

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -68,10 +68,14 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID admi
 			for _, u := range list {
 				if u.Role() == adminuser.RoleSystemAdmin {
 					count++
+					// count includes the target itself; >= 2 means another
+					// approved system_admin exists, so the demotion is safe and
+					// we can stop scanning entirely.
+					if count >= 2 {
+						break
+					}
 				}
 			}
-			// count includes the target itself; >= 2 means another approved
-			// system_admin exists, so the demotion is safe and we can stop paging.
 			if count >= 2 || len(list) < pageSize {
 				break
 			}

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -26,8 +26,11 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID admi
 		return nil, err
 	}
 
-	// Demoting a system_admin must never drop the count of system_admins to zero
-	// (otherwise nobody could ever assign roles again).
+	// Demoting an approved system_admin must never drop the count of approved
+	// system_admins to zero (otherwise nobody could ever assign roles again).
+	// Only approved system_admins count toward the minimum, so demoting a
+	// rejected/pending system_admin is always allowed: such a target isn't part
+	// of the approved set the count is taken over.
 	//
 	// NOTE: this is a check-then-act guard, not atomic. Two system_admins
 	// demoting each other at the exact same moment could both observe two
@@ -37,22 +40,33 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID admi
 	// it's actually needed.
 	//
 	// The repo List filter only supports Status (not Role) today, so we count
-	// system_admins in-memory from the approved set. This is acceptable for the
-	// tiny closed admin set; a follow-up can use an efficient role filter once the
-	// repo supports it.
-	if target.Role() == adminuser.RoleSystemAdmin && role != adminuser.RoleSystemAdmin {
+	// system_admins in-memory from the approved set, paging through it until
+	// exhaustion to avoid silently truncating a large set. We only need to know
+	// whether another approved system_admin exists besides the target, so we exit
+	// early once a second one is found. This is acceptable for the tiny closed
+	// admin set; a follow-up can use an efficient role filter once the repo
+	// supports it.
+	if target.IsApproved() && target.Role() == adminuser.RoleSystemAdmin && role != adminuser.RoleSystemAdmin {
 		approved := adminuser.StatusApproved
-		list, _, err := uc.repo.List(ctx, adminuser.ListFilter{
-			Status:     &approved,
-			Pagination: usecasex.OffsetPagination{Offset: 0, Limit: 1000}.Wrap(),
-		})
-		if err != nil {
-			return nil, err
-		}
+		const pageSize = 100
 		count := 0
-		for _, u := range list {
-			if u.Role() == adminuser.RoleSystemAdmin {
-				count++
+		for offset := 0; ; offset += pageSize {
+			list, _, err := uc.repo.List(ctx, adminuser.ListFilter{
+				Status:     &approved,
+				Pagination: usecasex.OffsetPagination{Offset: int64(offset), Limit: pageSize}.Wrap(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, u := range list {
+				if u.Role() == adminuser.RoleSystemAdmin {
+					count++
+				}
+			}
+			// count includes the target itself; >= 2 means another approved
+			// system_admin exists, so the demotion is safe and we can stop paging.
+			if count >= 2 || len(list) < pageSize {
+				break
 			}
 		}
 		// count includes the target itself; <= 1 means the target is the only

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -17,14 +17,11 @@ func NewSetRoleUseCase(repo adminuser.Repo) *SetRoleUseCase {
 	return &SetRoleUseCase{repo: repo}
 }
 
-// Execute assigns role to the target admin user. Unlike approve/reject, changing
-// one's own role is allowed, so the operator is intentionally unused (the RBAC
-// check happens in the middleware); the zero-system_admin guard below still
-// prevents the last system_admin from demoting themselves.
+// Execute assigns role to the target admin user. Self-role changes are allowed
+// (RBAC is enforced in the middleware), but the last approved system_admin
+// cannot be demoted.
 func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
-	// Validate the requested role before anything else so a bad input is
-	// reported as ErrInvalidRole regardless of target state (otherwise the
-	// demotion guard below could mask it with ErrLastSystemAdmin).
+	// Validate before loading the target so a bad input maps to ErrInvalidRole.
 	if !role.Valid() {
 		return nil, adminuser.ErrInvalidRole
 	}
@@ -34,26 +31,9 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID,
 		return nil, err
 	}
 
-	// Demoting an approved system_admin must never drop the count of approved
-	// system_admins to zero (otherwise nobody could ever assign roles again).
-	// Only approved system_admins count toward the minimum, so demoting a
-	// rejected/pending system_admin is always allowed: such a target isn't part
-	// of the approved set the count is taken over.
-	//
-	// NOTE: this is a check-then-act guard, not atomic. Two system_admins
-	// demoting each other at the exact same moment could both observe two
-	// system_admins and both succeed, leaving zero. Given the admin set is a tiny
-	// closed group (Eukarya employees) this race is acceptable for V1; enforcing
-	// it atomically would require backend-specific locking and is deferred until
-	// it's actually needed.
-	//
-	// The repo List filter only supports Status (not Role) today, so we count
-	// system_admins in-memory from the approved set, paging through it until
-	// exhaustion to avoid silently truncating a large set. We only need to know
-	// whether another approved system_admin exists besides the target, so we exit
-	// early once a second one is found. This is acceptable for the tiny closed
-	// admin set; a follow-up can use an efficient role filter once the repo
-	// supports it.
+	// Demoting an approved system_admin is blocked if it is the last one. Count
+	// approved system_admins by paging the approved set until a second one is
+	// found (check-then-act, not atomic; acceptable for the tiny admin set).
 	if target.IsApproved() && target.Role() == adminuser.RoleSystemAdmin && role != adminuser.RoleSystemAdmin {
 		approved := adminuser.StatusApproved
 		const pageSize = 100
@@ -69,9 +49,7 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID,
 			for _, u := range list {
 				if u.Role() == adminuser.RoleSystemAdmin {
 					count++
-					// count includes the target itself; >= 2 means another
-					// approved system_admin exists, so the demotion is safe and
-					// we can stop scanning entirely.
+					// count includes the target; >= 2 means the demotion is safe.
 					if count >= 2 {
 						break
 					}
@@ -81,8 +59,7 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID,
 				break
 			}
 		}
-		// count includes the target itself; <= 1 means the target is the only
-		// approved system_admin.
+		// <= 1 means the target is the only approved system_admin.
 		if count <= 1 {
 			return nil, ErrLastSystemAdmin
 		}

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -9,24 +9,30 @@ import (
 
 // SetRoleUseCase assigns a role to an admin user.
 type SetRoleUseCase struct {
-	repo adminuser.Repo
+	adminUserRepo adminuser.Repo
 }
 
 // NewSetRoleUseCase is a Wire provider for SetRoleUseCase.
-func NewSetRoleUseCase(repo adminuser.Repo) *SetRoleUseCase {
-	return &SetRoleUseCase{repo: repo}
+func NewSetRoleUseCase(adminUserRepo adminuser.Repo) *SetRoleUseCase {
+	return &SetRoleUseCase{adminUserRepo: adminUserRepo}
 }
 
-// Execute assigns role to the target admin user. Self-role changes are allowed
+// SetRoleInput is the input for SetRoleUseCase.Execute.
+type SetRoleInput struct {
+	TargetID adminuser.ID
+	Role     adminuser.Role
+}
+
+// Execute assigns a role to the target admin user. Self-role changes are allowed
 // (RBAC is enforced in the middleware), but the last approved system_admin
 // cannot be demoted.
-func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
+func (uc *SetRoleUseCase) Execute(ctx context.Context, in SetRoleInput) (*adminuser.AdminUser, error) {
 	// Validate before loading the target so a bad input maps to ErrInvalidRole.
-	if !role.Valid() {
+	if !in.Role.Valid() {
 		return nil, adminuser.ErrInvalidRole
 	}
 
-	target, err := uc.repo.FindByID(ctx, targetID)
+	target, err := uc.adminUserRepo.FindByID(ctx, in.TargetID)
 	if err != nil {
 		return nil, err
 	}
@@ -34,12 +40,12 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID,
 	// Demoting an approved system_admin is blocked if it is the last one. Count
 	// approved system_admins by paging the approved set until a second one is
 	// found (check-then-act, not atomic; acceptable for the tiny admin set).
-	if target.IsApproved() && target.Role() == adminuser.RoleSystemAdmin && role != adminuser.RoleSystemAdmin {
+	if target.IsApproved() && target.Role() == adminuser.RoleSystemAdmin && in.Role != adminuser.RoleSystemAdmin {
 		approved := adminuser.StatusApproved
 		const pageSize = 100
 		count := 0
 		for offset := 0; ; offset += pageSize {
-			list, _, err := uc.repo.List(ctx, adminuser.ListFilter{
+			list, _, err := uc.adminUserRepo.List(ctx, adminuser.ListFilter{
 				Status:     &approved,
 				Pagination: usecasex.OffsetPagination{Offset: int64(offset), Limit: pageSize}.Wrap(),
 			})
@@ -65,10 +71,10 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID,
 		}
 	}
 
-	if err := target.SetRole(role); err != nil {
+	if err := target.SetRole(in.Role); err != nil {
 		return nil, err
 	}
-	if err := uc.repo.Save(ctx, target); err != nil {
+	if err := uc.adminUserRepo.Save(ctx, target); err != nil {
 		return nil, err
 	}
 	return target, nil

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -1,0 +1,72 @@
+package adminuseruc
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/usecasex"
+)
+
+// SetRoleUseCase assigns a role to an admin user.
+type SetRoleUseCase struct {
+	repo adminuser.Repo
+}
+
+// NewSetRoleUseCase is a Wire provider for SetRoleUseCase.
+func NewSetRoleUseCase(repo adminuser.Repo) *SetRoleUseCase {
+	return &SetRoleUseCase{repo: repo}
+}
+
+// Execute assigns role to the target admin user. Unlike approve/reject, changing
+// one's own role is allowed; the zero-system_admin guard below still prevents the
+// last system_admin from demoting themselves.
+func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
+	target, err := uc.repo.FindByID(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Demoting a system_admin must never drop the count of system_admins to zero
+	// (otherwise nobody could ever assign roles again).
+	//
+	// NOTE: this is a check-then-act guard, not atomic. Two system_admins
+	// demoting each other at the exact same moment could both observe two
+	// system_admins and both succeed, leaving zero. Given the admin set is a tiny
+	// closed group (Eukarya employees) this race is acceptable for V1; enforcing
+	// it atomically would require backend-specific locking and is deferred until
+	// it's actually needed.
+	//
+	// The repo List filter only supports Status (not Role) today, so we count
+	// system_admins in-memory from the approved set. This is acceptable for the
+	// tiny closed admin set; a follow-up can use an efficient role filter once the
+	// repo supports it.
+	if target.Role() == adminuser.RoleSystemAdmin && role != adminuser.RoleSystemAdmin {
+		approved := adminuser.StatusApproved
+		list, _, err := uc.repo.List(ctx, adminuser.ListFilter{
+			Status:     &approved,
+			Pagination: usecasex.OffsetPagination{Offset: 0, Limit: 1000}.Wrap(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		count := 0
+		for _, u := range list {
+			if u.Role() == adminuser.RoleSystemAdmin {
+				count++
+			}
+		}
+		// count includes the target itself; <= 1 means the target is the only
+		// approved system_admin.
+		if count <= 1 {
+			return nil, ErrLastSystemAdmin
+		}
+	}
+
+	if err := target.SetRole(role); err != nil {
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
-	"github.com/reearth/reearthx/usecasex"
 )
 
 // SetRoleUseCase assigns a role to an admin user.
@@ -37,36 +36,14 @@ func (uc *SetRoleUseCase) Execute(ctx context.Context, in SetRoleInput) (*adminu
 		return nil, err
 	}
 
-	// Demoting an approved system_admin is blocked if it is the last one. Count
-	// approved system_admins by paging the approved set until a second one is
-	// found (check-then-act, not atomic; acceptable for the tiny admin set).
+	// Demoting an approved system_admin is blocked if it is the last one
+	// (check-then-act, not atomic; acceptable for the tiny closed admin set).
 	if target.IsApproved() && target.Role() == adminuser.RoleSystemAdmin && in.Role != adminuser.RoleSystemAdmin {
-		approved := adminuser.StatusApproved
-		const pageSize = 100
-		count := 0
-		for offset := 0; ; offset += pageSize {
-			list, _, err := uc.adminUserRepo.List(ctx, adminuser.ListFilter{
-				Status:     &approved,
-				Pagination: usecasex.OffsetPagination{Offset: int64(offset), Limit: pageSize}.Wrap(),
-			})
-			if err != nil {
-				return nil, err
-			}
-			for _, u := range list {
-				if u.Role() == adminuser.RoleSystemAdmin {
-					count++
-					// count includes the target; >= 2 means the demotion is safe.
-					if count >= 2 {
-						break
-					}
-				}
-			}
-			if count >= 2 || len(list) < pageSize {
-				break
-			}
+		hasOther, err := uc.adminUserRepo.ExistsApprovedSystemAdminExcept(ctx, target.ID())
+		if err != nil {
+			return nil, err
 		}
-		// <= 1 means the target is the only approved system_admin.
-		if count <= 1 {
+		if !hasOther {
 			return nil, ErrLastSystemAdmin
 		}
 	}

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -21,6 +21,13 @@ func NewSetRoleUseCase(repo adminuser.Repo) *SetRoleUseCase {
 // one's own role is allowed; the zero-system_admin guard below still prevents the
 // last system_admin from demoting themselves.
 func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
+	// Validate the requested role before anything else so a bad input is
+	// reported as ErrInvalidRole regardless of target state (otherwise the
+	// demotion guard below could mask it with ErrLastSystemAdmin).
+	if !role.Valid() {
+		return nil, adminuser.ErrInvalidRole
+	}
+
 	target, err := uc.repo.FindByID(ctx, targetID)
 	if err != nil {
 		return nil, err

--- a/server/internal/admin/usecase/adminuseruc/set_role.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role.go
@@ -18,9 +18,10 @@ func NewSetRoleUseCase(repo adminuser.Repo) *SetRoleUseCase {
 }
 
 // Execute assigns role to the target admin user. Unlike approve/reject, changing
-// one's own role is allowed; the zero-system_admin guard below still prevents the
-// last system_admin from demoting themselves.
-func (uc *SetRoleUseCase) Execute(ctx context.Context, operatorID, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
+// one's own role is allowed, so the operator is intentionally unused (the RBAC
+// check happens in the middleware); the zero-system_admin guard below still
+// prevents the last system_admin from demoting themselves.
+func (uc *SetRoleUseCase) Execute(ctx context.Context, _, targetID adminuser.ID, role adminuser.Role) (*adminuser.AdminUser, error) {
 	// Validate the requested role before anything else so a bad input is
 	// reported as ErrInvalidRole regardless of target state (otherwise the
 	// demotion guard below could mask it with ErrLastSystemAdmin).

--- a/server/internal/admin/usecase/adminuseruc/set_role_test.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role_test.go
@@ -1,0 +1,83 @@
+package adminuseruc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/adminuser"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func approvedWithRole(email string, role adminuser.Role) *adminuser.AdminUser {
+	u := approved(email)
+	if err := u.SetRole(role); err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestSetRole_DemoteSystemAdmin_OK(t *testing.T) {
+	ctx := context.Background()
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	target := approvedWithRole("target@eukarya.io", adminuser.RoleSystemAdmin)
+	other := approvedWithRole("other@eukarya.io", adminuser.RoleSystemAdmin)
+	repo := memory.NewAdminUserWith(operator, target, other)
+	uc := NewSetRoleUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleViewer)
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, got.Role())
+
+	reloaded, err := repo.FindByID(ctx, target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, reloaded.Role())
+}
+
+func TestSetRole_DemoteLastSystemAdminBlocked(t *testing.T) {
+	ctx := context.Background()
+	// target is the only approved system_admin; the other approved admin is a
+	// viewer, so demoting target would leave zero system_admins.
+	target := approvedWithRole("solo@eukarya.io", adminuser.RoleSystemAdmin)
+	viewer := approvedWithRole("viewer@eukarya.io", adminuser.RoleViewer)
+	repo := memory.NewAdminUserWith(target, viewer)
+	uc := NewSetRoleUseCase(repo)
+
+	_, err := uc.Execute(ctx, target.ID(), target.ID(), adminuser.RoleViewer)
+	assert.ErrorIs(t, err, ErrLastSystemAdmin)
+}
+
+func TestSetRole_PromoteViewer_OK(t *testing.T) {
+	ctx := context.Background()
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	target := approvedWithRole("target@eukarya.io", adminuser.RoleViewer)
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewSetRoleUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleSystemAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleSystemAdmin, got.Role())
+}
+
+func TestSetRole_InvalidRole(t *testing.T) {
+	ctx := context.Background()
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	target := approvedWithRole("target@eukarya.io", adminuser.RoleViewer)
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewSetRoleUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.Role("bogus"))
+	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
+}
+
+func TestSetRole_NotFound(t *testing.T) {
+	ctx := context.Background()
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewSetRoleUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), adminuser.NewID(), adminuser.RoleViewer)
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+}

--- a/server/internal/admin/usecase/adminuseruc/set_role_test.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role_test.go
@@ -19,6 +19,14 @@ func approvedWithRole(email string, role adminuser.Role) *adminuser.AdminUser {
 	return u
 }
 
+func rejectedWithRole(email string, role adminuser.Role) *adminuser.AdminUser {
+	u := adminuser.New().NewID().Name(email).Email(email).Status(adminuser.StatusRejected).MustBuild()
+	if err := u.SetRole(role); err != nil {
+		panic(err)
+	}
+	return u
+}
+
 func TestSetRole_DemoteSystemAdmin_OK(t *testing.T) {
 	ctx := context.Background()
 	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
@@ -47,6 +55,26 @@ func TestSetRole_DemoteLastSystemAdminBlocked(t *testing.T) {
 
 	_, err := uc.Execute(ctx, target.ID(), target.ID(), adminuser.RoleViewer)
 	assert.ErrorIs(t, err, ErrLastSystemAdmin)
+}
+
+func TestSetRole_DemoteRejectedSystemAdmin_OK(t *testing.T) {
+	ctx := context.Background()
+	// The operator is the only approved system_admin; target is a rejected
+	// system_admin. Rejected admins aren't part of the approved set, so demoting
+	// target must not trip the last-system_admin guard even though there is only
+	// one approved system_admin.
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	target := rejectedWithRole("target@eukarya.io", adminuser.RoleSystemAdmin)
+	repo := memory.NewAdminUserWith(operator, target)
+	uc := NewSetRoleUseCase(repo)
+
+	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleViewer)
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, got.Role())
+
+	reloaded, err := repo.FindByID(ctx, target.ID())
+	require.NoError(t, err)
+	assert.Equal(t, adminuser.RoleViewer, reloaded.Role())
 }
 
 func TestSetRole_PromoteViewer_OK(t *testing.T) {

--- a/server/internal/admin/usecase/adminuseruc/set_role_test.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role_test.go
@@ -100,6 +100,18 @@ func TestSetRole_InvalidRole(t *testing.T) {
 	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
 }
 
+// An invalid role must be reported as ErrInvalidRole even when the target is the
+// only approved system_admin — input validation runs before the demotion guard.
+func TestSetRole_InvalidRole_LastSystemAdmin(t *testing.T) {
+	ctx := context.Background()
+	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
+	repo := memory.NewAdminUserWith(operator)
+	uc := NewSetRoleUseCase(repo)
+
+	_, err := uc.Execute(ctx, operator.ID(), operator.ID(), adminuser.Role("bogus"))
+	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
+}
+
 func TestSetRole_NotFound(t *testing.T) {
 	ctx := context.Background()
 	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)

--- a/server/internal/admin/usecase/adminuseruc/set_role_test.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role_test.go
@@ -46,8 +46,7 @@ func TestSetRole_DemoteSystemAdmin_OK(t *testing.T) {
 
 func TestSetRole_DemoteLastSystemAdminBlocked(t *testing.T) {
 	ctx := context.Background()
-	// target is the only approved system_admin; the other approved admin is a
-	// viewer, so demoting target would leave zero system_admins.
+	// target is the only approved system_admin, so demoting it is blocked.
 	target := approvedWithRole("solo@eukarya.io", adminuser.RoleSystemAdmin)
 	viewer := approvedWithRole("viewer@eukarya.io", adminuser.RoleViewer)
 	repo := memory.NewAdminUserWith(target, viewer)
@@ -59,10 +58,7 @@ func TestSetRole_DemoteLastSystemAdminBlocked(t *testing.T) {
 
 func TestSetRole_DemoteRejectedSystemAdmin_OK(t *testing.T) {
 	ctx := context.Background()
-	// The operator is the only approved system_admin; target is a rejected
-	// system_admin. Rejected admins aren't part of the approved set, so demoting
-	// target must not trip the last-system_admin guard even though there is only
-	// one approved system_admin.
+	// target is a rejected system_admin, so it isn't counted and demotion is allowed.
 	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)
 	target := rejectedWithRole("target@eukarya.io", adminuser.RoleSystemAdmin)
 	repo := memory.NewAdminUserWith(operator, target)
@@ -100,8 +96,7 @@ func TestSetRole_InvalidRole(t *testing.T) {
 	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
 }
 
-// An invalid role must be reported as ErrInvalidRole even when the target is the
-// only approved system_admin — input validation runs before the demotion guard.
+// An invalid role is reported as ErrInvalidRole even for the last system_admin.
 func TestSetRole_InvalidRole_LastSystemAdmin(t *testing.T) {
 	ctx := context.Background()
 	operator := approvedWithRole("op@eukarya.io", adminuser.RoleSystemAdmin)

--- a/server/internal/admin/usecase/adminuseruc/set_role_test.go
+++ b/server/internal/admin/usecase/adminuseruc/set_role_test.go
@@ -35,7 +35,7 @@ func TestSetRole_DemoteSystemAdmin_OK(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator, target, other)
 	uc := NewSetRoleUseCase(repo)
 
-	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleViewer)
+	got, err := uc.Execute(ctx, SetRoleInput{TargetID: target.ID(), Role: adminuser.RoleViewer})
 	require.NoError(t, err)
 	assert.Equal(t, adminuser.RoleViewer, got.Role())
 
@@ -52,7 +52,7 @@ func TestSetRole_DemoteLastSystemAdminBlocked(t *testing.T) {
 	repo := memory.NewAdminUserWith(target, viewer)
 	uc := NewSetRoleUseCase(repo)
 
-	_, err := uc.Execute(ctx, target.ID(), target.ID(), adminuser.RoleViewer)
+	_, err := uc.Execute(ctx, SetRoleInput{TargetID: target.ID(), Role: adminuser.RoleViewer})
 	assert.ErrorIs(t, err, ErrLastSystemAdmin)
 }
 
@@ -64,7 +64,7 @@ func TestSetRole_DemoteRejectedSystemAdmin_OK(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator, target)
 	uc := NewSetRoleUseCase(repo)
 
-	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleViewer)
+	got, err := uc.Execute(ctx, SetRoleInput{TargetID: target.ID(), Role: adminuser.RoleViewer})
 	require.NoError(t, err)
 	assert.Equal(t, adminuser.RoleViewer, got.Role())
 
@@ -80,7 +80,7 @@ func TestSetRole_PromoteViewer_OK(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator, target)
 	uc := NewSetRoleUseCase(repo)
 
-	got, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.RoleSystemAdmin)
+	got, err := uc.Execute(ctx, SetRoleInput{TargetID: target.ID(), Role: adminuser.RoleSystemAdmin})
 	require.NoError(t, err)
 	assert.Equal(t, adminuser.RoleSystemAdmin, got.Role())
 }
@@ -92,7 +92,7 @@ func TestSetRole_InvalidRole(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator, target)
 	uc := NewSetRoleUseCase(repo)
 
-	_, err := uc.Execute(ctx, operator.ID(), target.ID(), adminuser.Role("bogus"))
+	_, err := uc.Execute(ctx, SetRoleInput{TargetID: target.ID(), Role: adminuser.Role("bogus")})
 	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
 }
 
@@ -103,7 +103,7 @@ func TestSetRole_InvalidRole_LastSystemAdmin(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator)
 	uc := NewSetRoleUseCase(repo)
 
-	_, err := uc.Execute(ctx, operator.ID(), operator.ID(), adminuser.Role("bogus"))
+	_, err := uc.Execute(ctx, SetRoleInput{TargetID: operator.ID(), Role: adminuser.Role("bogus")})
 	assert.ErrorIs(t, err, adminuser.ErrInvalidRole)
 }
 
@@ -113,6 +113,6 @@ func TestSetRole_NotFound(t *testing.T) {
 	repo := memory.NewAdminUserWith(operator)
 	uc := NewSetRoleUseCase(repo)
 
-	_, err := uc.Execute(ctx, operator.ID(), adminuser.NewID(), adminuser.RoleViewer)
+	_, err := uc.Execute(ctx, SetRoleInput{TargetID: adminuser.NewID(), Role: adminuser.RoleViewer})
 	assert.ErrorIs(t, err, rerror.ErrNotFound)
 }

--- a/server/internal/admin/usecase/authuc/signin_test.go
+++ b/server/internal/admin/usecase/authuc/signin_test.go
@@ -137,6 +137,9 @@ func (r *raceRepo) FindByIDs(context.Context, adminuser.IDList) (adminuser.List,
 func (r *raceRepo) List(context.Context, adminuser.ListFilter) (adminuser.List, *usecasex.PageInfo, error) {
 	return nil, nil, nil
 }
+func (r *raceRepo) ExistsApprovedSystemAdminExcept(context.Context, adminuser.ID) (bool, error) {
+	return false, nil
+}
 func (r *raceRepo) Save(_ context.Context, u *adminuser.AdminUser) error {
 	r.existing = u
 	return adminuser.ErrDuplicatedAdminUser

--- a/server/internal/infrastructure/memory/adminuser.go
+++ b/server/internal/infrastructure/memory/adminuser.go
@@ -112,6 +112,21 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 	return page, usecasex.NewPageInfo(total, nil, nil, hasNext, hasPrev), nil
 }
 
+func (r *AdminUser) ExistsApprovedSystemAdminExcept(ctx context.Context, excludeID adminuser.ID) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for id, v := range r.data {
+		if id == excludeID {
+			continue
+		}
+		if v.Status() == adminuser.StatusApproved && v.Role() == adminuser.RoleSystemAdmin {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (r *AdminUser) Save(ctx context.Context, u *adminuser.AdminUser) error {
 	if u == nil {
 		return nil

--- a/server/internal/infrastructure/memory/adminuser_test.go
+++ b/server/internal/infrastructure/memory/adminuser_test.go
@@ -107,7 +107,8 @@ func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
 
 	r := NewAdminUserWith(sysAdmin, viewer, pendingSys)
 
-	// excluding the only approved system_admin -> none left
+	// excluding the only approved system_admin -> none left (pendingSys is a
+	// system_admin but not approved, so it must not be counted here)
 	got, err := r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
 	assert.NoError(t, err)
 	assert.False(t, got)
@@ -116,11 +117,6 @@ func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
 	got, err = r.ExistsApprovedSystemAdminExcept(ctx, viewer.ID())
 	assert.NoError(t, err)
 	assert.True(t, got)
-
-	// a pending system_admin is not counted, so excluding sysAdmin still yields none
-	got, err = r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
-	assert.NoError(t, err)
-	assert.False(t, got)
 }
 
 func TestAdminUser_List_Pagination(t *testing.T) {

--- a/server/internal/infrastructure/memory/adminuser_test.go
+++ b/server/internal/infrastructure/memory/adminuser_test.go
@@ -95,6 +95,34 @@ func TestAdminUser_List_RejectsCursorPagination(t *testing.T) {
 	assert.ErrorIs(t, err, adminuser.ErrCursorPaginationUnsupported)
 }
 
+func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
+	ctx := context.Background()
+
+	sysAdmin := adminuser.New().NewID().Name("sys").Email("sys@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin).MustBuild()
+	viewer := adminuser.New().NewID().Name("viewer").Email("viewer@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleViewer).MustBuild()
+	pendingSys := adminuser.New().NewID().Name("pending").Email("pending@eukarya.io").
+		Status(adminuser.StatusPending).Role(adminuser.RoleSystemAdmin).MustBuild()
+
+	r := NewAdminUserWith(sysAdmin, viewer, pendingSys)
+
+	// excluding the only approved system_admin -> none left
+	got, err := r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
+	assert.NoError(t, err)
+	assert.False(t, got)
+
+	// excluding a viewer -> the approved system_admin still counts
+	got, err = r.ExistsApprovedSystemAdminExcept(ctx, viewer.ID())
+	assert.NoError(t, err)
+	assert.True(t, got)
+
+	// a pending system_admin is not counted, so excluding sysAdmin still yields none
+	got, err = r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
+	assert.NoError(t, err)
+	assert.False(t, got)
+}
+
 func TestAdminUser_List_Pagination(t *testing.T) {
 	ctx := context.Background()
 	u1 := adminuser.New().NewID().Name("1").Email("1@eukarya.io").MustBuild()

--- a/server/internal/infrastructure/mongo/adminuser.go
+++ b/server/internal/infrastructure/mongo/adminuser.go
@@ -64,6 +64,19 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 	return c.Result, pageInfo, nil
 }
 
+func (r *AdminUser) ExistsApprovedSystemAdminExcept(ctx context.Context, excludeID adminuser.ID) (bool, error) {
+	filter := bson.M{
+		"status": adminuser.StatusApproved.String(),
+		"role":   adminuser.RoleSystemAdmin.String(),
+		"id":     bson.M{"$ne": excludeID.String()},
+	}
+	n, err := r.client.Count(ctx, filter)
+	if err != nil {
+		return false, rerror.ErrInternalBy(err)
+	}
+	return n > 0, nil
+}
+
 func (r *AdminUser) Save(ctx context.Context, u *adminuser.AdminUser) error {
 	if u == nil {
 		return nil

--- a/server/internal/infrastructure/mongo/adminuser_test.go
+++ b/server/internal/infrastructure/mongo/adminuser_test.go
@@ -112,3 +112,29 @@ func TestAdminUser_List(t *testing.T) {
 	assert.Equal(t, "p2@eukarya.io", got[1].Email())
 	assert.Equal(t, int64(2), pi.TotalCount)
 }
+
+func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
+	c := Connect(t)(t)
+	ctx := context.Background()
+	r := NewAdminUser(mongox.NewClientWithDatabase(c))
+
+	sysAdmin := adminuser.New().NewID().Name("sys").Email("sys@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin).MustBuild()
+	viewer := adminuser.New().NewID().Name("viewer").Email("viewer@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleViewer).MustBuild()
+	pendingSys := adminuser.New().NewID().Name("pending").Email("pending@eukarya.io").
+		Status(adminuser.StatusPending).Role(adminuser.RoleSystemAdmin).MustBuild()
+	assert.NoError(t, r.Save(ctx, sysAdmin))
+	assert.NoError(t, r.Save(ctx, viewer))
+	assert.NoError(t, r.Save(ctx, pendingSys))
+
+	// excluding the only approved system_admin -> none left
+	got, err := r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
+	assert.NoError(t, err)
+	assert.False(t, got)
+
+	// excluding a viewer -> the approved system_admin still counts
+	got, err = r.ExistsApprovedSystemAdminExcept(ctx, viewer.ID())
+	assert.NoError(t, err)
+	assert.True(t, got)
+}

--- a/server/internal/infrastructure/postgres/adminuser.go
+++ b/server/internal/infrastructure/postgres/adminuser.go
@@ -145,6 +145,17 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 	return list, usecasex.NewPageInfo(total, nil, nil, hasNext, hasPrev), nil
 }
 
+func (r *AdminUser) ExistsApprovedSystemAdminExcept(ctx context.Context, excludeID adminuser.ID) (bool, error) {
+	const q = `SELECT EXISTS(SELECT 1 FROM admin_users WHERE status = $1 AND role = $2 AND id <> $3)`
+	var exists bool
+	if err := r.c.db(ctx).QueryRow(ctx, q,
+		adminuser.StatusApproved.String(), adminuser.RoleSystemAdmin.String(), excludeID.String(),
+	).Scan(&exists); err != nil {
+		return false, rerror.ErrInternalByWithContext(ctx, err)
+	}
+	return exists, nil
+}
+
 func (r *AdminUser) Save(ctx context.Context, u *adminuser.AdminUser) error {
 	if u == nil {
 		return nil

--- a/server/internal/infrastructure/postgres/adminuser_test.go
+++ b/server/internal/infrastructure/postgres/adminuser_test.go
@@ -129,3 +129,30 @@ func TestAdminUser_List(t *testing.T) {
 	assert.True(t, pi.HasNextPage)
 	assert.True(t, pi.HasPreviousPage)
 }
+
+func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
+	pool, cleanup := pgPool(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewAdminUser(NewClient(pool))
+
+	sysAdmin := adminuser.New().NewID().Name("sys").Email("sys@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleSystemAdmin).MustBuild()
+	viewer := adminuser.New().NewID().Name("viewer").Email("viewer@eukarya.io").
+		Status(adminuser.StatusApproved).Role(adminuser.RoleViewer).MustBuild()
+	pendingSys := adminuser.New().NewID().Name("pending").Email("pending@eukarya.io").
+		Status(adminuser.StatusPending).Role(adminuser.RoleSystemAdmin).MustBuild()
+	require.NoError(t, r.Save(ctx, sysAdmin))
+	require.NoError(t, r.Save(ctx, viewer))
+	require.NoError(t, r.Save(ctx, pendingSys))
+
+	// excluding the only approved system_admin -> none left
+	got, err := r.ExistsApprovedSystemAdminExcept(ctx, sysAdmin.ID())
+	require.NoError(t, err)
+	assert.False(t, got)
+
+	// excluding a viewer -> the approved system_admin still counts
+	got, err = r.ExistsApprovedSystemAdminExcept(ctx, viewer.ID())
+	require.NoError(t, err)
+	assert.True(t, got)
+}

--- a/server/pkg/adminuser/mock_adminuser.go
+++ b/server/pkg/adminuser/mock_adminuser.go
@@ -41,6 +41,21 @@ func (m *MockRepo) EXPECT() *MockRepoMockRecorder {
 	return m.recorder
 }
 
+// ExistsApprovedSystemAdminExcept mocks base method.
+func (m *MockRepo) ExistsApprovedSystemAdminExcept(ctx context.Context, excludeID ID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistsApprovedSystemAdminExcept", ctx, excludeID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExistsApprovedSystemAdminExcept indicates an expected call of ExistsApprovedSystemAdminExcept.
+func (mr *MockRepoMockRecorder) ExistsApprovedSystemAdminExcept(ctx, excludeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistsApprovedSystemAdminExcept", reflect.TypeOf((*MockRepo)(nil).ExistsApprovedSystemAdminExcept), ctx, excludeID)
+}
+
 // FindByEmail mocks base method.
 func (m *MockRepo) FindByEmail(arg0 context.Context, arg1 string) (*AdminUser, error) {
 	m.ctrl.T.Helper()

--- a/server/pkg/adminuser/repo.go
+++ b/server/pkg/adminuser/repo.go
@@ -28,5 +28,8 @@ type Repo interface {
 	FindByID(context.Context, ID) (*AdminUser, error)
 	FindByIDs(context.Context, IDList) (List, error)
 	List(context.Context, ListFilter) (List, *usecasex.PageInfo, error)
+	// ExistsApprovedSystemAdminExcept reports whether an approved system_admin
+	// other than excludeID exists. Used to guard against demoting the last one.
+	ExistsApprovedSystemAdminExcept(ctx context.Context, excludeID ID) (bool, error)
 	Save(context.Context, *AdminUser) error
 }


### PR DESCRIPTION
## Why

Final feature slice of **granular admin permissions** (reearth-dashboard#1316; design in #281). Adds `PUT /api/v1/admin-users/:id/roles` so a system_admin can assign an admin's role.

## What's included

- **`SetRoleUseCase`**: assigns the target's role and guards that demoting a `system_admin` never drops the count of approved system_admins to zero (`ErrLastSystemAdmin`). Changing one's own role is allowed; the zero-guard still blocks the last system_admin from self-demoting. The guard delegates to `adminUserRepo.ExistsApprovedSystemAdminExcept(ctx, targetID)`, a dedicated Repo method backed by a DB-level check in each backend (memory scan, mongo `Count`, postgres `SELECT EXISTS`). This is a check-then-act guard (not atomic), mirroring `reject.go`'s caveat; acceptable for the tiny closed admin set (Eukarya staff).
- **Handler + route**: `SetAdminUserRole` wired behind `RequirePermission(admin_user, assign_role)` (system_admin only); regenerated wire and swagger.
- **`AdminUserResponse.role`**: the role is now returned by the admin-user responses (the PUT echoes the updated role; list/approve/reject include it too).

## Behavior

- Only `system_admin` can call this (enforced by the RBAC matrix + middleware from #283/#285).
- Invalid role / id → 400; last-system_admin demotion → blocked; not found → 404.

## Checklist

- [x] Verified backward compatibility (additive endpoint; role now surfaced in responses)
- [x] Confirmed backward compatibility for migrations (no migration)
- [x] Verified that no PII is included in displayed values (role is an enum string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
