### PR TITLE
feat(server): add batch workspaces-by-IDs to admin API

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -529,7 +529,7 @@ const docTemplate = `{
         },
         "/workspaces": {
             "get": {
-                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.",
+                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nWhen one or more ` + "`" + `ids` + "`" + ` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores ` + "`" + `q` + "`" + `, ` + "`" + `page` + "`" + ` and ` + "`" + `per_page` + "`" + `. At most 100 ids may be supplied per request.",
                 "produces": [
                     "application/json"
                 ],
@@ -538,6 +538,16 @@ const docTemplate = `{
                 ],
                 "summary": "List workspaces",
                 "parameters": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored.",
+                        "name": "ids",
+                        "in": "query"
+                    },
                     {
                         "type": "string",
                         "description": "Search by name or alias",

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -522,7 +522,7 @@
         },
         "/workspaces": {
             "get": {
-                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.",
+                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nWhen one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.",
                 "produces": [
                     "application/json"
                 ],
@@ -531,6 +531,16 @@
                 ],
                 "summary": "List workspaces",
                 "parameters": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored.",
+                        "name": "ids",
+                        "in": "query"
+                    },
                     {
                         "type": "string",
                         "description": "Search by name or alias",

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -541,9 +541,18 @@ paths:
       - users
   /workspaces:
     get:
-      description: Lists workspaces across all tenants, optionally filtered by a name/alias
-        keyword, with offset pagination.
+      description: |-
+        Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.
+        When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.
       parameters:
+      - collectionFormat: multi
+        description: Batch fetch by workspace ID (repeatable, max 100). When present,
+          q/page/per_page are ignored.
+        in: query
+        items:
+          type: string
+        name: ids
+        type: array
       - description: Search by name or alias
         in: query
         name: q

--- a/server/internal/admin/presentation/handler/workspace/handler_list.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_list.go
@@ -5,18 +5,26 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-accounts/server/internal/admin/presentation/internal"
+	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/workspaceuc"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
 	"github.com/reearth/reearth-accounts/server/pkg/pagination"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 )
+
+// maxWorkspaceIDsPerRequest caps a single batch-by-IDs request.
+const maxWorkspaceIDsPerRequest = 100
 
 // ListWorkspaces godoc
 //
 //	@Summary		List workspaces
 //	@Description	Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.
+//	@Description	When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.
 //	@Tags			workspaces
 //	@Produce		json
-//	@Param			q			query		string	false	"Search by name or alias"
-//	@Param			page		query		int		false	"Page number (1-based)"
-//	@Param			per_page	query		int		false	"Items per page (max 100)"
+//	@Param			ids			query		[]string	false	"Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored."	collectionFormat(multi)
+//	@Param			q			query		string		false	"Search by name or alias"
+//	@Param			page		query		int			false	"Page number (1-based)"
+//	@Param			per_page	query		int			false	"Items per page (max 100)"
 //	@Success		200			{object}	ListWorkspacesResponse
 //	@Failure		400			{object}	internal.ErrorResponse	"invalid query"
 //	@Failure		401			{object}	internal.ErrorResponse	"unauthorized"
@@ -24,6 +32,10 @@ import (
 //	@Failure		501			{object}	internal.ErrorResponse	"not implemented on this backend"
 //	@Router			/workspaces [get]
 func (h *Handler) ListWorkspaces(c echo.Context) error {
+	if rawIDs := nonEmpty(c.QueryParams()["ids"]); len(rawIDs) > 0 {
+		return h.listWorkspacesByIDs(c, rawIDs)
+	}
+
 	var keyword *string
 	if q := c.QueryParam("q"); q != "" {
 		keyword = &q
@@ -39,7 +51,10 @@ func (h *Handler) ListWorkspaces(c echo.Context) error {
 	}
 	p := pagination.ToPagination(page, perPage)
 
-	list, pi, err := h.list.Execute(c.Request().Context(), keyword, p)
+	list, pi, err := h.list.Execute(c.Request().Context(), workspaceuc.ListWorkspacesInput{
+		Keyword:    keyword,
+		Pagination: p,
+	})
 	if err != nil {
 		return err
 	}
@@ -54,4 +69,46 @@ func (h *Handler) ListWorkspaces(c echo.Context) error {
 		Page:       effectivePage,
 		PerPage:    p.Offset.Limit,
 	})
+}
+
+// listWorkspacesByIDs resolves the given workspace IDs in one call. Malformed
+// IDs are rejected with 400; unknown-but-valid IDs are omitted.
+func (h *Handler) listWorkspacesByIDs(c echo.Context, rawIDs []string) error {
+	if len(rawIDs) > maxWorkspaceIDsPerRequest {
+		return echo.NewHTTPError(http.StatusBadRequest, "too many ids")
+	}
+
+	ids := make(workspace.IDList, 0, len(rawIDs))
+	for _, raw := range rawIDs {
+		wid, err := id.WorkspaceIDFrom(raw)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		}
+		ids = append(ids, wid)
+	}
+
+	list, _, err := h.list.Execute(c.Request().Context(), workspaceuc.ListWorkspacesInput{IDs: ids})
+	if err != nil {
+		return err
+	}
+
+	items := newWorkspaceResponses(list)
+	return c.JSON(http.StatusOK, ListWorkspacesResponse{
+		Items:      items,
+		TotalCount: int64(len(items)),
+		Page:       1,
+		PerPage:    int64(len(items)),
+	})
+}
+
+// nonEmpty drops empty strings, so a blank `?ids=` falls through to the normal
+// keyword/pagination listing.
+func nonEmpty(values []string) []string {
+	out := values[:0:0]
+	for _, v := range values {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/server/internal/admin/presentation/handler/workspace/handler_list.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_list.go
@@ -78,12 +78,20 @@ func (h *Handler) listWorkspacesByIDs(c echo.Context, rawIDs []string) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "too many ids")
 	}
 
