### PR TITLE
docs(server): note known reauth gap in updateMe/disableMFA (SEC-03)

### DIFF
--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -223,6 +223,10 @@ func (i *User) UpdateMe(ctx context.Context, p interfaces.UpdateMeParam, operato
 			}
 		}
 
+		// SEC-03: this sets a new password from the session alone, with no
+		// current-password or step-up MFA check. Re-authentication for
+		// sensitive account mutations is planned to be covered by MFA
+		// confirmation in a future change, not now.
 		if p.Password != nil && u.HasAuthProvider("reearth") {
 			if err := u.SetPassword(*p.Password); err != nil {
 				return nil, err
@@ -303,6 +307,11 @@ func (i *User) RemoveMyAuth(ctx context.Context, authProvider string, operator *
 	})
 }
 
+// SEC-03: disabling MFA here only requires a valid operator/session, with no
+// password confirmation, current-MFA challenge, or recent-auth check guarding
+// this privilege-lowering operation. Re-authentication for sensitive account
+// mutations like this is planned to be covered by MFA confirmation in a
+// future change, not now.
 func (i *User) DisableMFA(ctx context.Context, operator *workspace.Operator) error {
 	if operator == nil || operator.User == nil {
 		return interfaces.ErrInvalidOperator


### PR DESCRIPTION
## Why

An AI security scan (SEC-03) flagged that `disableMFA` and the password-change path in `updateMe` perform no re-authentication (current password / fresh MFA challenge / recent-auth check) before a privilege-lowering action, which could let a stolen session token be chained into permanent account takeover.

A code-level fix isn't being made in this PR: re-authentication for sensitive account mutations is planned to be handled via MFA confirmation in a future change. This PR adds explicit comments at both call sites so the gap is documented in the code itself rather than only in the compliance report.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values