### PR TITLE
feat(server): add Scim usecase layer for SCIM provisioning (U-D20-05b)

### DIFF
--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -25,6 +25,7 @@ func NewContainer(
 	cerbos := NewCerbos(r, cerbosAdapter)
 	return interfaces.Container{
 		Cerbos:    cerbos,
+		Scim:      NewScim(r),
 		User:      NewUser(r, acg, config.SignupSecret, config.AuthSrvUIDomain, config.AllowedISS...),
 		Workspace: NewWorkspace(r, enforcer, cerbos),
 	}

--- a/server/internal/usecase/interactor/scim.go
+++ b/server/internal/usecase/interactor/scim.go
@@ -1,0 +1,312 @@
+package interactor
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Scim struct {
+	repos *repo.Container
+}
+
+func NewScim(repos *repo.Container) *Scim {
+	return &Scim{repos: repos}
+}
+
+func (i *Scim) DeprovisionScimUser(ctx context.Context, workspaceID workspace.ID, externalID string) error {
+	return Run0(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return err
+		}
+
+		userID, ok := ws.Members().UserByExternalID(externalID)
+		if !ok {
+			return interfaces.ErrSCIMUserNotFound
+		}
+
+		if ws.Members().IsOnlyOwner(userID) {
+			return interfaces.ErrOwnerCannotLeaveTheWorkspace
+		}
+
+		if err := ws.Members().SetUserDisabled(userID, true); err != nil {
+			return err
+		}
+
+		return i.repos.Workspace.Save(ctx, ws)
+	})
+}
+
+func (i *Scim) GenerateScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (string, error) {
+	return Run1(ctx, operator, i.repos, Usecase().Transaction().WithMaintainableWorkspaces(workspaceID), func(ctx context.Context) (string, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return "", err
+		}
+
+		raw := make([]byte, 32)
+		if _, err := rand.Read(raw); err != nil {
+			return "", err
+		}
+		plaintext := base64.RawURLEncoding.EncodeToString(raw)
+
+		hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+		if err != nil {
+			return "", err
+		}
+
+		cfg := ws.ScimConfig()
+		if cfg == nil {
+			cfg = workspace.NewScimConfig()
+		}
+		cfg.SetTokenHash(string(hash))
+		ws.SetScimConfig(cfg)
+
+		if err := i.repos.Workspace.Save(ctx, ws); err != nil {
+			return "", err
+		}
+
+		return plaintext, nil
+	})
+}
+
+func (i *Scim) GetScimConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*workspace.ScimConfig, error) {
+	ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := ws.ScimConfig()
+	if cfg == nil {
+		return nil, nil
+	}
+
+	if cfg.TokenHash() != "" {
+		cfg.SetTokenHash("***")
+	}
+
+	return cfg, nil
+}
+
+func (i *Scim) GetScimUser(ctx context.Context, workspaceID workspace.ID, userID user.ID) (*user.User, error) {
+	ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ws.Members().HasUser(userID) {
+		return nil, interfaces.ErrSCIMUserNotFound
+	}
+
+	return i.repos.User.FindByID(ctx, userID)
+}
+
+func (i *Scim) ListScimUsers(ctx context.Context, workspaceID workspace.ID, _ string) ([]*user.User, error) {
+	ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	members := ws.Members().Users()
+	userIDs := make(user.IDList, 0, len(members))
+	for uid, m := range members {
+		if !m.Disabled {
+			userIDs = append(userIDs, uid)
+		}
+	}
+
+	if len(userIDs) == 0 {
+		return nil, nil
+	}
+
+	return i.repos.User.FindByIDs(ctx, userIDs)
+}
+
+func (i *Scim) ProvisionScimUser(ctx context.Context, param interfaces.ProvisionScimUserParam) (*user.User, error) {
+	return Run1(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) (*user.User, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, param.WorkspaceID)
+		if err != nil {
+			return nil, err
+		}
+		if !ws.ScimConfig().Enabled() {
+			return nil, interfaces.ErrSCIMNotEnabled
+		}
+
+		// Idempotent: already provisioned by this ExternalID
+		if uid, ok := ws.Members().UserByExternalID(param.ExternalID); ok {
+			return i.repos.User.FindByID(ctx, uid)
+		}
+
+		roleType := param.Role
+		if roleType == "" {
+			roleType = role.RoleReader
+		}
+
+		// User may already exist from JIT or manual invite
+		existingUser, err := i.repos.User.FindByEmail(ctx, param.Email)
+		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+			return nil, err
+		}
+
+		if existingUser != nil {
+			if !ws.Members().HasUser(existingUser.ID()) {
+				if err := ws.Members().Join(existingUser, roleType, existingUser.ID()); err != nil {
+					return nil, err
+				}
+			}
+			if err := ws.Members().SetUserExternalID(existingUser.ID(), param.ExternalID); err != nil {
+				return nil, err
+			}
+			if err := i.repos.Workspace.Save(ctx, ws); err != nil {
+				return nil, err
+			}
+			return existingUser, nil
+		}
+
+		// Create new user + personal workspace
+		newUser, personalWS, err := workspace.Init(workspace.InitParams{
+			Email: param.Email,
+			Name:  param.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := i.repos.User.Create(ctx, newUser); err != nil {
+			return nil, err
+		}
+		if err := i.repos.Workspace.Save(ctx, personalWS); err != nil {
+			return nil, err
+		}
+
+		if err := ws.Members().Join(newUser, roleType, newUser.ID()); err != nil {
+			return nil, err
+		}
+		if err := ws.Members().SetUserExternalID(newUser.ID(), param.ExternalID); err != nil {
+			return nil, err
+		}
+		if err := i.repos.Workspace.Save(ctx, ws); err != nil {
+			return nil, err
+		}
+
+		return newUser, nil
+	})
+}
+
+func (i *Scim) SyncScimGroup(ctx context.Context, workspaceID workspace.ID, _, groupName string, members []interfaces.ScimGroupMember) error {
+	return Run0(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return err
+		}
+		if !ws.ScimConfig().Enabled() {
+			return interfaces.ErrSCIMNotEnabled
+		}
+
+		// Determine role for this group
+		groupRole := role.RoleReader
+		if mapping := ws.ScimConfig().GroupRoleMapping(); mapping != nil {
+			if r, ok := mapping[groupName]; ok {
+				groupRole = r
+			}
+		}
+
+		// Index incoming members by ExternalID
+		incomingExtIDs := make(map[string]struct{}, len(members))
+		for _, m := range members {
+			incomingExtIDs[m.ExternalID] = struct{}{}
+		}
+
+		// Provision or update role for each incoming member
+		for _, m := range members {
+			uid, exists := ws.Members().UserByExternalID(m.ExternalID)
+			if exists {
+				if ws.Members().UserRole(uid) != groupRole {
+					if err := ws.Members().UpdateUserRole(uid, groupRole); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			// Resolve user from provided UserID
+			var targetUser *user.User
+			if m.UserID != nil {
+				targetUser, err = i.repos.User.FindByID(ctx, *m.UserID)
+				if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+					return err
+				}
+			}
+			if targetUser == nil {
+				continue
+			}
+
+			if !ws.Members().HasUser(targetUser.ID()) {
+				if err := ws.Members().Join(targetUser, groupRole, targetUser.ID()); err != nil {
+					return err
+				}
+			} else if ws.Members().UserRole(targetUser.ID()) != groupRole {
+				if err := ws.Members().UpdateUserRole(targetUser.ID(), groupRole); err != nil {
+					return err
+				}
+			}
+			if err := ws.Members().SetUserExternalID(targetUser.ID(), m.ExternalID); err != nil {
+				return err
+			}
+		}
+
+		// Soft-disable members no longer in the group
+		for uid, mem := range ws.Members().Users() {
+			if mem.ExternalID == "" {
+				continue
+			}
+			if _, ok := incomingExtIDs[mem.ExternalID]; ok {
+				continue
+			}
+			if ws.Members().IsOnlyOwner(uid) {
+				continue
+			}
+			if err := ws.Members().SetUserDisabled(uid, true); err != nil {
+				return err
+			}
+		}
+
+		return i.repos.Workspace.Save(ctx, ws)
+	})
+}
+
+func (i *Scim) UpdateScimConfig(ctx context.Context, workspaceID workspace.ID, enabled bool, groupRoleMapping map[string]role.RoleType, operator *workspace.Operator) (*workspace.ScimConfig, error) {
+	return Run1(ctx, operator, i.repos, Usecase().Transaction().WithMaintainableWorkspaces(workspaceID), func(ctx context.Context) (*workspace.ScimConfig, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+
+		cfg := ws.ScimConfig()
+		if cfg == nil {
+			cfg = workspace.NewScimConfig()
+		}
+		cfg.SetEnabled(enabled)
+		cfg.SetGroupRoleMapping(groupRoleMapping)
+		ws.SetScimConfig(cfg)
+
+		if err := i.repos.Workspace.Save(ctx, ws); err != nil {
+			return nil, err
+		}
+
+		result := ws.ScimConfig()
+		if result != nil && result.TokenHash() != "" {
+			result.SetTokenHash("***")
+		}
+		return result, nil
+	})
+}

