### PR TITLE
ci: add build workflow for reearth-accounts-admin-api image

### DIFF
--- a/.github/workflows/build_admin.yml
+++ b/.github/workflows/build_admin.yml
@@ -1,0 +1,140 @@
+name: build-admin-image
+on:
+  workflow_call:
+    inputs:
+      sha_short:
+        required: true
+        type: string
+      new_tag:
+        required: true
+        type: string
+      new_tag_short:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    env:
+      IMAGE_NAME: reearth/reearth-accounts-admin-api
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Determine version
+        id: options
+        run: |
+          TAG="${{ inputs.new_tag_short != 'blank' && inputs.new_tag_short || '' }}"
+          SHA="${{ inputs.sha_short }}"
+          if [[ -n "$TAG" ]]; then
+            echo "version=$TAG" >> $GITHUB_OUTPUT
+          else
+            echo "version=$SHA" >> $GITHUB_OUTPUT
+          fi
+      - name: Extract platform name
+        id: platform
+        run: echo "name=${PLATFORM//\//-}" >> $GITHUB_OUTPUT
+        env:
+          PLATFORM: ${{ matrix.platform }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          file: ./server/Dockerfile.admin
+          platforms: ${{ matrix.platform }}
+          build-args: VERSION=${{ steps.options.outputs.version }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=admin-${{ steps.platform.outputs.name }}
+          cache-to: type=gha,mode=max,scope=admin-${{ steps.platform.outputs.name }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.docker_build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-digests-${{ steps.platform.outputs.name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create Multi-Platform Manifest
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      IMAGE_NAME: reearth/reearth-accounts-admin-api
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: admin-digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAG="${{ inputs.new_tag_short != 'blank' && inputs.new_tag_short || '' }}"
+          NAME="${{ inputs.name }}"
+
+          if [[ -n "$TAG" ]]; then
+            TAGS="-t $IMAGE_NAME:$TAG"
+            if [[ ! "$TAG" =~ '-' ]]; then
+              TAGS+=" -t $IMAGE_NAME:${TAG%.*}"
+              TAGS+=" -t $IMAGE_NAME:${TAG%%.*}"
+              TAGS+=" -t $IMAGE_NAME:latest"
+            fi
+          else
+            TAGS="-t $IMAGE_NAME:$NAME"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            ${{ steps.tags.outputs.tags }} \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             .github/workflows/ci.yml
             .github/workflows/ci_server.yml
             .github/workflows/build_server.yml
+            .github/workflows/build_admin.yml
             .github/workflows/deploy_server_nightly.yml
 
       - name: Check server output
@@ -127,6 +128,32 @@ jobs:
         inputs.force_deploy_server
       )
     uses: ./.github/workflows/build_server.yml
+    with:
+      sha_short: ${{ needs.ci-collect-info.outputs.sha_short }}
+      new_tag: ${{ needs.ci-collect-info.outputs.new_tag }}
+      new_tag_short: ${{ needs.ci-collect-info.outputs.new_tag_short }}
+      name: ${{ needs.ci-collect-info.outputs.name }}
+      sha: ${{ github.sha }}
+    secrets: inherit
+
+  build-admin:
+    needs:
+      - prepare
+      - ci
+      - ci-server
+      - ci-collect-info
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    if: |
+      !failure() &&
+      needs.ci-server.result == 'success' &&
+      (
+        (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))) ||
+        inputs.force_deploy_server
+      )
+    uses: ./.github/workflows/build_admin.yml
     with:
       sha_short: ${{ needs.ci-collect-info.outputs.sha_short }}
       new_tag: ${{ needs.ci-collect-info.outputs.new_tag }}

--- a/server/Dockerfile.admin
+++ b/server/Dockerfile.admin
@@ -1,0 +1,28 @@
+FROM golang:1.24.10-alpine AS build
+ARG TAG=release
+ARG VERSION
+
+RUN apk add --update --no-cache git ca-certificates build-base
+
+WORKDIR /reearth-accounts-admin-api
+
+COPY go.mod go.sum main.go /reearth-accounts-admin-api/
+RUN go mod download
+
+COPY cmd/ /reearth-accounts-admin-api/cmd/
+COPY docs/ /reearth-accounts-admin-api/docs/
+COPY pkg/ /reearth-accounts-admin-api/pkg/
+COPY internal/ /reearth-accounts-admin-api/internal/
+
+RUN CGO_ENABLED=0 go build -o reearth-accounts-admin-api -tags "${TAG}" "-ldflags=-X main.version=${VERSION} -s -w -buildid=" -trimpath ./cmd/reearth-accounts-admin
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /reearth-accounts-admin-api/reearth-accounts-admin-api /reearth-accounts-admin-api/reearth-accounts-admin-api
+
+WORKDIR /reearth-accounts-admin-api
+
+EXPOSE 8091
+
+CMD ["./reearth-accounts-admin-api"]


### PR DESCRIPTION
## Why

The dev infrastructure PR ([eukarya-inc/infrastructure#2738](https://github.com/eukarya-inc/infrastructure/pull/2738)) provisions a new Cloud Run service for the admin API and references a `reearth-accounts-admin-api` image. That image has no build pipeline yet — the repo `Dockerfile` only builds `./cmd/reearth-accounts`, and the infra PR uses a flagged placeholder image pending this work.

This PR adds the Docker build pipeline for the admin API (`cmd/reearth-accounts-admin`) so the image can be published to DockerHub, mirroring the existing `reearth-accounts-api` pipeline.

### Changes

- **`server/Dockerfile.admin`** — multi-stage/scratch build (same shape as `server/Dockerfile`) that compiles `./cmd/reearth-accounts-admin` into the `reearth-accounts-admin-api` binary. `EXPOSE 8091` matches the admin app's default listen port (`REEARTH_ACCOUNTS_ADMIN_PORT`).
- **`.github/workflows/build_admin.yml`** — reusable workflow mirroring `build_server.yml`: builds `reearth/reearth-accounts-admin-api` for linux/amd64 + linux/arm64 and pushes a multi-platform manifest to DockerHub. gha cache scopes and digest artifacts are `admin-` prefixed so they don't collide with the api build.
- **`.github/workflows/ci.yml`** — adds a `build-admin` job that runs in parallel with `build-server` under the same conditions (main / release pushes, or `force_deploy_server`), and adds `build_admin.yml` to the server changed-files detection.

### Out of scope / follow-ups

- **Deploy wiring.** `deploy_server_nightly.yml` still deploys only the api to Cloud Run. Pushing the admin image to GC Artifact Registry and deploying it will be a separate PR (the infra service is dev-only with a placeholder image and sign-in env deferred).
- Release workflow (`release.yml`) is intentionally left unchanged; the admin image is published via the nightly build only.

## Checklist

- [x] Verified backward compatibility related to feature modifications (additive only; no existing workflow behavior changed)
- [x] Confirmed backward compatibility for migrations (N/A — no migrations)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)