### PR TITLE
feat(server): filter admin-user list by role (#1316)

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -17,7 +17,7 @@ const docTemplate = `{
     "paths": {
         "/admin-users": {
             "get": {
-                "description": "Lists admin users in creation order, optionally filtered by status, with offset pagination.",
+                "description": "Lists admin users in creation order, optionally filtered by status and/or role, with offset pagination.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -38,6 +38,16 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "system_admin",
+                            "viewer"
+                        ],
+                        "type": "string",
+                        "description": "Filter by role",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Page number (1-based)",
                         "name": "page",

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -10,7 +10,7 @@
     "paths": {
         "/admin-users": {
             "get": {
-                "description": "Lists admin users in creation order, optionally filtered by status, with offset pagination.",
+                "description": "Lists admin users in creation order, optionally filtered by status and/or role, with offset pagination.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -31,6 +31,16 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "system_admin",
+                            "viewer"
+                        ],
+                        "type": "string",
+                        "description": "Filter by role",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Page number (1-based)",
                         "name": "page",

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -203,6 +203,13 @@ paths:
         in: query
         name: status
         type: string
+      - description: Filter by role
+        enum:
+        - system_admin
+        - viewer
+        in: query
+        name: role
+        type: string
       - description: Page number (1-based)
         in: query
         name: page

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -192,8 +192,8 @@ info:
 paths:
   /admin-users:
     get:
-      description: Lists admin users in creation order, optionally filtered by status,
-        with offset pagination.
+      description: Lists admin users in creation order, optionally filtered by status
+        and/or role, with offset pagination.
       parameters:
       - description: Filter by status
         enum:

--- a/server/internal/admin/presentation/handler/adminuser/handler_list.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_list.go
@@ -12,7 +12,7 @@ import (
 // ListAdminUsers godoc
 //
 //	@Summary		List admin users
-//	@Description	Lists admin users in creation order, optionally filtered by status, with offset pagination.
+//	@Description	Lists admin users in creation order, optionally filtered by status and/or role, with offset pagination.
 //	@Tags			admin-users
 //	@Produce		json
 //	@Param			status		query		string	false	"Filter by status"	Enums(pending, approved, rejected)

--- a/server/internal/admin/presentation/handler/adminuser/handler_list.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_list.go
@@ -16,6 +16,7 @@ import (
 //	@Tags			admin-users
 //	@Produce		json
 //	@Param			status		query		string	false	"Filter by status"	Enums(pending, approved, rejected)
+//	@Param			role		query		string	false	"Filter by role"	Enums(system_admin, viewer)
 //	@Param			page		query		int		false	"Page number (1-based)"
 //	@Param			per_page	query		int		false	"Items per page (max 100)"
 //	@Success		200			{object}	ListAdminUsersResponse
@@ -32,6 +33,14 @@ func (h *Handler) ListAdminUsers(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid status")
 		}
 		filter.Status = &status
+	}
+
+	if v := c.QueryParam("role"); v != "" {
+		role, err := adminuser.RoleFrom(v)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		}
+		filter.Role = &role
 	}
 
 	page, err := internal.ParsePageParam(c.QueryParam("page"))

--- a/server/internal/admin/presentation/handler/adminuser/handler_test.go
+++ b/server/internal/admin/presentation/handler/adminuser/handler_test.go
@@ -94,6 +94,39 @@ func TestListAdminUsers_StatusFilter(t *testing.T) {
 	assert.Equal(t, "pending", body.Items[0].Status)
 }
 
+func TestListAdminUsers_RoleFilter(t *testing.T) {
+	op := adminuser.New().NewID().Name("op").Email("op@eukarya.io").Role(adminuser.RoleSystemAdmin).Status(adminuser.StatusApproved).MustBuild()
+	viewer := adminuser.New().NewID().Name("viewer").Email("viewer@eukarya.io").Role(adminuser.RoleViewer).Status(adminuser.StatusApproved).MustBuild()
+	repo := memory.NewAdminUserWith(op, viewer)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-users?role=viewer", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body adminuserhandler.ListAdminUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, int64(1), body.TotalCount)
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, "viewer@eukarya.io", body.Items[0].Email)
+}
+
+func TestListAdminUsers_InvalidRole(t *testing.T) {
+	op := approvedUser("op@eukarya.io")
+	repo := memory.NewAdminUserWith(op)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(repo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-users?role=bogus", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestListAdminUsers_InvalidStatus(t *testing.T) {
 	op := approvedUser("op@eukarya.io")
 	repo := memory.NewAdminUserWith(op)

--- a/server/internal/infrastructure/memory/adminuser.go
+++ b/server/internal/infrastructure/memory/adminuser.go
@@ -79,6 +79,9 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 		if f.Status != nil && v.Status() != *f.Status {
 			continue
 		}
+		if f.Role != nil && v.Role() != *f.Role {
+			continue
+		}
 		all = append(all, v)
 	}
 

--- a/server/internal/infrastructure/memory/adminuser_test.go
+++ b/server/internal/infrastructure/memory/adminuser_test.go
@@ -84,6 +84,43 @@ func TestAdminUser_List(t *testing.T) {
 	assert.Equal(t, int64(1), pi.TotalCount)
 }
 
+func TestAdminUser_List_RoleFilter(t *testing.T) {
+	ctx := context.Background()
+	admin := adminuser.New().NewID().Name("A").Email("a@eukarya.io").Role(adminuser.RoleSystemAdmin).Status(adminuser.StatusApproved).MustBuild()
+	viewer := adminuser.New().NewID().Name("V").Email("v@eukarya.io").Role(adminuser.RoleViewer).Status(adminuser.StatusApproved).MustBuild()
+	pendingViewer := adminuser.New().NewID().Name("PV").Email("pv@eukarya.io").Role(adminuser.RoleViewer).Status(adminuser.StatusPending).MustBuild()
+	r := NewAdminUserWith(admin, viewer, pendingViewer)
+
+	// nil role -> no role filtering (existing behavior)
+	got, pi, err := r.List(ctx, adminuser.ListFilter{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(got))
+	assert.Equal(t, int64(3), pi.TotalCount)
+
+	// role filter: system_admin
+	sysAdmin := adminuser.RoleSystemAdmin
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Role: &sysAdmin})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, admin.ID(), got[0].ID())
+	assert.Equal(t, int64(1), pi.TotalCount)
+
+	// role filter: viewer
+	viewerRole := adminuser.RoleViewer
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Role: &viewerRole})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, int64(2), pi.TotalCount)
+
+	// combined status + role
+	approved := adminuser.StatusApproved
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Status: &approved, Role: &viewerRole})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, viewer.ID(), got[0].ID())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}
+
 func TestAdminUser_List_RejectsCursorPagination(t *testing.T) {
 	ctx := context.Background()
 	r := NewAdminUserWith(adminuser.New().NewID().Name("A").Email("a@eukarya.io").MustBuild())

--- a/server/internal/infrastructure/mongo/adminuser.go
+++ b/server/internal/infrastructure/mongo/adminuser.go
@@ -48,6 +48,9 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 	if f.Status != nil {
 		filter["status"] = f.Status.String()
 	}
+	if f.Role != nil {
+		filter["role"] = f.Role.String()
+	}
 
 	// Sort by createdat for creation order; mongox.Paginate automatically
 	// appends the unique "id" field as a tie-breaker, so the effective sort is

--- a/server/internal/infrastructure/mongo/adminuser_test.go
+++ b/server/internal/infrastructure/mongo/adminuser_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/reearth/reearthx/mongox"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -144,11 +145,12 @@ func TestAdminUser_List_RoleFilter(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	_, _ = c.Collection("adminuser").InsertMany(ctx, []any{
+	_, err := c.Collection("adminuser").InsertMany(ctx, []any{
 		bson.M{"id": adminuser.NewID().String(), "email": "admin@eukarya.io", "name": "A", "role": "system_admin", "status": "approved", "createdat": now.Add(-2 * time.Hour), "updatedat": now},
 		bson.M{"id": adminuser.NewID().String(), "email": "viewer@eukarya.io", "name": "V", "role": "viewer", "status": "approved", "createdat": now.Add(-1 * time.Hour), "updatedat": now},
 		bson.M{"id": adminuser.NewID().String(), "email": "pviewer@eukarya.io", "name": "PV", "role": "viewer", "status": "pending", "createdat": now, "updatedat": now},
 	})
+	require.NoError(t, err)
 
 	r := NewAdminUser(mongox.NewClientWithDatabase(c))
 	p := usecasex.OffsetPagination{Offset: 0, Limit: 10}.Wrap()

--- a/server/internal/infrastructure/mongo/adminuser_test.go
+++ b/server/internal/infrastructure/mongo/adminuser_test.go
@@ -138,3 +138,41 @@ func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, got)
 }
+
+func TestAdminUser_List_RoleFilter(t *testing.T) {
+	c := Connect(t)(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	_, _ = c.Collection("adminuser").InsertMany(ctx, []any{
+		bson.M{"id": adminuser.NewID().String(), "email": "admin@eukarya.io", "name": "A", "role": "system_admin", "status": "approved", "createdat": now.Add(-2 * time.Hour), "updatedat": now},
+		bson.M{"id": adminuser.NewID().String(), "email": "viewer@eukarya.io", "name": "V", "role": "viewer", "status": "approved", "createdat": now.Add(-1 * time.Hour), "updatedat": now},
+		bson.M{"id": adminuser.NewID().String(), "email": "pviewer@eukarya.io", "name": "PV", "role": "viewer", "status": "pending", "createdat": now, "updatedat": now},
+	})
+
+	r := NewAdminUser(mongox.NewClientWithDatabase(c))
+	p := usecasex.OffsetPagination{Offset: 0, Limit: 10}.Wrap()
+
+	// role filter: system_admin
+	sysAdmin := adminuser.RoleSystemAdmin
+	got, pi, err := r.List(ctx, adminuser.ListFilter{Role: &sysAdmin, Pagination: p})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, "admin@eukarya.io", got[0].Email())
+	assert.Equal(t, int64(1), pi.TotalCount)
+
+	// role filter: viewer
+	viewerRole := adminuser.RoleViewer
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Role: &viewerRole, Pagination: p})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, int64(2), pi.TotalCount)
+
+	// combined status + role
+	approved := adminuser.StatusApproved
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Status: &approved, Role: &viewerRole, Pagination: p})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, "viewer@eukarya.io", got[0].Email())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}

--- a/server/internal/infrastructure/postgres/adminuser.go
+++ b/server/internal/infrastructure/postgres/adminuser.go
@@ -114,6 +114,10 @@ func (r *AdminUser) List(ctx context.Context, f adminuser.ListFilter) (adminuser
 		args = append(args, f.Status.String())
 		where = append(where, "status = $"+itoa(len(args)))
 	}
+	if f.Role != nil {
+		args = append(args, f.Role.String())
+		where = append(where, "role = $"+itoa(len(args)))
+	}
 	base := "FROM admin_users"
 	if len(where) > 0 {
 		base += " WHERE " + strings.Join(where, " AND ")

--- a/server/internal/infrastructure/postgres/adminuser_test.go
+++ b/server/internal/infrastructure/postgres/adminuser_test.go
@@ -156,3 +156,42 @@ func TestAdminUser_ExistsApprovedSystemAdminExcept(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got)
 }
+
+func TestAdminUser_List_RoleFilter(t *testing.T) {
+	pool, cleanup := pgPool(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewAdminUser(NewClient(pool))
+
+	admin := adminuser.New().NewID().Name("A").Email("a@eukarya.io").Role(adminuser.RoleSystemAdmin).Status(adminuser.StatusApproved).MustBuild()
+	viewer := adminuser.New().NewID().Name("V").Email("v@eukarya.io").Role(adminuser.RoleViewer).Status(adminuser.StatusApproved).MustBuild()
+	pendingViewer := adminuser.New().NewID().Name("PV").Email("pv@eukarya.io").Role(adminuser.RoleViewer).Status(adminuser.StatusPending).MustBuild()
+	for _, u := range []*adminuser.AdminUser{admin, viewer, pendingViewer} {
+		require.NoError(t, r.Save(ctx, u))
+	}
+
+	p := usecasex.OffsetPagination{Offset: 0, Limit: 10}.Wrap()
+
+	// role filter: system_admin
+	sysAdmin := adminuser.RoleSystemAdmin
+	got, pi, err := r.List(ctx, adminuser.ListFilter{Role: &sysAdmin, Pagination: p})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, admin.ID(), got[0].ID())
+	assert.Equal(t, int64(1), pi.TotalCount)
+
+	// role filter: viewer
+	viewerRole := adminuser.RoleViewer
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Role: &viewerRole, Pagination: p})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, int64(2), pi.TotalCount)
+
+	// combined status + role
+	approved := adminuser.StatusApproved
+	got, pi, err = r.List(ctx, adminuser.ListFilter{Status: &approved, Role: &viewerRole, Pagination: p})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, viewer.ID(), got[0].ID())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}

--- a/server/pkg/adminuser/repo.go
+++ b/server/pkg/adminuser/repo.go
@@ -19,6 +19,7 @@ var (
 // ListFilter narrows and paginates a List query.
 type ListFilter struct {
 	Status     *Status
+	Role       *Role
 	Pagination *usecasex.Pagination
 }
 


### PR DESCRIPTION
## Why

Complements the granular admin permissions work (reearth-dashboard#1316) by letting the admin-user list be filtered by role — useful for an admin UI (e.g. "show all system_admins").

## What's included

- **`adminuser.ListFilter.Role`**: new optional field, honored in the memory, mongo, and postgres `List` implementations (AND-combined with the existing status filter and pagination).
- **`GET /api/v1/admin-users?role=system_admin|viewer`**: parses the `role` query param (400 on invalid), mirroring the existing `status` param; regenerated swagger.
- Backend unit tests for role filtering (postgres/mongo under the `integration` tag) plus a handler test for the query param.

The `Repo` interface is unchanged (only a struct field was added), so the generated mock is untouched.

## Note

Independent of and parallel to the role-assignment endpoint PR; the only overlap is the regenerated `docs/admin/*` swagger, which re-generates cleanly on rebase.

## Checklist

- [x] Verified backward compatibility (additive optional filter; default behavior unchanged when role is absent)
- [x] Confirmed backward compatibility for migrations (no migration)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)