--- a/server/internal/usecase/interactor/scim_test.go
+++ b/server/internal/usecase/interactor/scim_test.go
@@ -1,0 +1,295 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountmemory "github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newScimEnabledWorkspace(ownerID user.ID) *workspace.Workspace {
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	return workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+}
+
+func TestProvisionScimUser_NewUser(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	ws := newScimEnabledWorkspace(ownerID)
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	u, err := uc.ProvisionScimUser(ctx, interfaces.ProvisionScimUserParam{
+		Email:       "alice@example.com",
+		ExternalID:  "ext-alice-001",
+		Name:        "Alice",
+		Role:        role.RoleWriter,
+		WorkspaceID: ws.ID(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.Equal(t, "alice@example.com", u.Email())
+	assert.Equal(t, "Alice", u.Name())
+
+	// verify membership with ExternalID set
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	uid, ok := saved.Members().UserByExternalID("ext-alice-001")
+	assert.True(t, ok)
+	assert.Equal(t, u.ID(), uid)
+}
+
+func TestProvisionScimUser_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	ws := newScimEnabledWorkspace(ownerID)
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	param := interfaces.ProvisionScimUserParam{
+		Email:       "bob@example.com",
+		ExternalID:  "ext-bob-001",
+		Name:        "Bob",
+		WorkspaceID: ws.ID(),
+	}
+
+	u1, err := uc.ProvisionScimUser(ctx, param)
+	require.NoError(t, err)
+	require.NotNil(t, u1)
+
+	u2, err := uc.ProvisionScimUser(ctx, param)
+	require.NoError(t, err)
+	require.NotNil(t, u2)
+
+	assert.Equal(t, u1.ID(), u2.ID(), "second call must return the same user, not a duplicate")
+
+	// verify only one membership with this ExternalID exists
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	count := 0
+	for _, m := range saved.Members().Users() {
+		if m.ExternalID == "ext-bob-001" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestProvisionScimUser_ExistingUserByEmail(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	ws := newScimEnabledWorkspace(ownerID)
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	// Pre-existing user (e.g. joined via JIT)
+	existingID := user.NewID()
+	existing := user.New().ID(existingID).Name("Carol").Email("carol@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, existing))
+
+	uc := NewScim(db)
+
+	u, err := uc.ProvisionScimUser(ctx, interfaces.ProvisionScimUserParam{
+		Email:       "carol@example.com",
+		ExternalID:  "ext-carol-001",
+		Name:        "Carol",
+		WorkspaceID: ws.ID(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.Equal(t, existingID, u.ID(), "must reuse existing user, not create a new one")
+
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	assert.True(t, saved.Members().HasUser(existingID))
+}
+
+func TestDeprovisionScimUser_OK(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	memberID := user.NewID()
+	member := user.New().ID(memberID).Name("member").Email("member@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, member))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID:  {Role: role.RoleOwner, InvitedBy: ownerID},
+			memberID: {Role: role.RoleWriter, InvitedBy: ownerID, ExternalID: "ext-member-001"},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	err := uc.DeprovisionScimUser(ctx, ws.ID(), "ext-member-001")
+	require.NoError(t, err)
+
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+
+	m := saved.Members().User(memberID)
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled, "member must be soft-disabled, not removed")
+}
+
+func TestDeprovisionScimUser_LastOwner(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID, ExternalID: "ext-owner-001"},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	err := uc.DeprovisionScimUser(ctx, ws.ID(), "ext-owner-001")
+	assert.ErrorIs(t, err, interfaces.ErrOwnerCannotLeaveTheWorkspace)
+}
+
+func TestSyncScimGroup_AddAndRemove(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	// A user who will be removed
+	removedID := user.NewID()
+	removed := user.New().ID(removedID).Name("removed").Email("removed@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, removed))
+
+	// A new user to be added
+	newID := user.NewID()
+	newUser := user.New().ID(newID).Name("newuser").Email("new@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, newUser))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID:   {Role: role.RoleOwner, InvitedBy: ownerID},
+			removedID: {Role: role.RoleWriter, InvitedBy: ownerID, ExternalID: "ext-removed-001"},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	err := uc.SyncScimGroup(ctx, ws.ID(), "group-id", "engineers", []interfaces.ScimGroupMember{
+		{ExternalID: "ext-new-001", UserID: &newID},
+	})
+	require.NoError(t, err)
+
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+
+	// new user must be a member
+	assert.True(t, saved.Members().HasUser(newID))
+
+	// removed user must be soft-disabled
+	m := saved.Members().User(removedID)
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled)
+}
+
+func TestGenerateScimToken(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	ws := newScimEnabledWorkspace(ownerID)
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	op := &workspace.Operator{
+		User:                   &ownerID,
+		MaintainableWorkspaces: []workspace.ID{ws.ID()},
+	}
+
+	uc := NewScim(db)
+
+	plaintext1, err := uc.GenerateScimToken(ctx, ws.ID(), op)
+	require.NoError(t, err)
+	assert.NotEmpty(t, plaintext1)
+
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	hash1 := saved.ScimConfig().TokenHash()
+	assert.NotEmpty(t, hash1)
+
+	// second call replaces hash
+	plaintext2, err := uc.GenerateScimToken(ctx, ws.ID(), op)
+	require.NoError(t, err)
+	assert.NotEmpty(t, plaintext2)
+	assert.NotEqual(t, plaintext1, plaintext2)
+
+	saved2, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	hash2 := saved2.ScimConfig().TokenHash()
+	assert.NotEmpty(t, hash2)
+	assert.NotEqual(t, hash1, hash2)
+}

--- a/server/internal/usecase/interfaces/common.go
+++ b/server/internal/usecase/interfaces/common.go
@@ -13,6 +13,7 @@ var (
 
 type Container struct {
 	Cerbos    Cerbos
+	Scim      Scim
 	User      User
 	Workspace Workspace
 }

--- a/server/internal/usecase/interfaces/scim.go
+++ b/server/internal/usecase/interfaces/scim.go
@@ -1,0 +1,41 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/i18n"
+	"github.com/reearth/reearthx/rerror"
+)
+
+var (
+	ErrSCIMNotEnabled         = rerror.NewE(i18n.T("SCIM is not enabled for this workspace"))
+	ErrSCIMTokenAlreadyIssued = rerror.NewE(i18n.T("rotate the token to replace it"))
+	ErrSCIMUserNotFound       = rerror.NewE(i18n.T("SCIM user not found"))
+)
+
+type ProvisionScimUserParam struct {
+	Email       string
+	ExternalID  string
+	Name        string
+	Role        role.RoleType
+	WorkspaceID workspace.ID
+}
+
+type ScimGroupMember struct {
+	ExternalID string
+	UserID     *user.ID
+}
+
+type Scim interface {
+	DeprovisionScimUser(ctx context.Context, workspaceID workspace.ID, externalID string) error
+	GenerateScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (string, error)
+	GetScimConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*workspace.ScimConfig, error)
+	GetScimUser(ctx context.Context, workspaceID workspace.ID, userID user.ID) (*user.User, error)
+	ListScimUsers(ctx context.Context, workspaceID workspace.ID, filter string) ([]*user.User, error)
+	ProvisionScimUser(ctx context.Context, param ProvisionScimUserParam) (*user.User, error)
+	SyncScimGroup(ctx context.Context, workspaceID workspace.ID, groupID, groupName string, members []ScimGroupMember) error
+	UpdateScimConfig(ctx context.Context, workspaceID workspace.ID, enabled bool, groupRoleMapping map[string]role.RoleType, operator *workspace.Operator) (*workspace.ScimConfig, error)
+}

--- a/server/pkg/workspace/member.go
+++ b/server/pkg/workspace/member.go
@@ -331,6 +331,44 @@ func (m *Members) DeleteIntegrations(iids IntegrationIDList) error {
 	return nil
 }
 
+func (m *Members) SetUserDisabled(u UserID, disabled bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	mem, ok := m.users[u]
+	if !ok {
+		return ErrTargetUserNotInTheWorkspace
+	}
+	mem.Disabled = disabled
+	m.users[u] = mem
+	return nil
+}
+
+func (m *Members) SetUserExternalID(u UserID, externalID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	mem, ok := m.users[u]
+	if !ok {
+		return ErrTargetUserNotInTheWorkspace
+	}
+	mem.ExternalID = externalID
+	m.users[u] = mem
+	return nil
+}
+
+func (m *Members) UserByExternalID(externalID string) (UserID, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for uid, mem := range m.users {
+		if mem.ExternalID == externalID {
+			return uid, true
+		}
+	}
+	return UserID{}, false
+}
+
 func (m *Members) UsersByRole(role role.RoleType) []UserID {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
## Why

Part of [D-20] U-D20-05 SCIM Provisioning via Auth0 (eukarya-inc/reearth-dashboard#1373).

This is the second of four PRs for SCIM support, stacked on top of #300 (U-D20-05a). It implements the business logic layer — no HTTP handlers or GraphQL changes in this PR.

- `interfaces.Scim` interface with 8 methods covering the full SCIM user/group/config lifecycle; `Container.Scim` wired in `NewContainer`.
- `interactor.Scim`: idempotent `ProvisionScimUser` (deduplicates on `ExternalID` then email, creates user + personal workspace when needed); `DeprovisionScimUser` soft-disables the membership and rejects last-owner removal; `SyncScimGroup` provisions incoming members and soft-disables removed ones respecting the last-owner guard; `GenerateScimToken` generates a 32-byte random token, stores its bcrypt hash (subsequent calls replace the hash), and returns the plaintext only once; read/update ops for `GetScimConfig`, `GetScimUser`, `ListScimUsers`, `UpdateScimConfig` (token hash masked as `***`).
- Three new `Members` helpers in the workspace domain: `UserByExternalID`, `SetUserExternalID`, `SetUserDisabled` — no invariants changed.
- `scim_test.go` covers all 7 spec cases using `memory.New()` repos.

## Checklist

- [x] Verified backward compatibility related to feature modifications (all new code is additive; no existing workspace or user path is affected)
- [x] Confirmed backward compatibility for migrations (no migrations in this PR)
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed