### PR TITLE
feat(server): add Auth0 MFA toggle via GraphQL API

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1000,6 +1000,8 @@ github.com/google/go-pkcs11 v0.3.0 h1:PVRnTgtArZ3QQqTGtbtjtnIkzl2iY2kt24yqbrf7td
 github.com/google/go-pkcs11 v0.3.0/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f/go.mod h1:Pt31oes+eGImORns3McJn8zHefuQl2rG8l6xQjGYB4U=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/googleapis/enterprise-certificate-proxy v0.3.5/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -80,6 +80,14 @@ type ComplexityRoot struct {
 		WorkspaceID func(childComplexity int) int
 	}
 
+	MFAEnrollResult struct {
+		EnrollmentURL func(childComplexity int) int
+	}
+
+	MFAStatus struct {
+		Enrolled func(childComplexity int) int
+	}
+
 	Me struct {
 		Alias          func(childComplexity int) int
 		Auths          func(childComplexity int) int
@@ -100,6 +108,8 @@ type ComplexityRoot struct {
 		CreateWorkspace                  func(childComplexity int, input gqlmodel.CreateWorkspaceInput) int
 		DeleteMe                         func(childComplexity int, input gqlmodel.DeleteMeInput) int
 		DeleteWorkspace                  func(childComplexity int, input gqlmodel.DeleteWorkspaceInput) int
+		DisableMfa                       func(childComplexity int) int
+		EnableMfa                        func(childComplexity int) int
 		FindOrCreate                     func(childComplexity int, input gqlmodel.FindOrCreateInput) int
 		Logout                           func(childComplexity int) int
 		PasswordReset                    func(childComplexity int, input gqlmodel.PasswordResetInput) int
@@ -132,6 +142,7 @@ type ComplexityRoot struct {
 		FindUsersByIDs               func(childComplexity int, ids []gqlmodel.ID) int
 		FindUsersByIDsWithPagination func(childComplexity int, ids []gqlmodel.ID, alias *string, pagination gqlmodel.Pagination) int
 		Me                           func(childComplexity int) int
+		MfaStatus                    func(childComplexity int) int
 		Node                         func(childComplexity int, id gqlmodel.ID, typeArg gqlmodel.NodeType) int
 		Nodes                        func(childComplexity int, id []gqlmodel.ID, typeArg gqlmodel.NodeType) int
 		SearchUser                   func(childComplexity int, keyword string) int
@@ -243,14 +254,16 @@ type MeResolver interface {
 type MutationResolver interface {
 	CreateVerification(ctx context.Context, input gqlmodel.CreateVerificationInput) (*bool, error)
 	DeleteMe(ctx context.Context, input gqlmodel.DeleteMeInput) (*gqlmodel.DeleteMePayload, error)
+	DisableMfa(ctx context.Context) (bool, error)
+	EnableMfa(ctx context.Context) (*gqlmodel.MFAEnrollResult, error)
 	FindOrCreate(ctx context.Context, input gqlmodel.FindOrCreateInput) (*gqlmodel.UserPayload, error)
+	Logout(ctx context.Context) (*gqlmodel.Me, error)
 	PasswordReset(ctx context.Context, input gqlmodel.PasswordResetInput) (*bool, error)
 	RemoveMyAuth(ctx context.Context, input gqlmodel.RemoveMyAuthInput) (*gqlmodel.UpdateMePayload, error)
 	Signup(ctx context.Context, input gqlmodel.SignupInput) (*gqlmodel.UserPayload, error)
 	SignupOidc(ctx context.Context, input gqlmodel.SignupOIDCInput) (*gqlmodel.UserPayload, error)
 	StartPasswordReset(ctx context.Context, input gqlmodel.StartPasswordResetInput) (*bool, error)
 	UpdateMe(ctx context.Context, input gqlmodel.UpdateMeInput) (*gqlmodel.UpdateMePayload, error)
-	Logout(ctx context.Context) (*gqlmodel.Me, error)
 	VerifyUser(ctx context.Context, input gqlmodel.VerifyUserInput) (*gqlmodel.UserPayload, error)
 	CreateWorkspace(ctx context.Context, input gqlmodel.CreateWorkspaceInput) (*gqlmodel.CreateWorkspacePayload, error)
 	DeleteWorkspace(ctx context.Context, input gqlmodel.DeleteWorkspaceInput) (*gqlmodel.DeleteWorkspacePayload, error)
@@ -274,10 +287,11 @@ type QueryResolver interface {
 	FindUsersByIDsWithPagination(ctx context.Context, ids []gqlmodel.ID, alias *string, pagination gqlmodel.Pagination) (*gqlmodel.UsersWithPagination, error)
 	FindUsersByIDs(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.User, error)
 	Me(ctx context.Context) (*gqlmodel.Me, error)
+	MfaStatus(ctx context.Context) (*gqlmodel.MFAStatus, error)
 	SearchUser(ctx context.Context, keyword string) ([]*gqlmodel.User, error)
 	User(ctx context.Context, id gqlmodel.ID) (*gqlmodel.User, error)
-	UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*gqlmodel.User, error)
 	UserByNameOrAlias(ctx context.Context, nameOrAlias string) ([]*gqlmodel.User, error)
+	UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*gqlmodel.User, error)
 	FindByID(ctx context.Context, id gqlmodel.ID) (*gqlmodel.Workspace, error)
 	FindByIDs(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.Workspace, error)
 	FindByName(ctx context.Context, name string) (*gqlmodel.Workspace, error)
@@ -391,6 +405,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteWorkspacePayload.WorkspaceID(childComplexity), true
+
+	case "MFAEnrollResult.enrollmentUrl":
+		if e.complexity.MFAEnrollResult.EnrollmentURL == nil {
+			break
+		}
+
+		return e.complexity.MFAEnrollResult.EnrollmentURL(childComplexity), true
+
+	case "MFAStatus.enrolled":
+		if e.complexity.MFAStatus.Enrolled == nil {
+			break
+		}
+
+		return e.complexity.MFAStatus.Enrolled(childComplexity), true
 
 	case "Me.alias":
 		if e.complexity.Me.Alias == nil {
@@ -519,6 +547,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteWorkspace(childComplexity, args["input"].(gqlmodel.DeleteWorkspaceInput)), true
+	case "Mutation.disableMFA":
+		if e.complexity.Mutation.DisableMfa == nil {
+			break
+		}
+
+		return e.complexity.Mutation.DisableMfa(childComplexity), true
+	case "Mutation.enableMFA":
+		if e.complexity.Mutation.EnableMfa == nil {
+			break
+		}
+
+		return e.complexity.Mutation.EnableMfa(childComplexity), true
 	case "Mutation.findOrCreate":
 		if e.complexity.Mutation.FindOrCreate == nil {
 			break
@@ -824,6 +864,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Me(childComplexity), true
+	case "Query.mfaStatus":
+		if e.complexity.Query.MfaStatus == nil {
+			break
+		}
+
+		return e.complexity.Query.MfaStatus(childComplexity), true
 	case "Query.node":
 		if e.complexity.Query.Node == nil {
 			break
@@ -1449,6 +1495,14 @@ type Verification {
   verified: Boolean!
 }
 
+type MFAEnrollResult {
+  enrollmentUrl: String!
+}
+
+type MFAStatus {
+  enrolled: Boolean!
+}
+
 type UsersWithPagination {
   users: [User!]!
   totalCount: Int!
@@ -1526,10 +1580,11 @@ extend type Query {
   findUsersByIDsWithPagination(ids: [ID!]!, alias: String, pagination: Pagination!): UsersWithPagination!
   findUsersByIDs(ids: [ID!]!): [User!]!
   me: Me
+  mfaStatus: MFAStatus!
   searchUser(keyword: String!): [User!]!
   user(id: ID!): User
-  userByNameOrEmail(nameOrEmail: String!): User
   userByNameOrAlias(nameOrAlias: String!): [User!]!
+  userByNameOrEmail(nameOrEmail: String!): User
 }
 
 type UserPayload {
@@ -1547,15 +1602,16 @@ type DeleteMePayload {
 extend type Mutation {
   createVerification(input: CreateVerificationInput!): Boolean
   deleteMe(input: DeleteMeInput!): DeleteMePayload
+  disableMFA: Boolean!
+  enableMFA: MFAEnrollResult!
   findOrCreate(input: FindOrCreateInput!): UserPayload
+  logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload
-
   startPasswordReset(input: StartPasswordResetInput!): Boolean
   updateMe(input: UpdateMeInput!): UpdateMePayload
-  logout: Me
   verifyUser(input: VerifyUserInput!): UserPayload
 }
 `, BuiltIn: false},
@@ -2662,6 +2718,64 @@ func (ec *executionContext) fieldContext_DeleteWorkspacePayload_workspaceId(_ co
 	return fc, nil
 }
 
+func (ec *executionContext) _MFAEnrollResult_enrollmentUrl(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.MFAEnrollResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MFAEnrollResult_enrollmentUrl,
+		func(ctx context.Context) (any, error) {
+			return obj.EnrollmentURL, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MFAEnrollResult_enrollmentUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MFAEnrollResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MFAStatus_enrolled(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.MFAStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MFAStatus_enrolled,
+		func(ctx context.Context) (any, error) {
+			return obj.Enrolled, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MFAStatus_enrolled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MFAStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Me_id(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Me) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3064,6 +3178,68 @@ func (ec *executionContext) fieldContext_Mutation_deleteMe(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_disableMFA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_disableMFA,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().DisableMfa(ctx)
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_disableMFA(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_enableMFA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_enableMFA,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().EnableMfa(ctx)
+		},
+		nil,
+		ec.marshalNMFAEnrollResult2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAEnrollResult,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_enableMFA(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enrollmentUrl":
+				return ec.fieldContext_MFAEnrollResult_enrollmentUrl(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type MFAEnrollResult", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_findOrCreate(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3105,6 +3281,57 @@ func (ec *executionContext) fieldContext_Mutation_findOrCreate(ctx context.Conte
 	if fc.Args, err = ec.field_Mutation_findOrCreate_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_logout,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().Logout(ctx)
+		},
+		nil,
+		ec.marshalOMe2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMe,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_logout(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Me_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Me_name(ctx, field)
+			case "alias":
+				return ec.fieldContext_Me_alias(ctx, field)
+			case "email":
+				return ec.fieldContext_Me_email(ctx, field)
+			case "metadata":
+				return ec.fieldContext_Me_metadata(ctx, field)
+			case "host":
+				return ec.fieldContext_Me_host(ctx, field)
+			case "latestLogoutAt":
+				return ec.fieldContext_Me_latestLogoutAt(ctx, field)
+			case "myWorkspaceId":
+				return ec.fieldContext_Me_myWorkspaceId(ctx, field)
+			case "auths":
+				return ec.fieldContext_Me_auths(ctx, field)
+			case "myWorkspace":
+				return ec.fieldContext_Me_myWorkspace(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Me", field.Name)
+		},
 	}
 	return fc, nil
 }
@@ -3367,57 +3594,6 @@ func (ec *executionContext) fieldContext_Mutation_updateMe(ctx context.Context, 
 	if fc.Args, err = ec.field_Mutation_updateMe_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Mutation_logout,
-		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Mutation().Logout(ctx)
-		},
-		nil,
-		ec.marshalOMe2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMe,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Mutation_logout(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Me_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Me_name(ctx, field)
-			case "alias":
-				return ec.fieldContext_Me_alias(ctx, field)
-			case "email":
-				return ec.fieldContext_Me_email(ctx, field)
-			case "metadata":
-				return ec.fieldContext_Me_metadata(ctx, field)
-			case "host":
-				return ec.fieldContext_Me_host(ctx, field)
-			case "latestLogoutAt":
-				return ec.fieldContext_Me_latestLogoutAt(ctx, field)
-			case "myWorkspaceId":
-				return ec.fieldContext_Me_myWorkspaceId(ctx, field)
-			case "auths":
-				return ec.fieldContext_Me_auths(ctx, field)
-			case "myWorkspace":
-				return ec.fieldContext_Me_myWorkspace(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Me", field.Name)
-		},
 	}
 	return fc, nil
 }
@@ -4401,6 +4577,39 @@ func (ec *executionContext) fieldContext_Query_me(_ context.Context, field graph
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_mfaStatus(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_mfaStatus,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().MfaStatus(ctx)
+		},
+		nil,
+		ec.marshalNMFAStatus2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAStatus,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_mfaStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enrolled":
+				return ec.fieldContext_MFAStatus_enrolled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type MFAStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_searchUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4523,67 +4732,6 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_userByNameOrEmail(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Query_userByNameOrEmail,
-		func(ctx context.Context) (any, error) {
-			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().UserByNameOrEmail(ctx, fc.Args["nameOrEmail"].(string))
-		},
-		nil,
-		ec.marshalOUser2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUser,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Query_userByNameOrEmail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "alias":
-				return ec.fieldContext_User_alias(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
-			case "host":
-				return ec.fieldContext_User_host(ctx, field)
-			case "workspace":
-				return ec.fieldContext_User_workspace(ctx, field)
-			case "auths":
-				return ec.fieldContext_User_auths(ctx, field)
-			case "metadata":
-				return ec.fieldContext_User_metadata(ctx, field)
-			case "verification":
-				return ec.fieldContext_User_verification(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_userByNameOrEmail_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_userByNameOrAlias(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4639,6 +4787,67 @@ func (ec *executionContext) fieldContext_Query_userByNameOrAlias(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_userByNameOrAlias_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_userByNameOrEmail(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_userByNameOrEmail,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().UserByNameOrEmail(ctx, fc.Args["nameOrEmail"].(string))
+		},
+		nil,
+		ec.marshalOUser2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUser,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_userByNameOrEmail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "alias":
+				return ec.fieldContext_User_alias(ctx, field)
+			case "email":
+				return ec.fieldContext_User_email(ctx, field)
+			case "host":
+				return ec.fieldContext_User_host(ctx, field)
+			case "workspace":
+				return ec.fieldContext_User_workspace(ctx, field)
+			case "auths":
+				return ec.fieldContext_User_auths(ctx, field)
+			case "metadata":
+				return ec.fieldContext_User_metadata(ctx, field)
+			case "verification":
+				return ec.fieldContext_User_verification(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_userByNameOrEmail_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9455,6 +9664,84 @@ func (ec *executionContext) _DeleteWorkspacePayload(ctx context.Context, sel ast
 	return out
 }
 
+var mFAEnrollResultImplementors = []string{"MFAEnrollResult"}
+
+func (ec *executionContext) _MFAEnrollResult(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.MFAEnrollResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mFAEnrollResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MFAEnrollResult")
+		case "enrollmentUrl":
+			out.Values[i] = ec._MFAEnrollResult_enrollmentUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var mFAStatusImplementors = []string{"MFAStatus"}
+
+func (ec *executionContext) _MFAStatus(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.MFAStatus) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mFAStatusImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MFAStatus")
+		case "enrolled":
+			out.Values[i] = ec._MFAStatus_enrolled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var meImplementors = []string{"Me"}
 
 func (ec *executionContext) _Me(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.Me) graphql.Marshaler {
@@ -9591,9 +9878,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteMe(ctx, field)
 			})
+		case "disableMFA":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_disableMFA(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "enableMFA":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_enableMFA(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "findOrCreate":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_findOrCreate(ctx, field)
+			})
+		case "logout":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_logout(ctx, field)
 			})
 		case "passwordReset":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -9618,10 +9923,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "updateMe":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateMe(ctx, field)
-			})
-		case "logout":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_logout(ctx, field)
 			})
 		case "verifyUser":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -9875,6 +10176,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "mfaStatus":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_mfaStatus(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "searchUser":
 			field := field
 
@@ -9916,25 +10239,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "userByNameOrEmail":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_userByNameOrEmail(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "userByNameOrAlias":
 			field := field
 
@@ -9948,6 +10252,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "userByNameOrEmail":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_userByNameOrEmail(ctx, field)
 				return res
 			}
 
@@ -11379,6 +11702,34 @@ func (ec *executionContext) marshalNLang2string(ctx context.Context, sel ast.Sel
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNMFAEnrollResult2githubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAEnrollResult(ctx context.Context, sel ast.SelectionSet, v gqlmodel.MFAEnrollResult) graphql.Marshaler {
+	return ec._MFAEnrollResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNMFAEnrollResult2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAEnrollResult(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.MFAEnrollResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._MFAEnrollResult(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNMFAStatus2githubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAStatus(ctx context.Context, sel ast.SelectionSet, v gqlmodel.MFAStatus) graphql.Marshaler {
+	return ec._MFAStatus(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNMFAStatus2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAStatus(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.MFAStatus) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._MFAStatus(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNMe2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMe(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.Me) graphql.Marshaler {

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -102,6 +102,14 @@ type FindOrCreateInput struct {
 	Token string `json:"token"`
 }
 
+type MFAEnrollResult struct {
+	EnrollmentURL string `json:"enrollmentUrl"`
+}
+
+type MFAStatus struct {
+	Enrolled bool `json:"enrolled"`
+}
+
 type Me struct {
 	ID             ID            `json:"id"`
 	Name           string        `json:"name"`

--- a/server/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/internal/adapter/gql/resolver_mutation_user.go
@@ -172,6 +172,19 @@ func (r *mutationResolver) StartPasswordReset(ctx context.Context, input gqlmode
 	return lo.ToPtr(true), nil
 }
 
+func (r *mutationResolver) DisableMfa(ctx context.Context) (bool, error) {
+	err := usecases(ctx).User.DisableMFA(ctx, getOperator(ctx))
+	return err == nil, err
+}
+
+func (r *mutationResolver) EnableMfa(ctx context.Context) (*gqlmodel.MFAEnrollResult, error) {
+	enrollmentURL, err := usecases(ctx).User.EnableMFA(ctx, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &gqlmodel.MFAEnrollResult{EnrollmentURL: enrollmentURL}, nil
+}
+
 func (r *mutationResolver) PasswordReset(ctx context.Context, input gqlmodel.PasswordResetInput) (*bool, error) {
 	err := usecases(ctx).User.PasswordReset(ctx, input.Password, input.Token)
 	if err != nil {

--- a/server/internal/adapter/gql/resolver_query.go
+++ b/server/internal/adapter/gql/resolver_query.go
@@ -111,6 +111,14 @@ func (r *queryResolver) FindUserByAlias(ctx context.Context, alias string) (*gql
 	return loaders(ctx).User.FetchByAlias(ctx, alias)
 }
 
+func (r *queryResolver) MfaStatus(ctx context.Context) (*gqlmodel.MFAStatus, error) {
+	res, err := usecases(ctx).User.GetMFAStatus(ctx, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &gqlmodel.MFAStatus{Enrolled: res.Enrolled}, nil
+}
+
 func (r *queryResolver) AuthConfig(ctx context.Context) (*gqlmodel.AuthConfig, error) {
 	cfgInterface := adapter.GetConfig(ctx)
 	if cfgInterface == nil {

--- a/server/internal/infrastructure/auth0/authenticator.go
+++ b/server/internal/infrastructure/auth0/authenticator.go
@@ -40,10 +40,16 @@ type response struct {
 	Email            string `json:"email"`
 	EmailVerified    bool   `json:"email_verified"`
 	Message          string `json:"message"`
+	TicketURL        string `json:"ticket_url"`
 	Token            string `json:"access_token"`
 	Scope            string `json:"scope"`
 	ExpiresIn        int64  `json:"expires_in"`
 	ErrorDescription string `json:"error_description"`
+}
+
+type enrollment struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
 }
 
 func (u response) Into() gateway.AuthenticatorUser {
@@ -142,6 +148,93 @@ func (a *Auth0) ResendVerificationEmail(ctx context.Context, userID string) erro
 	return nil
 }
 
+func (a *Auth0) DisableMFA(ctx context.Context, sub string) error {
+	if err := a.updateToken(ctx); err != nil {
+		return err
+	}
+
+	var enrollments []enrollment
+	if err := a.execInto(ctx, http.MethodGet, "api/v2/users/"+sub+"/enrollments", a.token, nil, &enrollments); err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: disable mfa: list enrollments: %+v", err)
+		}
+		return rerror.NewE(i18n.T("failed to list mfa enrollments"))
+	}
+
+	for _, e := range enrollments {
+		if e.Status != "confirmed" {
+			continue
+		}
+		if err := a.execInto(ctx, http.MethodDelete, "api/v2/guardian/enrollments/"+e.ID, a.token, nil, nil); err != nil {
+			if !a.disableLogging {
+				log.Errorf("auth0: disable mfa: delete enrollment %s: %+v", e.ID, err)
+			}
+			return rerror.NewE(i18n.T("failed to delete mfa enrollment"))
+		}
+	}
+
+	if _, err := a.exec(ctx, http.MethodPatch, "api/v2/users/"+sub, a.token, map[string]any{
+		"app_metadata": map[string]any{"mfa_enabled": false},
+	}); err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: disable mfa: update app_metadata: %+v", err)
+		}
+		return rerror.NewE(i18n.T("failed to update mfa status"))
+	}
+
+	return nil
+}
+
+func (a *Auth0) EnableMFA(ctx context.Context, sub string) (string, error) {
+	if err := a.updateToken(ctx); err != nil {
+		return "", err
+	}
+
+	if _, err := a.exec(ctx, http.MethodPatch, "api/v2/users/"+sub, a.token, map[string]any{
+		"app_metadata": map[string]any{"mfa_enabled": true},
+	}); err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: enable mfa: update app_metadata: %+v", err)
+		}
+		return "", rerror.NewE(i18n.T("failed to update mfa status"))
+	}
+
+	r, err := a.exec(ctx, http.MethodPost, "api/v2/guardian/enrollments/ticket", a.token, map[string]any{
+		"user_id":   sub,
+		"send_mail": false,
+	})
+	if err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: enable mfa: create enrollment ticket: %+v", err)
+		}
+		return "", rerror.NewE(i18n.T("failed to create mfa enrollment ticket"))
+	}
+
+	return r.TicketURL, nil
+}
+
+func (a *Auth0) GetMFAStatus(ctx context.Context, sub string) (gateway.MFAStatus, error) {
+	if err := a.updateToken(ctx); err != nil {
+		return gateway.MFAStatus{}, err
+	}
+
+	var enrollments []enrollment
+	if err := a.execInto(ctx, http.MethodGet, "api/v2/users/"+sub+"/enrollments", a.token, nil, &enrollments); err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: get mfa status: %+v", err)
+		}
+		return gateway.MFAStatus{}, rerror.NewE(i18n.T("failed to get mfa status"))
+	}
+
+	for _, e := range enrollments {
+		if e.Status == "confirmed" {
+			return gateway.MFAStatus{Enrolled: true}, nil
+		}
+	}
+
+	return gateway.MFAStatus{Enrolled: false}, nil
+}
+
 func (a *Auth0) needsFetchToken() bool {
 	if a == nil {
 		return false
@@ -173,7 +266,7 @@ func (a *Auth0) updateToken(ctx context.Context) error {
 		"client_secret": a.clientSecret,
 		"audience":      urlFromDomain(a.domain) + "api/v2/",
 		"grant_type":    "client_credentials",
-		"scope":         "read:users update:users",
+		"scope":         "read:users update:users create:guardian_enrollment_tickets delete:guardian_enrollments",
 	})
 	if err != nil {
 		if !a.disableLogging {
@@ -256,6 +349,68 @@ func (a *Auth0) exec(ctx context.Context, method, path, token string, b interfac
 		return
 	}
 	return
+}
+
+// execInto is like exec but unmarshals the response into target (any type, including
+// slices). Pass nil for target on endpoints that return 204 No Content.
+func (a *Auth0) execInto(ctx context.Context, method, path, token string, b, target any) error {
+	if a == nil || a.domain == "" {
+		return rerror.NewE(i18n.T("auth0: domain is not set"))
+	}
+
+	var body io.Reader
+	if b != nil {
+		b2, err := json.Marshal(b)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b2)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, urlFromDomain(a.domain)+path, body)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	respb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if !a.disableLogging {
+		log.Infof("auth0: path: %s, status: %d, resp: %s", path, resp.StatusCode, respb)
+	}
+
+	if resp.StatusCode >= 300 {
+		var r response
+		if jsonErr := json.Unmarshal(respb, &r); jsonErr == nil && r.Error() != "" {
+			return errors.New(r.Error())
+		}
+		return errors.New(string(respb))
+	}
+
+	if target != nil {
+		if err := json.Unmarshal(respb, target); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func urlFromDomain(path string) string {

--- a/server/internal/infrastructure/cip/authenticator.go
+++ b/server/internal/infrastructure/cip/authenticator.go
@@ -145,6 +145,18 @@ func (a *Authenticator) ResendVerificationEmail(ctx context.Context, userID stri
 	return nil
 }
 
+func (a *Authenticator) DisableMFA(_ context.Context, _ string) error {
+	return nil
+}
+
+func (a *Authenticator) EnableMFA(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (a *Authenticator) GetMFAStatus(_ context.Context, _ string) (gateway.MFAStatus, error) {
+	return gateway.MFAStatus{}, nil
+}
+
 func toAuthenticatorUser(rec *fbauth.UserRecord) gateway.AuthenticatorUser {
 	out := gateway.AuthenticatorUser{}
 	if rec == nil {

--- a/server/internal/usecase/gateway/authenticator.go
+++ b/server/internal/usecase/gateway/authenticator.go
@@ -16,7 +16,14 @@ type AuthenticatorUser struct {
 	EmailVerified bool
 }
 
+type MFAStatus struct {
+	Enrolled bool
+}
+
 type Authenticator interface {
-	UpdateUser(context.Context, AuthenticatorUpdateUserParam) (AuthenticatorUser, error)
+	DisableMFA(ctx context.Context, sub string) error
+	EnableMFA(ctx context.Context, sub string) (enrollmentURL string, err error)
+	GetMFAStatus(ctx context.Context, sub string) (MFAStatus, error)
 	ResendVerificationEmail(ctx context.Context, userID string) error
+	UpdateUser(context.Context, AuthenticatorUpdateUserParam) (AuthenticatorUser, error)
 }

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -303,6 +303,80 @@ func (i *User) RemoveMyAuth(ctx context.Context, authProvider string, operator *
 	})
 }
 
+func (i *User) DisableMFA(ctx context.Context, operator *workspace.Operator) error {
+	if operator == nil || operator.User == nil {
+		return interfaces.ErrInvalidOperator
+	}
+	return Run0(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+		u, err := i.repos.User.FindByID(ctx, *operator.User)
+		if err != nil {
+			return err
+		}
+		for _, a := range u.Auths() {
+			authenticator := i.gateways.AuthenticatorFor(a.Provider)
+			if authenticator == nil {
+				continue
+			}
+			if err := authenticator.DisableMFA(ctx, a.Sub); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (i *User) EnableMFA(ctx context.Context, operator *workspace.Operator) (string, error) {
+	if operator == nil || operator.User == nil {
+		return "", interfaces.ErrInvalidOperator
+	}
+	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (string, error) {
+		u, err := i.repos.User.FindByID(ctx, *operator.User)
+		if err != nil {
+			return "", err
+		}
+		for _, a := range u.Auths() {
+			authenticator := i.gateways.AuthenticatorFor(a.Provider)
+			if authenticator == nil {
+				continue
+			}
+			enrollmentURL, err := authenticator.EnableMFA(ctx, a.Sub)
+			if err != nil {
+				return "", err
+			}
+			if enrollmentURL != "" {
+				return enrollmentURL, nil
+			}
+		}
+		return "", rerror.NewE(i18n.T("no authenticator found"))
+	})
+}
+
+func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (gateway.MFAStatus, error) {
+	if operator == nil || operator.User == nil {
+		return gateway.MFAStatus{}, interfaces.ErrInvalidOperator
+	}
+	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (gateway.MFAStatus, error) {
+		u, err := i.repos.User.FindByID(ctx, *operator.User)
+		if err != nil {
+			return gateway.MFAStatus{}, err
+		}
+		for _, a := range u.Auths() {
+			authenticator := i.gateways.AuthenticatorFor(a.Provider)
+			if authenticator == nil {
+				continue
+			}
+			status, err := authenticator.GetMFAStatus(ctx, a.Sub)
+			if err != nil {
+				return gateway.MFAStatus{}, err
+			}
+			if status.Enrolled {
+				return status, nil
+			}
+		}
+		return gateway.MFAStatus{Enrolled: false}, nil
+	})
+}
+
 func (i *User) DeleteMe(ctx context.Context, userID user.ID, operator *workspace.Operator) (err error) {
 	if operator.User == nil {
 		return interfaces.ErrInvalidOperator

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -312,16 +312,15 @@ func (i *User) DisableMFA(ctx context.Context, operator *workspace.Operator) err
 		if err != nil {
 			return err
 		}
-		for _, a := range u.Auths() {
-			authenticator := i.gateways.AuthenticatorFor(a.Provider)
-			if authenticator == nil {
-				continue
-			}
-			if err := authenticator.DisableMFA(ctx, a.Sub); err != nil {
-				return err
-			}
+		a := u.Auths().GetByProvider(user.ProviderAuth0)
+		if a == nil {
+			return rerror.NewE(i18n.T("no authenticator found"))
 		}
-		return nil
+		authenticator := i.gateways.AuthenticatorFor(a.Provider)
+		if authenticator == nil {
+			return rerror.NewE(i18n.T("no authenticator found"))
+		}
+		return authenticator.DisableMFA(ctx, a.Sub)
 	})
 }
 
@@ -334,20 +333,15 @@ func (i *User) EnableMFA(ctx context.Context, operator *workspace.Operator) (str
 		if err != nil {
 			return "", err
 		}
-		for _, a := range u.Auths() {
-			authenticator := i.gateways.AuthenticatorFor(a.Provider)
-			if authenticator == nil {
-				continue
-			}
-			enrollmentURL, err := authenticator.EnableMFA(ctx, a.Sub)
-			if err != nil {
-				return "", err
-			}
-			if enrollmentURL != "" {
-				return enrollmentURL, nil
-			}
+		a := u.Auths().GetByProvider(user.ProviderAuth0)
+		if a == nil {
+			return "", rerror.NewE(i18n.T("no authenticator found"))
 		}
-		return "", rerror.NewE(i18n.T("no authenticator found"))
+		authenticator := i.gateways.AuthenticatorFor(a.Provider)
+		if authenticator == nil {
+			return "", rerror.NewE(i18n.T("no authenticator found"))
+		}
+		return authenticator.EnableMFA(ctx, a.Sub)
 	})
 }
 
@@ -360,20 +354,15 @@ func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (
 		if err != nil {
 			return gateway.MFAStatus{}, err
 		}
-		for _, a := range u.Auths() {
-			authenticator := i.gateways.AuthenticatorFor(a.Provider)
-			if authenticator == nil {
-				continue
-			}
-			status, err := authenticator.GetMFAStatus(ctx, a.Sub)
-			if err != nil {
-				return gateway.MFAStatus{}, err
-			}
-			if status.Enrolled {
-				return status, nil
-			}
+		a := u.Auths().GetByProvider(user.ProviderAuth0)
+		if a == nil {
+			return gateway.MFAStatus{Enrolled: false}, nil
 		}
-		return gateway.MFAStatus{Enrolled: false}, nil
+		authenticator := i.gateways.AuthenticatorFor(a.Provider)
+		if authenticator == nil {
+			return gateway.MFAStatus{Enrolled: false}, nil
+		}
+		return authenticator.GetMFAStatus(ctx, a.Sub)
 	})
 }
 

--- a/server/internal/usecase/interactor/user_signup_test.go
+++ b/server/internal/usecase/interactor/user_signup_test.go
@@ -782,6 +782,14 @@ func (m *mockAuthenticator) UpdateUser(ctx context.Context, p gateway.Authentica
 	}, nil
 }
 
+func (m *mockAuthenticator) DisableMFA(_ context.Context, _ string) error { return nil }
+
+func (m *mockAuthenticator) EnableMFA(_ context.Context, _ string) (string, error) { return "", nil }
+
+func (m *mockAuthenticator) GetMFAStatus(_ context.Context, _ string) (gateway.MFAStatus, error) {
+	return gateway.MFAStatus{}, nil
+}
+
 func (m *mockAuthenticator) ResendVerificationEmail(ctx context.Context, userID string) error {
 	m.resendVerificationEmailCalled = true
 	m.resendVerificationEmailUserID = userID

--- a/server/internal/usecase/interactor/user_test.go
+++ b/server/internal/usecase/interactor/user_test.go
@@ -1223,6 +1223,16 @@ func (m *mockAuthenticatorWithError) UpdateUser(_ context.Context, _ gateway.Aut
 	return gateway.AuthenticatorUser{}, nil
 }
 
+func (m *mockAuthenticatorWithError) DisableMFA(_ context.Context, _ string) error { return nil }
+
+func (m *mockAuthenticatorWithError) EnableMFA(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockAuthenticatorWithError) GetMFAStatus(_ context.Context, _ string) (gateway.MFAStatus, error) {
+	return gateway.MFAStatus{}, nil
+}
+
 func (m *mockAuthenticatorWithError) ResendVerificationEmail(_ context.Context, _ string) error {
 	return nil
 }

--- a/server/internal/usecase/interfaces/user.go
+++ b/server/internal/usecase/interfaces/user.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"context"
 
+	"github.com/reearth/reearth-accounts/server/internal/usecase/gateway"
 	"github.com/reearth/reearth-accounts/server/pkg/user"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/reearth/reearthx/i18n"
@@ -127,4 +128,9 @@ type User interface {
 	VerifyUser(context.Context, string) (*user.User, error)
 	StartPasswordReset(context.Context, string) error
 	PasswordReset(context.Context, string, string) error
+
+	// mfa
+	DisableMFA(context.Context, *workspace.Operator) error
+	EnableMFA(context.Context, *workspace.Operator) (enrollmentURL string, err error)
+	GetMFAStatus(context.Context, *workspace.Operator) (gateway.MFAStatus, error)
 }

--- a/server/internal/usecase/proxy/user.go
+++ b/server/internal/usecase/proxy/user.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/reearth/reearth-accounts/server/internal/usecase/gateway"
 	"github.com/reearth/reearth-accounts/server/pkg/user"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/reearth/reearthx/util"
@@ -198,4 +199,16 @@ func (u *User) PasswordReset(ctx context.Context, password string, token string)
 		return err
 	}
 	return nil
+}
+
+func (u *User) DisableMFA(_ context.Context, _ *workspace.Operator) error {
+	return errors.New("DisableMFA is not supported in proxy mode")
+}
+
+func (u *User) EnableMFA(_ context.Context, _ *workspace.Operator) (string, error) {
+	return "", errors.New("EnableMFA is not supported in proxy mode")
+}
+
+func (u *User) GetMFAStatus(_ context.Context, _ *workspace.Operator) (gateway.MFAStatus, error) {
+	return gateway.MFAStatus{}, errors.New("GetMFAStatus is not supported in proxy mode")
 }

--- a/server/pkg/gqlclient/user/mockrepo/mockrepo.go
+++ b/server/pkg/gqlclient/user/mockrepo/mockrepo.go
@@ -309,6 +309,50 @@ func (mr *MockRepoMockRecorder) UpdateMe(ctx, input any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMe", reflect.TypeOf((*MockRepo)(nil).UpdateMe), ctx, input)
 }
 
+// DisableMFA mocks base method.
+func (m *MockRepo) DisableMFA(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisableMFA", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DisableMFA indicates an expected call of DisableMFA.
+func (mr *MockRepoMockRecorder) DisableMFA(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableMFA", reflect.TypeOf((*MockRepo)(nil).DisableMFA), ctx)
+}
+
+// EnableMFA mocks base method.
+func (m *MockRepo) EnableMFA(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableMFA", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnableMFA indicates an expected call of EnableMFA.
+func (mr *MockRepoMockRecorder) EnableMFA(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFA", reflect.TypeOf((*MockRepo)(nil).EnableMFA), ctx)
+}
+
+// GetMFAStatus mocks base method.
+func (m *MockRepo) GetMFAStatus(ctx context.Context) (user.MFAStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMFAStatus", ctx)
+	ret0, _ := ret[0].(user.MFAStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMFAStatus indicates an expected call of GetMFAStatus.
+func (mr *MockRepoMockRecorder) GetMFAStatus(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMFAStatus", reflect.TypeOf((*MockRepo)(nil).GetMFAStatus), ctx)
+}
+
 // VerifyUser mocks base method.
 func (m *MockRepo) VerifyUser(ctx context.Context, code string) (*user0.User, error) {
 	m.ctrl.T.Helper()

--- a/server/pkg/gqlclient/user/mockrepo/mockrepo.go
+++ b/server/pkg/gqlclient/user/mockrepo/mockrepo.go
@@ -71,6 +71,35 @@ func (mr *MockRepoMockRecorder) DeleteMe(ctx, userID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMe", reflect.TypeOf((*MockRepo)(nil).DeleteMe), ctx, userID)
 }
 
+// DisableMFA mocks base method.
+func (m *MockRepo) DisableMFA(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisableMFA", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DisableMFA indicates an expected call of DisableMFA.
+func (mr *MockRepoMockRecorder) DisableMFA(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableMFA", reflect.TypeOf((*MockRepo)(nil).DisableMFA), ctx)
+}
+
+// EnableMFA mocks base method.
+func (m *MockRepo) EnableMFA(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableMFA", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnableMFA indicates an expected call of EnableMFA.
+func (mr *MockRepoMockRecorder) EnableMFA(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFA", reflect.TypeOf((*MockRepo)(nil).EnableMFA), ctx)
+}
+
 // FindByAlias mocks base method.
 func (m *MockRepo) FindByAlias(ctx context.Context, alias string) (*user0.User, error) {
 	m.ctrl.T.Helper()
@@ -175,6 +204,21 @@ func (m *MockRepo) FindUsersByIDsWithPagination(ctx context.Context, id []string
 func (mr *MockRepoMockRecorder) FindUsersByIDsWithPagination(ctx, id, alias, page, size any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUsersByIDsWithPagination", reflect.TypeOf((*MockRepo)(nil).FindUsersByIDsWithPagination), ctx, id, alias, page, size)
+}
+
+// GetMFAStatus mocks base method.
+func (m *MockRepo) GetMFAStatus(ctx context.Context) (user.MFAStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMFAStatus", ctx)
+	ret0, _ := ret[0].(user.MFAStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMFAStatus indicates an expected call of GetMFAStatus.
+func (mr *MockRepoMockRecorder) GetMFAStatus(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMFAStatus", reflect.TypeOf((*MockRepo)(nil).GetMFAStatus), ctx)
 }
 
 // Logout mocks base method.
@@ -307,50 +351,6 @@ func (m *MockRepo) UpdateMe(ctx context.Context, input user.UpdateMeInput) (*use
 func (mr *MockRepoMockRecorder) UpdateMe(ctx, input any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMe", reflect.TypeOf((*MockRepo)(nil).UpdateMe), ctx, input)
-}
-
-// DisableMFA mocks base method.
-func (m *MockRepo) DisableMFA(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DisableMFA", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DisableMFA indicates an expected call of DisableMFA.
-func (mr *MockRepoMockRecorder) DisableMFA(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableMFA", reflect.TypeOf((*MockRepo)(nil).DisableMFA), ctx)
-}
-
-// EnableMFA mocks base method.
-func (m *MockRepo) EnableMFA(ctx context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableMFA", ctx)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnableMFA indicates an expected call of EnableMFA.
-func (mr *MockRepoMockRecorder) EnableMFA(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFA", reflect.TypeOf((*MockRepo)(nil).EnableMFA), ctx)
-}
-
-// GetMFAStatus mocks base method.
-func (m *MockRepo) GetMFAStatus(ctx context.Context) (user.MFAStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMFAStatus", ctx)
-	ret0, _ := ret[0].(user.MFAStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMFAStatus indicates an expected call of GetMFAStatus.
-func (mr *MockRepoMockRecorder) GetMFAStatus(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMFAStatus", reflect.TypeOf((*MockRepo)(nil).GetMFAStatus), ctx)
 }
 
 // VerifyUser mocks base method.

--- a/server/pkg/gqlclient/user/query.go
+++ b/server/pkg/gqlclient/user/query.go
@@ -127,3 +127,19 @@ type PasswordResetInput struct {
 type passwordResetMutation struct {
 	PasswordReset graphql.Boolean `graphql:"passwordReset(input: $input)"`
 }
+
+type mfaStatusQuery struct {
+	MfaStatus struct {
+		Enrolled graphql.Boolean `graphql:"enrolled"`
+	} `graphql:"mfaStatus"`
+}
+
+type enableMFAMutation struct {
+	EnableMFA struct {
+		EnrollmentURL graphql.String `graphql:"enrollmentUrl"`
+	} `graphql:"enableMFA"`
+}
+
+type disableMFAMutation struct {
+	DisableMFA graphql.Boolean `graphql:"disableMFA"`
+}

--- a/server/pkg/gqlclient/user/repo.go
+++ b/server/pkg/gqlclient/user/repo.go
@@ -60,9 +60,15 @@ type UpdateMeInput struct {
 	Website              *string
 }
 
+type MFAStatus struct {
+	Enrolled bool
+}
+
 type Repo interface {
 	CreateVerification(ctx context.Context, email string) (bool, error)
 	DeleteMe(ctx context.Context, userID string) error
+	DisableMFA(ctx context.Context) error
+	EnableMFA(ctx context.Context) (enrollmentURL string, err error)
 	FindByAlias(ctx context.Context, alias string) (*user.User, error)
 	FindByID(ctx context.Context, id string) (*user.User, error)
 	FindByIDs(ctx context.Context, ids []string) ([]*user.User, error)
@@ -70,6 +76,7 @@ type Repo interface {
 	FindByNameOrEmail(ctx context.Context, nameOrEmail string) (*user.User, error)
 	FindMe(ctx context.Context) (*user.User, error)
 	FindUsersByIDsWithPagination(ctx context.Context, id []string, alias string, page, size int64) (user.List, int, error)
+	GetMFAStatus(ctx context.Context) (MFAStatus, error)
 	Logout(ctx context.Context) (*user.User, error)
 	PasswordReset(ctx context.Context, password string, token string) error
 	RemoveMyAuth(ctx context.Context, auth string) (*user.User, error)
@@ -679,6 +686,30 @@ func (r *userRepo) StartPasswordReset(ctx context.Context, email string) error {
 	}
 
 	return nil
+}
+
+func (r *userRepo) DisableMFA(ctx context.Context) error {
+	var m disableMFAMutation
+	if err := r.client.Mutate(ctx, &m, nil); err != nil {
+		return gqlerror.ReturnAccountsError(ctx, err)
+	}
+	return nil
+}
+
+func (r *userRepo) EnableMFA(ctx context.Context) (string, error) {
+	var m enableMFAMutation
+	if err := r.client.Mutate(ctx, &m, nil); err != nil {
+		return "", gqlerror.ReturnAccountsError(ctx, err)
+	}
+	return string(m.EnableMFA.EnrollmentURL), nil
+}
+
+func (r *userRepo) GetMFAStatus(ctx context.Context) (MFAStatus, error) {
+	var q mfaStatusQuery
+	if err := r.client.Query(ctx, &q, nil); err != nil {
+		return MFAStatus{}, gqlerror.ReturnAccountsError(ctx, err)
+	}
+	return MFAStatus{Enrolled: bool(q.MfaStatus.Enrolled)}, nil
 }
 
 func (r *userRepo) PasswordReset(ctx context.Context, password string, token string) error {

--- a/server/schemas/user.graphql
+++ b/server/schemas/user.graphql
@@ -37,6 +37,14 @@ type Verification {
   verified: Boolean!
 }
 
+type MFAEnrollResult {
+  enrollmentUrl: String!
+}
+
+type MFAStatus {
+  enrolled: Boolean!
+}
+
 type UsersWithPagination {
   users: [User!]!
   totalCount: Int!
@@ -114,10 +122,11 @@ extend type Query {
   findUsersByIDsWithPagination(ids: [ID!]!, alias: String, pagination: Pagination!): UsersWithPagination!
   findUsersByIDs(ids: [ID!]!): [User!]!
   me: Me
+  mfaStatus: MFAStatus!
   searchUser(keyword: String!): [User!]!
   user(id: ID!): User
-  userByNameOrEmail(nameOrEmail: String!): User
   userByNameOrAlias(nameOrAlias: String!): [User!]!
+  userByNameOrEmail(nameOrEmail: String!): User
 }
 
 type UserPayload {
@@ -135,14 +144,15 @@ type DeleteMePayload {
 extend type Mutation {
   createVerification(input: CreateVerificationInput!): Boolean
   deleteMe(input: DeleteMeInput!): DeleteMePayload
+  disableMFA: Boolean!
+  enableMFA: MFAEnrollResult!
   findOrCreate(input: FindOrCreateInput!): UserPayload
+  logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload
-
   startPasswordReset(input: StartPasswordResetInput!): Boolean
   updateMe(input: UpdateMeInput!): UpdateMePayload
-  logout: Me
   verifyUser(input: VerifyUserInput!): UserPayload
 }


### PR DESCRIPTION
## Why

Users need a per-user MFA on/off toggle accessible from reearth-dashboard. When enabled, the dashboard receives an Auth0 Guardian enrollment ticket URL and presents it in a popup so the user can enroll. When disabled, all confirmed Guardian enrollments are removed from Auth0.

This PR adds the server-side plumbing: three new GraphQL operations backed by Auth0 Management API calls.

## Changes

### New GraphQL API
- `mfaStatus: MFAStatus!` — returns `enrolled: Boolean` for the authenticated user
- `enableMFA: MFAEnrollResult!` — sets `app_metadata.mfa_enabled=true`, creates a Guardian enrollment ticket, returns `enrollmentUrl`
- `disableMFA: Boolean!` — deletes all confirmed enrollments, sets `app_metadata.mfa_enabled=false`

### Auth0 Management API calls added
- `PATCH /api/v2/users/{id}` — update `app_metadata.mfa_enabled`
- `POST /api/v2/guardian/enrollments/ticket` — create single-use enrollment URL
- `GET /api/v2/users/{id}/enrollments` — check enrollment status
- `DELETE /api/v2/guardian/enrollments/{id}` — remove individual enrollment

### Token scopes extended
`create:guardian_enrollment_tickets delete:guardian_enrollments` added to the management API client credentials request.

### Auth0 Action update required (dashboard)
The existing PostLogin Action must be updated to make MFA enforcement conditional:
```javascript
if (event.user.app_metadata?.mfa_enabled === true) {
    api.multifactor.enable('any', { allowRememberBrowser: false });
}
```

## Checklist

- [x] Verified backward compatibility related to feature modifications (new GraphQL fields only, no breaking changes)
- [x] Confirmed backward compatibility for migrations (no DB schema changes)
- [x] Verified that no PII is included in displayed values