### PR TITLE
ci: use dedicated concurrency group for build-admin

### DIFF
--- a/.github/workflows/build_admin.yml
+++ b/.github/workflows/build_admin.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: build-admin-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Why

On the first main build after [#289](https://github.com/reearth/reearth-accounts/pull/289), `build-admin` was cancelled with `Canceling since a higher priority waiting request for ci-main exists`.

Root cause: in a reusable workflow, `${{ github.workflow }}` resolves to the **caller** workflow name (`ci`), not the reusable workflow's own name. So both `build_admin.yml` and `build_server.yml` computed the same concurrency group `ci-main`, and with `cancel-in-progress: true` they cancelled each other — `build-admin` lost the race to `build-server`.

Fix: give `build-admin` its own dedicated concurrency group (`build-admin-<ref>`) so it no longer races with `build-server`.

## Checklist

- [x] Verified backward compatibility related to feature modifications (CI-only change; build-server unaffected)
- [x] Confirmed backward compatibility for migrations (N/A — no migrations)
- [x] Verified that no PII is included in displayed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)