### PR TITLE
feat(server): issue admin_csrf double-submit cookie for admin auth

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -261,7 +261,7 @@ const docTemplate = `{
         },
         "/auth/google": {
             "post": {
-                "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
+                "description": "Verifies the Google id_token and issues an HttpOnly admin session cookie plus a readable (non-HttpOnly) admin_csrf double-submit cookie. New accounts are created as pending (approved when the email is bootstrapped).",
                 "consumes": [
                     "application/json"
                 ],
@@ -313,7 +313,7 @@ const docTemplate = `{
         },
         "/auth/logout": {
             "post": {
-                "description": "Clears the session cookie. Public endpoint so the cookie can be cleared even with an expired/invalid token.",
+                "description": "Clears the admin session cookie and the admin_csrf double-submit cookie. Public endpoint so the cookies can be cleared even with an expired/invalid token.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -254,7 +254,7 @@
         },
         "/auth/google": {
             "post": {
-                "description": "Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).",
+                "description": "Verifies the Google id_token and issues an HttpOnly admin session cookie plus a readable (non-HttpOnly) admin_csrf double-submit cookie. New accounts are created as pending (approved when the email is bootstrapped).",
                 "consumes": [
                     "application/json"
                 ],
@@ -306,7 +306,7 @@
         },
         "/auth/logout": {
             "post": {
-                "description": "Clears the session cookie. Public endpoint so the cookie can be cleared even with an expired/invalid token.",
+                "description": "Clears the admin session cookie and the admin_csrf double-submit cookie. Public endpoint so the cookies can be cleared even with an expired/invalid token.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -362,8 +362,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Verifies the Google id_token and issues an admin session cookie.
-        New accounts are created as pending (approved when the email is bootstrapped).
+      description: Verifies the Google id_token and issues an HttpOnly admin session
+        cookie plus a readable (non-HttpOnly) admin_csrf double-submit cookie. New
+        accounts are created as pending (approved when the email is bootstrapped).
       parameters:
       - description: Google id_token
         in: body
@@ -395,8 +396,9 @@ paths:
       - auth
   /auth/logout:
     post:
-      description: Clears the session cookie. Public endpoint so the cookie can be
-        cleared even with an expired/invalid token.
+      description: Clears the admin session cookie and the admin_csrf double-submit
+        cookie. Public endpoint so the cookies can be cleared even with an expired/invalid
+        token.
       produces:
       - application/json
       responses:

--- a/server/internal/admin/presentation/handler/auth/handler.go
+++ b/server/internal/admin/presentation/handler/auth/handler.go
@@ -1,5 +1,6 @@
 // Package auth implements the admin authentication endpoints: Google sign-in,
-// logout, and the current-user lookup, backed by an HttpOnly session cookie.
+// logout, and the current-user lookup, backed by an HttpOnly session cookie
+// plus a readable (non-HttpOnly) admin_csrf double-submit companion cookie.
 package auth
 
 import (

--- a/server/internal/admin/presentation/handler/auth/handler.go
+++ b/server/internal/admin/presentation/handler/auth/handler.go
@@ -3,12 +3,19 @@
 package auth
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
 	"time"
 
 	"github.com/reearth/reearth-accounts/server/internal/admin/auth/session"
 	"github.com/reearth/reearth-accounts/server/internal/admin/usecase/authuc"
 )
+
+// csrfCookieName is the name of the non-HttpOnly companion cookie carrying the
+// double-submit CSRF token. The frontend JS reads it via document.cookie and
+// echoes it back in a request header; the admin BFF matches the two.
+const csrfCookieName = "admin_csrf"
 
 // CookieSecure is a named bool so Wire can inject it unambiguously. It controls
 // the Secure attribute of the session cookie (true in production/HTTPS).
@@ -53,4 +60,47 @@ func (h *Handler) clearSessionCookie() *http.Cookie {
 		// RFC6265 deletion behavior rather than Max-Age.
 		Expires: time.Unix(0, 0),
 	}
+}
+
+// newCSRFCookie builds the double-submit CSRF cookie. It mirrors
+// newSessionCookie but is deliberately NOT HttpOnly so the frontend JS can read
+// its value and echo it back in a request header.
+func (h *Handler) newCSRFCookie(value string, now time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     csrfCookieName,
+		Value:    value,
+		Path:     "/",
+		HttpOnly: false,
+		Secure:   h.secure,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  now.Add(h.sess.TTL()),
+		MaxAge:   int(h.sess.TTL().Seconds()),
+	}
+}
+
+func (h *Handler) clearCSRFCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:     csrfCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: false,
+		Secure:   h.secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+		// Also set a past Expires for clients/proxies that honor the legacy
+		// RFC6265 deletion behavior rather than Max-Age.
+		Expires: time.Unix(0, 0),
+	}
+}
+
+// newCSRFToken returns an unguessable, URL-safe token suitable as both a cookie
+// value and an HTTP header value. Double-submit validation only requires that
+// the cookie and header values match, so the token needs no server-side storage
+// and is independent of the session JWT.
+func newCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/server/internal/admin/presentation/handler/auth/handler_google.go
+++ b/server/internal/admin/presentation/handler/auth/handler_google.go
@@ -10,7 +10,7 @@ import (
 // GoogleSignIn godoc
 //
 //	@Summary		Sign in with a Google id_token
-//	@Description	Verifies the Google id_token and issues an admin session cookie. New accounts are created as pending (approved when the email is bootstrapped).
+//	@Description	Verifies the Google id_token and issues an HttpOnly admin session cookie plus a readable (non-HttpOnly) admin_csrf double-submit cookie. New accounts are created as pending (approved when the email is bootstrapped).
 //	@Tags			auth
 //	@Accept			json
 //	@Produce		json

--- a/server/internal/admin/presentation/handler/auth/handler_google.go
+++ b/server/internal/admin/presentation/handler/auth/handler_google.go
@@ -40,7 +40,12 @@ func (h *Handler) GoogleSignIn(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	csrf, err := newCSRFToken()
+	if err != nil {
+		return err
+	}
 	c.SetCookie(h.newSessionCookie(token, now))
+	c.SetCookie(h.newCSRFCookie(csrf, now))
 
 	return c.JSON(http.StatusOK, newGoogleSignInResponse(u))
 }

--- a/server/internal/admin/presentation/handler/auth/handler_logout.go
+++ b/server/internal/admin/presentation/handler/auth/handler_logout.go
@@ -9,7 +9,7 @@ import (
 // Logout godoc
 //
 //	@Summary		Log out
-//	@Description	Clears the session cookie. Public endpoint so the cookie can be cleared even with an expired/invalid token.
+//	@Description	Clears the admin session cookie and the admin_csrf double-submit cookie. Public endpoint so the cookies can be cleared even with an expired/invalid token.
 //	@Tags			auth
 //	@Produce		json
 //	@Success		204	"No Content"

--- a/server/internal/admin/presentation/handler/auth/handler_logout.go
+++ b/server/internal/admin/presentation/handler/auth/handler_logout.go
@@ -16,5 +16,6 @@ import (
 //	@Router			/auth/logout [post]
 func (h *Handler) Logout(c echo.Context) error {
 	c.SetCookie(h.clearSessionCookie())
+	c.SetCookie(h.clearCSRFCookie())
 	return c.NoContent(http.StatusNoContent)
 }

--- a/server/internal/admin/presentation/handler/auth/handler_test.go
+++ b/server/internal/admin/presentation/handler/auth/handler_test.go
@@ -89,7 +89,7 @@ func TestAuthFlow_GoogleThenMeThenLogout(t *testing.T) {
 	// session cookie, but readable by JS (not HttpOnly).
 	require.NotNil(t, csrfCookie, "csrf cookie must be set")
 	assert.False(t, csrfCookie.HttpOnly, "csrf cookie must be readable by JS")
-	assert.False(t, csrfCookie.Secure, "csrf cookie Secure must match the handler's secure flag")
+	assert.Equal(t, sessionCookie.Secure, csrfCookie.Secure, "csrf cookie Secure must mirror the session cookie's")
 	assert.Equal(t, http.SameSiteLaxMode, csrfCookie.SameSite)
 	assert.Equal(t, "/", csrfCookie.Path)
 	assert.NotEmpty(t, csrfCookie.Value)

--- a/server/internal/admin/presentation/handler/auth/handler_test.go
+++ b/server/internal/admin/presentation/handler/auth/handler_test.go
@@ -71,16 +71,30 @@ func TestAuthFlow_GoogleThenMeThenLogout(t *testing.T) {
 	assert.Equal(t, "alice@eukarya.io", signInBody.Email)
 
 	cookies := rec.Result().Cookies()
-	var sessionCookie *http.Cookie
+	var sessionCookie, csrfCookie *http.Cookie
 	for _, c := range cookies {
-		if c.Name == session.CookieName {
+		switch c.Name {
+		case session.CookieName:
 			sessionCookie = c
+		case "admin_csrf":
+			csrfCookie = c
 		}
 	}
 	require.NotNil(t, sessionCookie, "session cookie must be set")
 	assert.True(t, sessionCookie.HttpOnly)
 	assert.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite)
 	assert.NotEmpty(t, sessionCookie.Value)
+
+	// The double-submit CSRF companion cookie must be set alongside the
+	// session cookie, but readable by JS (not HttpOnly).
+	require.NotNil(t, csrfCookie, "csrf cookie must be set")
+	assert.False(t, csrfCookie.HttpOnly, "csrf cookie must be readable by JS")
+	assert.False(t, csrfCookie.Secure, "csrf cookie Secure must match the handler's secure flag")
+	assert.Equal(t, http.SameSiteLaxMode, csrfCookie.SameSite)
+	assert.Equal(t, "/", csrfCookie.Path)
+	assert.NotEmpty(t, csrfCookie.Value)
+	// Both cookies share the same lifetime basis (the session TTL).
+	assert.Equal(t, sessionCookie.MaxAge, csrfCookie.MaxAge)
 
 	// 2. /me with the cookie
 	meReq := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
@@ -101,13 +115,17 @@ func TestAuthFlow_GoogleThenMeThenLogout(t *testing.T) {
 	e.ServeHTTP(logoutRec, logoutReq)
 	require.Equal(t, http.StatusNoContent, logoutRec.Code)
 
-	var cleared bool
+	var cleared, csrfCleared bool
 	for _, c := range logoutRec.Result().Cookies() {
 		if c.Name == session.CookieName && c.MaxAge < 0 {
 			cleared = true
 		}
+		if c.Name == "admin_csrf" && c.MaxAge < 0 {
+			csrfCleared = true
+		}
 	}
 	assert.True(t, cleared, "logout must expire the session cookie")
+	assert.True(t, csrfCleared, "logout must expire the csrf cookie")
 }
 
 func TestLogout_NoCookie_Succeeds(t *testing.T) {
@@ -118,13 +136,17 @@ func TestLogout_NoCookie_Succeeds(t *testing.T) {
 	// logout is public: it clears the cookie even with no/expired session
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 
-	var cleared bool
+	var cleared, csrfCleared bool
 	for _, c := range rec.Result().Cookies() {
 		if c.Name == session.CookieName && c.MaxAge < 0 {
 			cleared = true
 		}
+		if c.Name == "admin_csrf" && c.MaxAge < 0 {
+			csrfCleared = true
+		}
 	}
 	assert.True(t, cleared, "logout must expire the session cookie")
+	assert.True(t, csrfCleared, "logout must expire the csrf cookie")
 }
 
 func TestMe_Unauthorized_NoCookie(t *testing.T) {


### PR DESCRIPTION
# Overview

The reearth-dashboard admin-api (BFF) enforces a **double-submit CSRF** check on mutating admin endpoints: it requires a non-HttpOnly `admin_csrf` cookie whose value the frontend echoes back in an `X-Csrf-Token` header (the BFF matches the two).

reearth-accounts owns admin session issuance but until now only set the `admin_session` HttpOnly cookie at sign-in — it never issued `admin_csrf`. As a result, on deployed (Cloud Run) environments every mutating admin action failed with `403 missing csrf token` (surfaced concretely on **admin plan creation**), because the browser had no `admin_csrf` cookie for the frontend JS to read, so no `X-Csrf-Token` header was sent.

Deploy note: this must ship **before** the dashboard admin-api revision that requires CSRF (the BFF already enforces it in the deployed environment).

## What I've done

- Issue an `admin_csrf` companion cookie at Google sign-in (`GoogleSignIn`), alongside `admin_session`.
- Clear `admin_csrf` at logout, alongside `admin_session`.
- The cookie mirrors the session cookie's attributes (`Path=/`, `Secure=h.secure`, `SameSite=Lax`, same TTL) **except** it is deliberately **not** `HttpOnly`, so the frontend JS can read it via `document.cookie`.
- Token value: 32 `crypto/rand` bytes, `base64.RawURLEncoding` (URL-safe, valid as both a cookie value and an HTTP header value). No server-side storage — double-submit only needs cookie == header; the token is independent of the session JWT.

## What I haven't done

- No upstream CSRF **validation** in reearth-accounts (header vs cookie comparison on mutating relayed endpoints). The dashboard BFF already validates locally, so cookie issuance alone unblocks the 403. Upstream validation can be added later as a second defense layer if desired.

## How I tested

- `go build ./...` — OK
- `go test ./internal/admin/presentation/handler/auth/...` — OK (tests assert `admin_csrf` is not HttpOnly, has matching `Secure`/`SameSite=Lax`/`Path=/`, a non-empty value and TTL matching the session cookie; and that logout clears it)
- `go vet` / `golangci-lint` on the changed package — clean

## Which point I want you to review particularly

- Cookie attributes for the deployed topology: `admin_csrf` must be readable by the admin-web frontend's JS on the same host it is set. Please confirm `SameSite=Lax` + non-HttpOnly is correct for the production admin-web / admin-api origin setup (vs. needing `SameSite=None` if they ever end up cross-site).

## Memo

Related: reearth-dashboard admin-api `ValidateCSRF` (`internal/reearth-dashboard-admin-api/.../session_cookie.go`) and the mock contract in `server/cmd/mock-accounts-admin/main.go`.