+	// De-duplicate parsed IDs while preserving first-seen order so that a
+	// repeated `?ids=a&ids=a` resolves each workspace once, matching the
+	// intended "set of IDs" semantics.
 	ids := make(workspace.IDList, 0, len(rawIDs))
+	seen := make(map[id.WorkspaceID]struct{}, len(rawIDs))
 	for _, raw := range rawIDs {
 		wid, err := id.WorkspaceIDFrom(raw)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 		}
+		if _, ok := seen[wid]; ok {
+			continue
+		}
+		seen[wid] = struct{}{}
 		ids = append(ids, wid)
 	}
 
@@ -97,7 +105,10 @@ func (h *Handler) listWorkspacesByIDs(c echo.Context, rawIDs []string) error {
 		Items:      items,
 		TotalCount: int64(len(items)),
 		Page:       1,
-		PerPage:    int64(len(items)),
+		// PerPage reflects the number of requested (de-duplicated) IDs rather
+		// than the returned count, keeping response metadata consistent with the
+		// non-batch listing and avoiding a zero PerPage when no IDs resolve.
+		PerPage: int64(len(ids)),
 	})
 }
 

--- a/server/internal/admin/presentation/handler/workspace/handler_list.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_list.go
@@ -115,7 +115,7 @@ func (h *Handler) listWorkspacesByIDs(c echo.Context, rawIDs []string) error {
 // nonEmpty drops empty strings, so a blank `?ids=` falls through to the normal
 // keyword/pagination listing.
 func nonEmpty(values []string) []string {
-	out := values[:0:0]
+	out := make([]string, 0, len(values))
 	for _, v := range values {
 		if v != "" {
 			out = append(out, v)

--- a/server/internal/admin/presentation/handler/workspace/handler_test.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -97,6 +98,95 @@ func TestListWorkspaces_Keyword(t *testing.T) {
 	assert.Equal(t, int64(1), body.TotalCount)
 	require.Len(t, body.Items, 1)
 	assert.Equal(t, "Beta", body.Items[0].Name)
+}
+
+func TestListWorkspaces_ByIDs_ReturnsMatching_OmitsUnknown(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	alpha := ws("Alpha", "alpha")
+	beta := ws("Beta", "beta")
+	wsRepo := memory.NewWorkspaceWith(alpha, beta)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	// Request alpha + an unknown id; unknown must be silently omitted.
+	q := url.Values{"ids": {alpha.ID().String(), workspace.NewID().String()}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, alpha.ID().String(), body.Items[0].ID)
+	assert.Equal(t, int64(1), body.TotalCount)
+	assert.Equal(t, int64(1), body.Page)
+	assert.Equal(t, int64(1), body.PerPage)
+}
+
+func TestListWorkspaces_ByIDs_IgnoresKeywordAndPaging(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	alpha := ws("Alpha", "alpha")
+	beta := ws("Beta", "beta")
+	wsRepo := memory.NewWorkspaceWith(alpha, beta)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	// q/page/per_page are present but must be ignored in batch mode.
+	q := url.Values{
+		"ids":      {alpha.ID().String()},
+		"q":        {"zzz-no-match"},
+		"page":     {"5"},
+		"per_page": {"1"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, alpha.ID().String(), body.Items[0].ID)
+	assert.Equal(t, int64(1), body.Page)
+}
+
+func TestListWorkspaces_ByIDs_TooMany_400(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	ids := make([]string, 0, 101)
+	for i := 0; i < 101; i++ {
+		ids = append(ids, workspace.NewID().String())
+	}
+	q := url.Values{"ids": ids}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListWorkspaces_ByIDs_InvalidID_400(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	q := url.Values{"ids": {"not-an-id"}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListWorkspaces_InvalidPagination(t *testing.T) {

--- a/server/internal/admin/presentation/handler/workspace/handler_test.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_test.go
@@ -123,6 +123,34 @@ func TestListWorkspaces_ByIDs_ReturnsMatching_OmitsUnknown(t *testing.T) {
 	assert.Equal(t, alpha.ID().String(), body.Items[0].ID)
 	assert.Equal(t, int64(1), body.TotalCount)
 	assert.Equal(t, int64(1), body.Page)
+	// PerPage reflects the number of requested (de-duplicated) IDs, not the
+	// number that resolved: alpha + one unknown id => 2.
+	assert.Equal(t, int64(2), body.PerPage)
+}
+
+func TestListWorkspaces_ByIDs_DeduplicatesRepeatedIDs(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	alpha := ws("Alpha", "alpha")
+	beta := ws("Beta", "beta")
+	wsRepo := memory.NewWorkspaceWith(alpha, beta)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	// The same id repeated must resolve the workspace exactly once.
+	q := url.Values{"ids": {alpha.ID().String(), alpha.ID().String()}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, alpha.ID().String(), body.Items[0].ID)
+	assert.Equal(t, int64(1), body.TotalCount)
+	// PerPage reflects the de-duplicated request size, so 1 not 2.
 	assert.Equal(t, int64(1), body.PerPage)
 }
 

--- a/server/internal/admin/usecase/workspaceuc/list.go
+++ b/server/internal/admin/usecase/workspaceuc/list.go
@@ -10,8 +10,8 @@ import (
 	"github.com/reearth/reearthx/usecasex"
 )
 
-// ListWorkspacesUseCase lists workspaces across all tenants, optionally filtered
-// by a name/alias keyword, with offset pagination.
+// ListWorkspacesUseCase lists admin workspaces. See ListWorkspacesInput for its
+// two modes (keyword listing vs. batch-by-IDs).
 type ListWorkspacesUseCase struct {
 	repo workspace.Repo
 }
@@ -21,7 +21,25 @@ func NewListWorkspacesUseCase(repo workspace.Repo) *ListWorkspacesUseCase {
 	return &ListWorkspacesUseCase{repo: repo}
 }
 
-// Execute returns the matching workspaces and pagination info.
-func (uc *ListWorkspacesUseCase) Execute(ctx context.Context, keyword *string, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
-	return uc.repo.FindAll(ctx, keyword, pagination)
+// ListWorkspacesInput selects which workspaces to return. When IDs is non-empty
+// it is a batch-by-IDs lookup (unknown IDs omitted) and Keyword/Pagination are
+// ignored; otherwise it is a keyword-filtered, offset-paginated listing. Both
+// modes read across all tenants (the admin repo is unfiltered).
+type ListWorkspacesInput struct {
+	Keyword    *string
+	Pagination *usecasex.Pagination
+	IDs        workspace.IDList
+}
+
+// Execute returns the matching workspaces. Batch-by-IDs mode returns a nil
+// *PageInfo; callers derive counts from the list.
+func (uc *ListWorkspacesUseCase) Execute(ctx context.Context, in ListWorkspacesInput) (workspace.List, *usecasex.PageInfo, error) {
+	if len(in.IDs) > 0 {
+		list, err := uc.repo.FindByIDs(ctx, in.IDs)
+		if err != nil {
+			return nil, nil, err
+		}
+		return list, nil, nil
+	}
+	return uc.repo.FindAll(ctx, in.Keyword, in.Pagination)
 }

--- a/server/internal/admin/usecase/workspaceuc/list.go
+++ b/server/internal/admin/usecase/workspaceuc/list.go
@@ -44,16 +44,22 @@ func (uc *ListWorkspacesUseCase) Execute(ctx context.Context, in ListWorkspacesI
 	}
 
 	// FindByIDs order is backend-dependent (Mongo matches the requested order,
-	// the memory repo sorts by ID). Re-order to the requested (de-duplicated)
-	// IDs so the API response order is stable across backends; unknown IDs are
-	// naturally omitted.
+	// the memory repo sorts by ID). Re-order to match in.IDs so the API response
+	// order is stable across backends; unknown IDs are naturally omitted. Each
+	// workspace is emitted at most once, so a repeated input ID does not produce
+	// a duplicate entry even though de-duplication is normally done by the caller.
 	byID := make(map[workspace.ID]*workspace.Workspace, len(list))
 	for _, w := range list {
 		byID[w.ID()] = w
 	}
 	ordered := make(workspace.List, 0, len(in.IDs))
+	seen := make(map[workspace.ID]struct{}, len(in.IDs))
 	for _, wid := range in.IDs {
+		if _, dup := seen[wid]; dup {
+			continue
+		}
 		if w, ok := byID[wid]; ok {
+			seen[wid] = struct{}{}
 			ordered = append(ordered, w)
 		}
 	}

--- a/server/internal/admin/usecase/workspaceuc/list.go
+++ b/server/internal/admin/usecase/workspaceuc/list.go
@@ -34,12 +34,28 @@ type ListWorkspacesInput struct {
 // Execute returns the matching workspaces. Batch-by-IDs mode returns a nil
 // *PageInfo; callers derive counts from the list.
 func (uc *ListWorkspacesUseCase) Execute(ctx context.Context, in ListWorkspacesInput) (workspace.List, *usecasex.PageInfo, error) {
-	if len(in.IDs) > 0 {
-		list, err := uc.repo.FindByIDs(ctx, in.IDs)
-		if err != nil {
-			return nil, nil, err
-		}
-		return list, nil, nil
+	if len(in.IDs) == 0 {
+		return uc.repo.FindAll(ctx, in.Keyword, in.Pagination)
 	}
-	return uc.repo.FindAll(ctx, in.Keyword, in.Pagination)
+
+	list, err := uc.repo.FindByIDs(ctx, in.IDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// FindByIDs order is backend-dependent (Mongo matches the requested order,
+	// the memory repo sorts by ID). Re-order to the requested (de-duplicated)
+	// IDs so the API response order is stable across backends; unknown IDs are
+	// naturally omitted.
+	byID := make(map[workspace.ID]*workspace.Workspace, len(list))
+	for _, w := range list {
+		byID[w.ID()] = w
+	}
+	ordered := make(workspace.List, 0, len(in.IDs))
+	for _, wid := range in.IDs {
+		if w, ok := byID[wid]; ok {
+			ordered = append(ordered, w)
+		}
+	}
+	return ordered, nil, nil
 }

--- a/server/internal/admin/usecase/workspaceuc/list_test.go
+++ b/server/internal/admin/usecase/workspaceuc/list_test.go
@@ -20,10 +20,24 @@ func TestList_All(t *testing.T) {
 	repo := memory.NewWorkspaceWith(ws("Alpha", "alpha"), ws("Beta", "beta"))
 	uc := NewListWorkspacesUseCase(repo)
 
-	got, pi, err := uc.Execute(ctx, nil, nil)
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(got))
 	assert.Equal(t, int64(2), pi.TotalCount)
+}
+
+func TestList_ByIDs_ReturnsMatching_OmitsUnknown(t *testing.T) {
+	ctx := context.Background()
+	alpha := ws("Alpha", "alpha")
+	beta := ws("Beta", "beta")
+	repo := memory.NewWorkspaceWith(alpha, beta)
+	uc := NewListWorkspacesUseCase(repo)
+
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{IDs: workspace.IDList{alpha.ID(), workspace.NewID()}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, alpha.ID(), got[0].ID())
+	assert.Nil(t, pi)
 }
 
 func TestList_Keyword(t *testing.T) {
@@ -32,7 +46,7 @@ func TestList_Keyword(t *testing.T) {
 	uc := NewListWorkspacesUseCase(repo)
 
 	kw := "alph"
-	got, pi, err := uc.Execute(ctx, &kw, nil)
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{Keyword: &kw})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(got))
 	assert.Equal(t, "Alpha", got[0].Name())
@@ -47,7 +61,7 @@ func TestList_RejectsCursorPagination(t *testing.T) {
 	cur := usecasex.Cursor("x")
 	first := int64(1)
 	p := usecasex.CursorPagination{First: &first, After: &cur}.Wrap()
-	_, _, err := uc.Execute(ctx, nil, p)
+	_, _, err := uc.Execute(ctx, ListWorkspacesInput{Pagination: p})
 	assert.ErrorIs(t, err, workspace.ErrCursorPaginationUnsupported)
 }
 
@@ -57,7 +71,7 @@ func TestList_Pagination(t *testing.T) {
 	uc := NewListWorkspacesUseCase(repo)
 
 	p := usecasex.OffsetPagination{Offset: 1, Limit: 1}.Wrap()
-	got, pi, err := uc.Execute(ctx, nil, p)
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{Pagination: p})
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(got))
 	assert.Equal(t, int64(3), pi.TotalCount)

--- a/server/internal/admin/usecase/workspaceuc/list_test.go
+++ b/server/internal/admin/usecase/workspaceuc/list_test.go
@@ -40,6 +40,24 @@ func TestList_ByIDs_ReturnsMatching_OmitsUnknown(t *testing.T) {
 	assert.Nil(t, pi)
 }
 
+func TestList_ByIDs_PreservesRequestedOrder(t *testing.T) {
+	ctx := context.Background()
+	a := ws("Alpha", "alpha")
+	b := ws("Beta", "beta")
+	c := ws("Gamma", "gamma")
+	repo := memory.NewWorkspaceWith(a, b, c)
+	uc := NewListWorkspacesUseCase(repo)
+
+	// Request in an order that does not match the backend's natural (by-ID)
+	// order; the response must follow the requested order.
+	want := workspace.IDList{c.ID(), a.ID(), b.ID()}
+	got, _, err := uc.Execute(ctx, ListWorkspacesInput{IDs: want})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	gotIDs := workspace.IDList{got[0].ID(), got[1].ID(), got[2].ID()}
+	assert.Equal(t, want, gotIDs)
+}
+
 func TestList_Keyword(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewWorkspaceWith(ws("Alpha", "alpha"), ws("Beta", "beta"))

--- a/server/internal/admin/usecase/workspaceuc/list_test.go
+++ b/server/internal/admin/usecase/workspaceuc/list_test.go
@@ -58,6 +58,21 @@ func TestList_ByIDs_PreservesRequestedOrder(t *testing.T) {
 	assert.Equal(t, want, gotIDs)
 }
 
+func TestList_ByIDs_DeduplicatesRepeatedIDs(t *testing.T) {
+	ctx := context.Background()
+	a := ws("Alpha", "alpha")
+	b := ws("Beta", "beta")
+	repo := memory.NewWorkspaceWith(a, b)
+	uc := NewListWorkspacesUseCase(repo)
+
+	// A repeated input ID must yield the workspace exactly once.
+	got, _, err := uc.Execute(ctx, ListWorkspacesInput{IDs: workspace.IDList{a.ID(), a.ID(), b.ID()}})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, a.ID(), got[0].ID())
+	assert.Equal(t, b.ID(), got[1].ID())
+}
+
 func TestList_Keyword(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewWorkspaceWith(ws("Alpha", "alpha"), ws("Beta", "beta"))


### PR DESCRIPTION
## Why

The reearth-dashboard **admin** API lists subscriptions across all tenants and wants to show each row's workspace name / alias / personal flag. The admin surface only had `GET /api/v1/workspaces` (q/page list) and `GET /api/v1/workspaces/:id` (single), so resolving a page of ~N workspaces meant N round-trips. This adds a batch-by-IDs read so a whole page resolves in one call.

## What

Extend `GET /api/v1/workspaces` to accept a repeated `ids` query param:

- `GET /api/v1/workspaces?ids=<id1>&ids=<id2>...` returns the existing workspaces in that set (same `ListWorkspacesResponse` shape), in the requested (de-duplicated) order, **silently omitting** IDs that don't exist; `q`/`page`/`per_page` are ignored.
- More than 100 ids → `400 "too many ids"`; a malformed id → `400 "invalid id"` (consistent with the single `:id` handler).
- `ids` absent → behavior unchanged. RBAC guard `RequirePermission(ResourceWorkspace, ActionList)` is untouched.
- Reads are cross-tenant/unfiltered (the admin repo container is built without `.Filtered(...)`), consistent with the admin layer's existing `GetWorkspace`/`ListWorkspaces`; built on the existing `repo.FindByIDs`.

Rather than a separate usecase, the existing `ListWorkspacesUseCase` gains a dual-mode `ListWorkspacesInput`: when `IDs` is non-empty it is a batch-by-IDs lookup (results re-ordered to match the requested IDs, duplicates collapsed, unknown IDs omitted), otherwise it is the existing keyword-filtered, offset-paginated listing. The handler branches on `ids` (de-duplicating and validating them first); DI + admin swagger regenerated.

## Checklist

- [x] Backward compatible (additive query param; absent `ids` = unchanged behavior)
- [x] No migrations
- [x] No PII in responses/logs (workspace id/name/alias only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)