### PR TITLE
feat(server): filter admin workspaces list by type (personal/team)

### DIFF
--- a/server/docs/admin/docs.go
+++ b/server/docs/admin/docs.go
@@ -529,7 +529,7 @@ const docTemplate = `{
         },
         "/workspaces": {
             "get": {
-                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nWhen one or more ` + "`" + `ids` + "`" + ` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores ` + "`" + `q` + "`" + `, ` + "`" + `page` + "`" + ` and ` + "`" + `per_page` + "`" + `. At most 100 ids may be supplied per request.",
+                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nUse ` + "`" + `type` + "`" + ` to filter by workspace type: ` + "`" + `personal` + "`" + ` returns only personal workspaces, ` + "`" + `team` + "`" + ` returns only team (non-personal) workspaces; when absent, both types are returned.\nWhen one or more ` + "`" + `ids` + "`" + ` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores ` + "`" + `q` + "`" + `, ` + "`" + `type` + "`" + `, ` + "`" + `page` + "`" + ` and ` + "`" + `per_page` + "`" + `. At most 100 ids may be supplied per request.",
                 "produces": [
                     "application/json"
                 ],
@@ -544,7 +544,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored.",
+                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/type/page/per_page are ignored.",
                         "name": "ids",
                         "in": "query"
                     },
@@ -552,6 +552,16 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Search by name or alias",
                         "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "personal",
+                            "team"
+                        ],
+                        "type": "string",
+                        "description": "Filter by workspace type",
+                        "name": "type",
                         "in": "query"
                     },
                     {

--- a/server/docs/admin/swagger.json
+++ b/server/docs/admin/swagger.json
@@ -522,7 +522,7 @@
         },
         "/workspaces": {
             "get": {
-                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nWhen one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.",
+                "description": "Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.\nUse `type` to filter by workspace type: `personal` returns only personal workspaces, `team` returns only team (non-personal) workspaces; when absent, both types are returned.\nWhen one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `type`, `page` and `per_page`. At most 100 ids may be supplied per request.",
                 "produces": [
                     "application/json"
                 ],
@@ -537,7 +537,7 @@
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored.",
+                        "description": "Batch fetch by workspace ID (repeatable, max 100). When present, q/type/page/per_page are ignored.",
                         "name": "ids",
                         "in": "query"
                     },
@@ -545,6 +545,16 @@
                         "type": "string",
                         "description": "Search by name or alias",
                         "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "personal",
+                            "team"
+                        ],
+                        "type": "string",
+                        "description": "Filter by workspace type",
+                        "name": "type",
                         "in": "query"
                     },
                     {

--- a/server/docs/admin/swagger.yaml
+++ b/server/docs/admin/swagger.yaml
@@ -545,11 +545,12 @@ paths:
     get:
       description: |-
         Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.
-        When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.
+        Use `type` to filter by workspace type: `personal` returns only personal workspaces, `team` returns only team (non-personal) workspaces; when absent, both types are returned.
+        When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `type`, `page` and `per_page`. At most 100 ids may be supplied per request.
       parameters:
       - collectionFormat: multi
         description: Batch fetch by workspace ID (repeatable, max 100). When present,
-          q/page/per_page are ignored.
+          q/type/page/per_page are ignored.
         in: query
         items:
           type: string
@@ -558,6 +559,13 @@ paths:
       - description: Search by name or alias
         in: query
         name: q
+        type: string
+      - description: Filter by workspace type
+        enum:
+        - personal
+        - team
+        in: query
+        name: type
         type: string
       - description: Page number (1-based)
         in: query

--- a/server/internal/admin/presentation/handler/workspace/handler_list.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_list.go
@@ -18,11 +18,13 @@ const maxWorkspaceIDsPerRequest = 100
 //
 //	@Summary		List workspaces
 //	@Description	Lists workspaces across all tenants, optionally filtered by a name/alias keyword, with offset pagination.
-//	@Description	When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `page` and `per_page`. At most 100 ids may be supplied per request.
+//	@Description	Use `type` to filter by workspace type: `personal` returns only personal workspaces, `team` returns only team (non-personal) workspaces; when absent, both types are returned.
+//	@Description	When one or more `ids` query parameters are supplied, the endpoint instead resolves those workspaces by ID (existing ones only; unknown IDs are omitted) and ignores `q`, `type`, `page` and `per_page`. At most 100 ids may be supplied per request.
 //	@Tags			workspaces
 //	@Produce		json
-//	@Param			ids			query		[]string	false	"Batch fetch by workspace ID (repeatable, max 100). When present, q/page/per_page are ignored."	collectionFormat(multi)
+//	@Param			ids			query		[]string	false	"Batch fetch by workspace ID (repeatable, max 100). When present, q/type/page/per_page are ignored."	collectionFormat(multi)
 //	@Param			q			query		string		false	"Search by name or alias"
+//	@Param			type		query		string		false	"Filter by workspace type"	Enums(personal, team)
 //	@Param			page		query		int			false	"Page number (1-based)"
 //	@Param			per_page	query		int			false	"Items per page (max 100)"
 //	@Success		200			{object}	ListWorkspacesResponse
@@ -41,6 +43,22 @@ func (h *Handler) ListWorkspaces(c echo.Context) error {
 		keyword = &q
 	}
 
+	// type filters by workspace type: "personal" or "team". Absent/empty means no
+	// filter; any other value is rejected with 400 (mirrors the page-param errors).
+	var personal *bool
+	switch c.QueryParam("type") {
+	case "":
+		// no filter
+	case "personal":
+		v := true
+		personal = &v
+	case "team":
+		v := false
+		personal = &v
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid type")
+	}
+
 	page, err := internal.ParsePageParam(c.QueryParam("page"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid page")
@@ -53,6 +71,7 @@ func (h *Handler) ListWorkspaces(c echo.Context) error {
 
 	list, pi, err := h.list.Execute(c.Request().Context(), workspaceuc.ListWorkspacesInput{
 		Keyword:    keyword,
+		Personal:   personal,
 		Pagination: p,
 	})
 	if err != nil {

--- a/server/internal/admin/presentation/handler/workspace/handler_test.go
+++ b/server/internal/admin/presentation/handler/workspace/handler_test.go
@@ -33,6 +33,10 @@ func ws(name, alias string) *workspace.Workspace {
 	return workspace.New().NewID().Name(name).Alias(alias).MustBuild()
 }
 
+func personalWs(name, alias string) *workspace.Workspace {
+	return workspace.New().NewID().Name(name).Alias(alias).Personal(true).MustBuild()
+}
+
 func newTestEcho(wsRepo workspace.Repo, adminRepo adminuser.Repo, sess *session.Manager) *echo.Echo {
 	return newTestEchoWithUsers(wsRepo, memory.NewUserWith(), adminRepo, sess)
 }
@@ -98,6 +102,83 @@ func TestListWorkspaces_Keyword(t *testing.T) {
 	assert.Equal(t, int64(1), body.TotalCount)
 	require.Len(t, body.Items, 1)
 	assert.Equal(t, "Beta", body.Items[0].Name)
+}
+
+func TestListWorkspaces_TypePersonal(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(personalWs("Solo", "solo"), ws("Team", "team"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?type=personal", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, int64(1), body.TotalCount)
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, "Solo", body.Items[0].Name)
+}
+
+func TestListWorkspaces_TypeTeam(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(personalWs("Solo", "solo"), ws("Team", "team"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?type=team", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, int64(1), body.TotalCount)
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, "Team", body.Items[0].Name)
+}
+
+func TestListWorkspaces_TypeInvalid_400(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	wsRepo := memory.NewWorkspaceWith(ws("A", "a"))
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?type=bogus", nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListWorkspaces_ByIDs_IgnoresType(t *testing.T) {
+	op := approvedAdmin("op@eukarya.io")
+	adminRepo := memory.NewAdminUserWith(op)
+	team := ws("Team", "team")
+	wsRepo := memory.NewWorkspaceWith(team)
+	sess := session.NewManager(testSecret, time.Hour)
+	e := newTestEcho(wsRepo, adminRepo, sess)
+
+	// type=personal would exclude the team workspace in the listing path, but in
+	// batch-by-IDs mode type is ignored, so the workspace still resolves.
+	q := url.Values{"ids": {team.ID().String()}, "type": {"personal"}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?"+q.Encode(), nil)
+	req.AddCookie(cookieFor(t, sess, op.ID()))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body workspacehandler.ListWorkspacesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Items, 1)
+	assert.Equal(t, team.ID().String(), body.Items[0].ID)
 }
 
 func TestListWorkspaces_ByIDs_ReturnsMatching_OmitsUnknown(t *testing.T) {

--- a/server/internal/admin/usecase/workspaceuc/list.go
+++ b/server/internal/admin/usecase/workspaceuc/list.go
@@ -22,11 +22,15 @@ func NewListWorkspacesUseCase(repo workspace.Repo) *ListWorkspacesUseCase {
 }
 
 // ListWorkspacesInput selects which workspaces to return. When IDs is non-empty
-// it is a batch-by-IDs lookup (unknown IDs omitted) and Keyword/Pagination are
-// ignored; otherwise it is a keyword-filtered, offset-paginated listing. Both
+// it is a batch-by-IDs lookup (unknown IDs omitted) and Keyword/Personal/Pagination
+// are ignored; otherwise it is a keyword-filtered, offset-paginated listing. Both
 // modes read across all tenants (the admin repo is unfiltered).
+//
+// Personal filters by workspace type: nil returns both types, true returns only
+// personal workspaces, false returns only team (non-personal) workspaces.
 type ListWorkspacesInput struct {
 	Keyword    *string
+	Personal   *bool
 	Pagination *usecasex.Pagination
 	IDs        workspace.IDList
 }
@@ -35,7 +39,7 @@ type ListWorkspacesInput struct {
 // *PageInfo; callers derive counts from the list.
 func (uc *ListWorkspacesUseCase) Execute(ctx context.Context, in ListWorkspacesInput) (workspace.List, *usecasex.PageInfo, error) {
 	if len(in.IDs) == 0 {
-		return uc.repo.FindAll(ctx, in.Keyword, in.Pagination)
+		return uc.repo.FindAll(ctx, in.Keyword, in.Personal, in.Pagination)
 	}
 
 	list, err := uc.repo.FindByIDs(ctx, in.IDs)

--- a/server/internal/admin/usecase/workspaceuc/list_test.go
+++ b/server/internal/admin/usecase/workspaceuc/list_test.go
@@ -15,6 +15,10 @@ func ws(name, alias string) *workspace.Workspace {
 	return workspace.New().NewID().Name(name).Alias(alias).MustBuild()
 }
 
+func personalWs(name, alias string) *workspace.Workspace {
+	return workspace.New().NewID().Name(name).Alias(alias).Personal(true).MustBuild()
+}
+
 func TestList_All(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewWorkspaceWith(ws("Alpha", "alpha"), ws("Beta", "beta"))
@@ -84,6 +88,61 @@ func TestList_Keyword(t *testing.T) {
 	require.Equal(t, 1, len(got))
 	assert.Equal(t, "Alpha", got[0].Name())
 	assert.Equal(t, int64(1), pi.TotalCount)
+}
+
+func TestList_PersonalOnly(t *testing.T) {
+	ctx := context.Background()
+	repo := memory.NewWorkspaceWith(personalWs("Solo", "solo"), ws("Team", "team"))
+	uc := NewListWorkspacesUseCase(repo)
+
+	yes := true
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{Personal: &yes})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	assert.Equal(t, "Solo", got[0].Name())
+	assert.True(t, got[0].IsPersonal())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}
+
+func TestList_TeamOnly(t *testing.T) {
+	ctx := context.Background()
+	repo := memory.NewWorkspaceWith(personalWs("Solo", "solo"), ws("Team", "team"))
+	uc := NewListWorkspacesUseCase(repo)
+
+	no := false
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{Personal: &no})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	assert.Equal(t, "Team", got[0].Name())
+	assert.False(t, got[0].IsPersonal())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}
+
+func TestList_AllTypes_WhenPersonalNil(t *testing.T) {
+	ctx := context.Background()
+	repo := memory.NewWorkspaceWith(personalWs("Solo", "solo"), ws("Team", "team"))
+	uc := NewListWorkspacesUseCase(repo)
+
+	got, pi, err := uc.Execute(ctx, ListWorkspacesInput{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, int64(2), pi.TotalCount)
+}
+
+func TestList_ByIDs_IgnoresPersonalFilter(t *testing.T) {
+	ctx := context.Background()
+	solo := personalWs("Solo", "solo")
+	team := ws("Team", "team")
+	repo := memory.NewWorkspaceWith(solo, team)
+	uc := NewListWorkspacesUseCase(repo)
+
+	// Personal is ignored in batch-by-IDs mode: a team workspace resolves even
+	// though Personal=true would exclude it in the keyword-listing path.
+	yes := true
+	got, _, err := uc.Execute(ctx, ListWorkspacesInput{IDs: workspace.IDList{team.ID()}, Personal: &yes})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, team.ID(), got[0].ID())
 }
 
 func TestList_RejectsCursorPagination(t *testing.T) {

--- a/server/internal/infrastructure/memory/workspace.go
+++ b/server/internal/infrastructure/memory/workspace.go
@@ -43,7 +43,7 @@ func (r *Workspace) Filtered(f workspace.WorkspaceFilter) workspace.Repo {
 	}
 }
 
-func (r *Workspace) FindAll(_ context.Context, keyword *string, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
+func (r *Workspace) FindAll(_ context.Context, keyword *string, personal *bool, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
 	if r.err != nil {
 		return nil, nil, r.err
 	}
@@ -58,6 +58,10 @@ func (r *Workspace) FindAll(_ context.Context, keyword *string, pagination *usec
 	all := workspace.List(r.data.FindAll(func(id workspace.ID, v *workspace.Workspace) bool {
 		// respect the readable-workspace filter (unset for the admin base repo)
 		if !r.f.CanRead(id) {
+			return false
+		}
+		// filter by workspace type when requested (nil = both types)
+		if personal != nil && v.IsPersonal() != *personal {
 			return false
 		}
 		if kw == "" {

--- a/server/internal/infrastructure/memory/workspace_test.go
+++ b/server/internal/infrastructure/memory/workspace_test.go
@@ -231,3 +231,34 @@ func TestWorkspace_RemoveAll(t *testing.T) {
 	SetWorkspaceError(r, wantErr)
 	assert.Same(t, wantErr, r.RemoveAll(ctx, ids))
 }
+
+func TestWorkspace_FindAll_PersonalFilter(t *testing.T) {
+	ctx := context.Background()
+	solo := workspace.New().NewID().Name("Solo").Alias("solo").Personal(true).MustBuild()
+	team := workspace.New().NewID().Name("Team").Alias("team").MustBuild()
+	r := NewWorkspaceWith(solo, team)
+
+	// nil => both types
+	got, pi, err := r.FindAll(ctx, nil, nil, nil)
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+	assert.Equal(t, int64(2), pi.TotalCount)
+
+	// true => personal only
+	yes := true
+	got, pi, err = r.FindAll(ctx, nil, &yes, nil)
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, solo.ID(), got[0].ID())
+	assert.True(t, got[0].IsPersonal())
+	assert.Equal(t, int64(1), pi.TotalCount)
+
+	// false => team (non-personal) only
+	no := false
+	got, pi, err = r.FindAll(ctx, nil, &no, nil)
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, team.ID(), got[0].ID())
+	assert.False(t, got[0].IsPersonal())
+	assert.Equal(t, int64(1), pi.TotalCount)
+}

--- a/server/internal/infrastructure/mongo/workspace.go
+++ b/server/internal/infrastructure/mongo/workspace.go
@@ -40,7 +40,7 @@ func (r *Workspace) Filtered(f workspace.WorkspaceFilter) workspace.Repo {
 	}
 }
 
-func (r *Workspace) FindAll(ctx context.Context, keyword *string, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
+func (r *Workspace) FindAll(ctx context.Context, keyword *string, personal *bool, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
 	if pagination != nil && pagination.Cursor != nil {
 		return nil, nil, workspace.ErrCursorPaginationUnsupported
 	}
@@ -52,6 +52,11 @@ func (r *Workspace) FindAll(ctx context.Context, keyword *string, pagination *us
 			{"name": bson.M{"$regex": re}},
 			{"alias": bson.M{"$regex": re}},
 		}
+	}
+	// filter by workspace type when requested (nil = both types). The personal
+	// flag is stored on the workspace doc as the boolean `personal` field.
+	if personal != nil {
+		filter["personal"] = *personal
 	}
 
 	// Respect the readable-workspace filter: for the admin base repo it is unset

--- a/server/internal/infrastructure/postgres/workspace.go
+++ b/server/internal/infrastructure/postgres/workspace.go
@@ -31,7 +31,7 @@ func (r *Workspace) Filtered(f workspace.WorkspaceFilter) workspace.Repo {
 // FindAll is not implemented for the PostgreSQL backend: the admin app (which
 // is the only consumer of this cross-tenant listing) runs on MongoDB, so the
 // Postgres admin list path is intentionally left unimplemented for now.
-func (r *Workspace) FindAll(_ context.Context, _ *string, _ *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
+func (r *Workspace) FindAll(_ context.Context, _ *string, _ *bool, _ *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
 	return nil, nil, workspace.ErrNotImplemented
 }
 

--- a/server/internal/infrastructure/postgres/workspace_test.go
+++ b/server/internal/infrastructure/postgres/workspace_test.go
@@ -19,6 +19,6 @@ func TestWorkspace_FindAll_NotImplemented(t *testing.T) {
 
 	// FindAll (admin cross-tenant listing) is intentionally not implemented on
 	// the Postgres backend; the admin app runs on MongoDB.
-	_, _, err := r.FindAll(ctx, nil, usecasex.OffsetPagination{Offset: 0, Limit: 10}.Wrap())
+	_, _, err := r.FindAll(ctx, nil, nil, usecasex.OffsetPagination{Offset: 0, Limit: 10}.Wrap())
 	assert.ErrorIs(t, err, workspace.ErrNotImplemented)
 }

--- a/server/pkg/workspace/mock_workspace.go
+++ b/server/pkg/workspace/mock_workspace.go
@@ -71,9 +71,9 @@ func (mr *MockRepoMockRecorder) Filtered(arg0 any) *gomock.Call {
 }
 
 // FindAll mocks base method.
-func (m *MockRepo) FindAll(ctx context.Context, keyword *string, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error) {
+func (m *MockRepo) FindAll(ctx context.Context, keyword *string, personal *bool, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx, keyword, pagination)
+	ret := m.ctrl.Call(m, "FindAll", ctx, keyword, personal, pagination)
 	ret0, _ := ret[0].(List)
 	ret1, _ := ret[1].(*usecasex.PageInfo)
 	ret2, _ := ret[2].(error)
@@ -81,9 +81,9 @@ func (m *MockRepo) FindAll(ctx context.Context, keyword *string, pagination *use
 }
 
 // FindAll indicates an expected call of FindAll.
-func (mr *MockRepoMockRecorder) FindAll(ctx, keyword, pagination any) *gomock.Call {
+func (mr *MockRepoMockRecorder) FindAll(ctx, keyword, personal, pagination any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepo)(nil).FindAll), ctx, keyword, pagination)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepo)(nil).FindAll), ctx, keyword, personal, pagination)
 }
 
 // FindByAlias mocks base method.

--- a/server/pkg/workspace/repo.go
+++ b/server/pkg/workspace/repo.go
@@ -22,7 +22,11 @@ var (
 //go:generate mockgen -source=./repo.go -destination=./mock_workspace.go -package workspace
 type Repo interface {
 	Filtered(WorkspaceFilter) Repo
-	FindAll(ctx context.Context, keyword *string, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error)
+	// FindAll lists workspaces across all tenants. keyword filters by name/alias
+	// (nil or blank = no keyword filter). personal filters by workspace type:
+	// nil returns both, true returns only personal workspaces, false returns only
+	// team (non-personal) workspaces.
+	FindAll(ctx context.Context, keyword *string, personal *bool, pagination *usecasex.Pagination) (List, *usecasex.PageInfo, error)
 	FindByID(context.Context, ID) (*Workspace, error)
 	FindByName(context.Context, string) (*Workspace, error)
 	FindByAlias(ctx context.Context, alias string) (*Workspace, error)


### PR DESCRIPTION
## Why

The admin workspaces list (`GET /api/v1/workspaces`) only supported a keyword (`q`) and pagination. The reearth-dashboard admin console needs to filter workspaces by **type** — personal vs team — so operators can narrow a long list. This adds a `type` query parameter.

Paired with reearth-dashboard PR that forwards the param and adds the UI dropdown (the dashboard admin-api relays this endpoint).

### What changed

- **Repo**: `workspace.Repo.FindAll` gains a `personal *bool` argument (`nil` = all, `true` = personal only, `false` = team only). The **memory** and **mongo** backends apply it (mongo filters on the boolean `personal` field); **postgres** `FindAll` remains not-implemented (admin runs on MongoDB) and only takes the new arg. Gomock regenerated.
- **Usecase**: `ListWorkspacesInput.Personal` threads the filter through the keyword-list mode; the batch-by-IDs mode ignores it (as it does `q`/pagination).
- **Handler**: parses `?type=personal|team` (absent = all; any other value → **400**); ignored when `ids` are supplied. Admin swagger regenerated with `type` as an `Enums(personal, team)` param.
- **Tests**: usecase, handler, and memory repo cover personal-only / team-only / all and the ids-ignores-type path.

Backwards compatible: an absent `type` behaves exactly as before.

## Checklist

- [x] Verified backward compatibility related to feature modifications (new optional param; absent = unchanged behavior).
- [x] Confirmed backward compatibility for migrations (none — no schema change; `personal` already stored).
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)