### PR TITLE
fix(server): remove DB transaction wrapper from MFA methods

### DIFF
--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -307,7 +307,7 @@ func (i *User) DisableMFA(ctx context.Context, operator *workspace.Operator) err
 	if operator == nil || operator.User == nil {
 		return interfaces.ErrInvalidOperator
 	}
-	return Run0(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+	return Run0(ctx, operator, i.repos, Usecase(), func(ctx context.Context) error {
 		u, err := i.repos.User.FindByID(ctx, *operator.User)
 		if err != nil {
 			return err
@@ -328,7 +328,7 @@ func (i *User) EnableMFA(ctx context.Context, operator *workspace.Operator) (str
 	if operator == nil || operator.User == nil {
 		return "", interfaces.ErrInvalidOperator
 	}
-	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (string, error) {
+	return Run1(ctx, operator, i.repos, Usecase(), func(ctx context.Context) (string, error) {
 		u, err := i.repos.User.FindByID(ctx, *operator.User)
 		if err != nil {
 			return "", err
@@ -349,7 +349,7 @@ func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (
 	if operator == nil || operator.User == nil {
 		return gateway.MFAStatus{}, interfaces.ErrInvalidOperator
 	}
-	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (gateway.MFAStatus, error) {
+	return Run1(ctx, operator, i.repos, Usecase(), func(ctx context.Context) (gateway.MFAStatus, error) {
 		u, err := i.repos.User.FindByID(ctx, *operator.User)
 		if err != nil {
 			return gateway.MFAStatus{}, err


### PR DESCRIPTION
## Why

`DisableMFA`/`EnableMFA`/`GetMFAStatus` wrap `Usecase().Transaction()` around `authenticator.*MFA(ctx, a.Sub)`, holding a real DB transaction open for the entire Auth0 Management API round-trip chain, even though the callbacks perform only a `FindByID` read and zero writes.

If Auth0's Management API degrades (routine event; per-call budget is 5s via `REEARTH_ACCOUNTS_AUTH0_HTTP_TIMEOUT`), `DisableMFA` issues token-refresh + list-enrollments + N deletes + PATCH sequentially, holding one pooled connection/session for up to ~30s per request. With `pgxpool.New` using the default `MaxConns`, a handful of concurrent MFA requests can drain the pool; on Mongo the session is pinned toward the 60s `transactionLifetimeLimitSeconds` ceiling. Every other request then blocks in `Transaction.Begin` — including the Cerbos permission-evaluation path shared by all Re:Earth microservices, so an Auth0 latency spike in one optional toggle becomes platform-wide authorization failure.

This is the same class of issue fixed in `1ab70ba` ("move SendMail outside transaction in StartPasswordReset"); unlike that case there is nothing to commit at all here, so the fix is to drop the transaction wrapper entirely.

Fixes the issue documented in `docs/compliance/REL-02-mfa-tx-held-open.md`.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values