### PR TITLE
feat(server): add SCIM adapter layer for SCIM provisioning (U-D20-05c)

### DIFF
--- a/server/internal/adapter/scim/handler_discovery.go
+++ b/server/internal/adapter/scim/handler_discovery.go
@@ -1,0 +1,135 @@
+package scim
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// DiscoveryHandler serves the static SCIM 2.0 RFC 7643 §5 discovery endpoints.
+// These endpoints are public (no authentication required).
+type DiscoveryHandler struct{}
+
+// NewDiscoveryHandler constructs a DiscoveryHandler.
+func NewDiscoveryHandler() *DiscoveryHandler {
+	return &DiscoveryHandler{}
+}
+
+// ResourceTypes handles GET /scim/v2/ResourceTypes.
+func (h *DiscoveryHandler) ResourceTypes(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+		"totalResults": 1,
+		"startIndex":   1,
+		"itemsPerPage": 1,
+		"Resources": []map[string]interface{}{
+			{
+				"schemas":          []string{"urn:ietf:params:scim:schemas:core:2.0:ResourceType"},
+				"id":               "User",
+				"name":             "User",
+				"endpoint":         "/Users",
+				"description":      "User Account",
+				"schema":           ScimSchemaUser,
+				"schemaExtensions": []interface{}{},
+				"meta": map[string]interface{}{
+					"location":     "/scim/v2/ResourceTypes/User",
+					"resourceType": "ResourceType",
+				},
+			},
+		},
+	})
+}
+
+// Schemas handles GET /scim/v2/Schemas.
+func (h *DiscoveryHandler) Schemas(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
+		"totalResults": 1,
+		"startIndex":   1,
+		"itemsPerPage": 1,
+		"Resources": []map[string]interface{}{
+			{
+				"id":          ScimSchemaUser,
+				"name":        "User",
+				"description": "User Account",
+				"attributes": []map[string]interface{}{
+					{
+						"name":        "userName",
+						"type":        "string",
+						"multiValued": false,
+						"required":    true,
+						"caseExact":   false,
+					},
+					{
+						"name":        "name",
+						"type":        "complex",
+						"multiValued": false,
+						"required":    false,
+					},
+					{
+						"name":        "emails",
+						"type":        "complex",
+						"multiValued": true,
+						"required":    false,
+					},
+					{
+						"name":        "active",
+						"type":        "boolean",
+						"multiValued": false,
+						"required":    false,
+					},
+					{
+						"name":        "externalId",
+						"type":        "string",
+						"multiValued": false,
+						"required":    false,
+					},
+				},
+				"meta": map[string]interface{}{
+					"location":     "/scim/v2/Schemas/" + ScimSchemaUser,
+					"resourceType": "Schema",
+				},
+			},
+		},
+	})
+}
+
+// ServiceProviderConfig handles GET /scim/v2/ServiceProviderConfig.
+func (h *DiscoveryHandler) ServiceProviderConfig(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"schemas": []string{"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"},
+		"documentationUri": "",
+		"patch": map[string]interface{}{
+			"supported": true,
+		},
+		"bulk": map[string]interface{}{
+			"supported":      false,
+			"maxOperations":  0,
+			"maxPayloadSize": 0,
+		},
+		"filter": map[string]interface{}{
+			"supported":  true,
+			"maxResults": 200,
+		},
+		"changePassword": map[string]interface{}{
+			"supported": false,
+		},
+		"sort": map[string]interface{}{
+			"supported": false,
+		},
+		"etag": map[string]interface{}{
+			"supported": false,
+		},
+		"authenticationSchemes": []map[string]interface{}{
+			{
+				"type":        "oauthbearertoken",
+				"name":        "OAuth Bearer Token",
+				"description": "Authentication scheme using the OAuth Bearer Token standard",
+			},
+		},
+		"meta": map[string]interface{}{
+			"location":     "/scim/v2/ServiceProviderConfig",
+			"resourceType": "ServiceProviderConfig",
+		},
+	})
+}

--- a/server/internal/adapter/scim/handler_users.go
+++ b/server/internal/adapter/scim/handler_users.go
@@ -1,0 +1,358 @@
+package scim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+)
+
+// UserHandler handles SCIM 2.0 /scim/v2/Users routes.
+type UserHandler struct {
+	baseURL       string
+	scimUC        interfaces.Scim
+	workspaceRepo workspace.Repo
+}
+
+// NewUserHandler constructs a UserHandler.
+func NewUserHandler(scimUC interfaces.Scim, workspaceRepo workspace.Repo, baseURL string) *UserHandler {
+	return &UserHandler{
+		baseURL:       baseURL,
+		scimUC:        scimUC,
+		workspaceRepo: workspaceRepo,
+	}
+}
+
+// Create handles POST /scim/v2/Users — provision a new user (201 Created).
+func (h *UserHandler) Create(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	var body ScimUser
+	if err := c.Bind(&body); err != nil {
+		return scimErrorResponse(c, http.StatusBadRequest, "invalid request body", "invalidValue")
+	}
+
+	email := body.UserName
+	if email == "" && len(body.Emails) > 0 {
+		email = body.Emails[0].Value
+	}
+	name := body.Name.Formatted
+	if name == "" {
+		name = email
+	}
+
+	u, err := h.scimUC.ProvisionScimUser(ctx, interfaces.ProvisionScimUserParam{
+		Email:       email,
+		ExternalID:  body.ExternalID,
+		Name:        name,
+		Role:        role.RoleReader,
+		WorkspaceID: wsID,
+	})
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	member := h.memberForUser(ctx, wsID, u.ID())
+	resp := DomainUserToScimUser(u, member, h.baseURL)
+
+	c.Response().Header().Set("Location", resp.Meta.Location)
+	return c.JSON(http.StatusCreated, resp)
+}
+
+// Delete handles DELETE /scim/v2/Users/:id — soft-deprovision (200 OK with active:false).
+func (h *UserHandler) Delete(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	uid, err := user.IDFrom(c.Param("id"))
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "user not found", "")
+	}
+
+	// Retrieve user first to build the response.
+	u, err := h.scimUC.GetScimUser(ctx, wsID, uid)
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	memberBefore := h.memberForUser(ctx, wsID, uid)
+
+	if err := h.scimUC.DeprovisionScimUserByUserID(ctx, wsID, uid); err != nil {
+		return h.mapError(c, err)
+	}
+
+	// Build disabled member for the response to reflect active:false.
+	disabledMember := memberBefore
+	disabledMember.Disabled = true
+	resp := DomainUserToScimUser(u, disabledMember, h.baseURL)
+	return c.JSON(http.StatusOK, resp)
+}
+
+// Get handles GET /scim/v2/Users/:id.
+func (h *UserHandler) Get(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	uid, err := user.IDFrom(c.Param("id"))
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "user not found", "")
+	}
+
+	u, err := h.scimUC.GetScimUser(ctx, wsID, uid)
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	member := h.memberForUser(ctx, wsID, uid)
+	return c.JSON(http.StatusOK, DomainUserToScimUser(u, member, h.baseURL))
+}
+
+// List handles GET /scim/v2/Users with optional ?filter= query param.
+func (h *UserHandler) List(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	filterParam := c.QueryParam("filter")
+
+	users, err := h.scimUC.ListScimUsers(ctx, wsID, filterParam)
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	// Apply in-memory filter if provided.
+	var filtered []*user.User
+	if filterParam == "" {
+		filtered = users
+	} else {
+		attr, op, val, parseErr := parseFilter(filterParam)
+		if parseErr != nil {
+			return scimErrorResponse(c, http.StatusBadRequest, "unsupported filter expression", "invalidFilter")
+		}
+		switch {
+		case attr == "username" && op == "eq":
+			for _, u := range users {
+				if strings.EqualFold(u.Email(), val) {
+					filtered = append(filtered, u)
+				}
+			}
+		case attr == "externalid" && op == "eq":
+			members := h.membersForWorkspace(ctx, wsID)
+			for _, u := range users {
+				if m, ok := members[u.ID()]; ok && m.ExternalID == val {
+					filtered = append(filtered, u)
+				}
+			}
+		default:
+			return scimErrorResponse(c, http.StatusBadRequest, "unsupported filter attribute", "invalidFilter")
+		}
+	}
+
+	resources := make([]ScimUser, 0, len(filtered))
+	members := h.membersForWorkspace(ctx, wsID)
+	for _, u := range filtered {
+		member := members[u.ID()]
+		resources = append(resources, DomainUserToScimUser(u, member, h.baseURL))
+	}
+
+	return c.JSON(http.StatusOK, ScimListResponse{
+		ItemsPerPage: len(resources),
+		Resources:    resources,
+		Schemas:      []string{ScimSchemaListResponse},
+		StartIndex:   1,
+		TotalResults: len(resources),
+	})
+}
+
+// Patch handles PATCH /scim/v2/Users/:id — partial update (handles deprovisioning).
+func (h *UserHandler) Patch(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	uid, err := user.IDFrom(c.Param("id"))
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "user not found", "")
+	}
+
+	var patchOp ScimPatchOp
+	if err := c.Bind(&patchOp); err != nil {
+		return scimErrorResponse(c, http.StatusBadRequest, "invalid request body", "invalidValue")
+	}
+
+	// Retrieve user to confirm existence.
+	u, err := h.scimUC.GetScimUser(ctx, wsID, uid)
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	deprovisioned := false
+	for _, op := range patchOp.Operations {
+		if !strings.EqualFold(op.Op, "replace") {
+			continue
+		}
+
+		// Okta format: {"op":"replace","path":"active","value":false}
+		if strings.EqualFold(op.Path, "active") {
+			if active, ok := parseBoolValue(op.Value); ok && !active {
+				deprovisioned = true
+			}
+			continue
+		}
+
+		// Azure AD format: {"op":"replace","value":{"active":false}}
+		if op.Path == "" {
+			if active, ok := extractActiveBool(op.Value); ok && !active {
+				deprovisioned = true
+			}
+		}
+	}
+
+	if deprovisioned {
+		if err := h.scimUC.DeprovisionScimUserByUserID(ctx, wsID, uid); err != nil {
+			return h.mapError(c, err)
+		}
+	}
+
+	member := h.memberForUser(ctx, wsID, uid)
+	return c.JSON(http.StatusOK, DomainUserToScimUser(u, member, h.baseURL))
+}
+
+// Replace handles PUT /scim/v2/Users/:id — full replace (returns current state).
+func (h *UserHandler) Replace(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	uid, err := user.IDFrom(c.Param("id"))
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "user not found", "")
+	}
+
+	u, err := h.scimUC.GetScimUser(ctx, wsID, uid)
+	if err != nil {
+		return h.mapError(c, err)
+	}
+
+	member := h.memberForUser(ctx, wsID, uid)
+	return c.JSON(http.StatusOK, DomainUserToScimUser(u, member, h.baseURL))
+}
+
+// --- helpers ---
+
+// memberForUser retrieves the workspace.Member for a given user within a workspace.
+// Returns an empty Member on any error (graceful degradation).
+func (h *UserHandler) memberForUser(ctx context.Context, wsID workspace.ID, uid user.ID) workspace.Member {
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return workspace.Member{}
+	}
+	if m := ws.Members().User(uid); m != nil {
+		return *m
+	}
+	return workspace.Member{}
+}
+
+// membersForWorkspace returns all members of a workspace as a map.
+// Returns an empty map on error.
+func (h *UserHandler) membersForWorkspace(ctx context.Context, wsID workspace.ID) map[workspace.UserID]workspace.Member {
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return map[workspace.UserID]workspace.Member{}
+	}
+	return ws.Members().Users()
+}
+
+// mapError converts domain errors to appropriate SCIM HTTP responses.
+func (h *UserHandler) mapError(c echo.Context, err error) error {
+	if errors.Is(err, rerror.ErrNotFound) || errors.Is(err, interfaces.ErrSCIMUserNotFound) {
+		return scimErrorResponse(c, http.StatusNotFound, "user not found", "")
+	}
+	if errors.Is(err, interfaces.ErrOwnerCannotLeaveTheWorkspace) {
+		return scimErrorResponse(c, http.StatusConflict, "cannot deprovision the last owner", "")
+	}
+	if errors.Is(err, interfaces.ErrSCIMNotEnabled) {
+		return scimErrorResponse(c, http.StatusForbidden, "SCIM is not enabled for this workspace", "")
+	}
+	return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+}
+
+// parseFilter parses a simple SCIM filter of the form `attr eq "value"`.
+// Returns the lower-cased attribute name, operator, unquoted value, and any error.
+func parseFilter(filter string) (attr, op, val string, err error) {
+	parts := strings.SplitN(strings.TrimSpace(filter), " ", 3)
+	if len(parts) != 3 {
+		return "", "", "", errors.New("invalid filter syntax")
+	}
+	attr = strings.ToLower(parts[0])
+	op = strings.ToLower(parts[1])
+	val = strings.Trim(parts[2], `"`)
+	if op != "eq" {
+		return "", "", "", errors.New("only eq operator is supported")
+	}
+	return attr, op, val, nil
+}
+
+// parseBoolValue attempts to extract a boolean from an interface{} value.
+func parseBoolValue(v interface{}) (bool, bool) {
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	case float64:
+		return t != 0, true
+	}
+	return false, false
+}
+
+// extractActiveBool extracts the "active" field from a map/object value (Azure AD PATCH format).
+func extractActiveBool(v interface{}) (bool, bool) {
+	if m, ok := v.(map[string]interface{}); ok {
+		if av, ok := m["active"]; ok {
+			return parseBoolValue(av)
+		}
+		return false, false
+	}
+	// Try JSON round-trip for edge cases where the value is already serialised.
+	data, err := json.Marshal(v)
+	if err != nil {
+		return false, false
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return false, false
+	}
+	if av, ok := obj["active"]; ok {
+		return parseBoolValue(av)
+	}
+	return false, false
+}

--- a/server/internal/adapter/scim/handler_users_test.go
+++ b/server/internal/adapter/scim/handler_users_test.go
@@ -1,0 +1,445 @@
+package scim
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	accountmemory "github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interactor"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testBaseURL = "https://accounts.example.com"
+
+// setupHandlerTest creates a fresh in-memory DB, a SCIM-enabled workspace, and a UserHandler.
+func setupHandlerTest(t *testing.T) (
+	db *repo.Container,
+	ws *workspace.Workspace,
+	ownerID user.ID,
+	handler *UserHandler,
+) {
+	t.Helper()
+	db = accountmemory.New()
+
+	ownerID = user.NewID()
+	owner := user.New().ID(ownerID).Name("Owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+
+	ws = workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	scimUC := interactor.NewScim(db)
+	handler = NewUserHandler(scimUC, db.Workspace, testBaseURL)
+	return
+}
+
+// provisionTestUser is a helper to provision a standard test user.
+func provisionTestUser(t *testing.T, ctx context.Context, db *repo.Container, wsID workspace.ID) *user.User {
+	t.Helper()
+	scimUC := interactor.NewScim(db)
+	u, err := scimUC.ProvisionScimUser(ctx, interfaces.ProvisionScimUserParam{
+		Email:       "alice@example.com",
+		ExternalID:  "ext-alice-001",
+		Name:        "Alice",
+		Role:        role.RoleWriter,
+		WorkspaceID: wsID,
+	})
+	require.NoError(t, err)
+	return u
+}
+
+// contextWithWorkspace injects a workspace ID into the request context (simulating middleware).
+func contextWithWorkspace(req *http.Request, wsID workspace.ID) *http.Request {
+	ctx := context.WithValue(req.Context(), scimWorkspaceKey{}, wsID)
+	return req.WithContext(ctx)
+}
+
+// --- List ---
+
+func TestUserHandler_List_OnlyOwner(t *testing.T) {
+	// The owner is a non-disabled member, so they appear in the list.
+	_, ws, _, handler := setupHandlerTest(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// The owner is a member, so there is 1 result.
+	assert.Equal(t, 1, resp.TotalResults)
+}
+
+func TestUserHandler_List_WithUsers(t *testing.T) {
+	// After provisioning Alice, the list has the owner + Alice = 2 members.
+	db, ws, _, handler := setupHandlerTest(t)
+
+	provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.TotalResults)
+}
+
+func TestUserHandler_List_FilterByUserName(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.QueryParams().Set("filter", `userName eq "alice@example.com"`)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.TotalResults)
+}
+
+func TestUserHandler_List_FilterByUserName_NoMatch(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.QueryParams().Set("filter", `userName eq "nobody@example.com"`)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.TotalResults)
+}
+
+func TestUserHandler_List_FilterByExternalID(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.QueryParams().Set("filter", `externalId eq "ext-alice-001"`)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.TotalResults)
+}
+
+func TestUserHandler_List_FilterInvalidAttr(t *testing.T) {
+	_, ws, _, handler := setupHandlerTest(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.QueryParams().Set("filter", `displayName eq "Alice"`)
+
+	err := handler.List(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Create ---
+
+func TestUserHandler_Create(t *testing.T) {
+	_, ws, _, handler := setupHandlerTest(t)
+
+	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"newuser@example.com","externalId":"ext-new-001","name":{"formatted":"New User"}}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Create(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("Location"))
+
+	var resp ScimUser
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "newuser@example.com", resp.UserName)
+	assert.True(t, resp.Active)
+	assert.Equal(t, "ext-new-001", resp.ExternalID)
+}
+
+func TestUserHandler_Create_LocationHeader(t *testing.T) {
+	_, ws, _, handler := setupHandlerTest(t)
+
+	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"user2@example.com","externalId":"ext-002","name":{"formatted":"User Two"}}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Create(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	location := rec.Header().Get("Location")
+	assert.True(t, strings.HasPrefix(location, testBaseURL+"/scim/v2/Users/"), "location must point to the created user")
+}
+
+// --- Get ---
+
+func TestUserHandler_Get_NotFound(t *testing.T) {
+	_, ws, _, handler := setupHandlerTest(t)
+
+	unknownID := user.NewID()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users/"+unknownID.String(), nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(unknownID.String())
+
+	err := handler.Get(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestUserHandler_Get_Found(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	u := provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users/"+u.ID().String(), nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(u.ID().String())
+
+	err := handler.Get(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimUser
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, u.ID().String(), resp.ID)
+	assert.Equal(t, "alice@example.com", resp.UserName)
+	assert.True(t, resp.Active)
+}
+
+// --- Delete ---
+
+func TestUserHandler_Delete(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	u := provisionTestUser(t, t.Context(), db, ws.ID())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/scim/v2/Users/"+u.ID().String(), nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(u.ID().String())
+
+	err := handler.Delete(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimUser
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.False(t, resp.Active, "deprovisioned user must have active:false")
+
+	// Verify soft-disabled in workspace.
+	saved, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := saved.Members().User(u.ID())
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled)
+}
+
+func TestUserHandler_Delete_LastOwner_Conflict(t *testing.T) {
+	db, ws, ownerID, handler := setupHandlerTest(t)
+
+	// Set an ExternalID for the owner.
+	ws2, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, ws2.Members().SetUserExternalID(ownerID, "ext-owner-001"))
+	require.NoError(t, db.Workspace.Save(t.Context(), ws2))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/scim/v2/Users/"+ownerID.String(), nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(ownerID.String())
+
+	err = handler.Delete(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// --- Patch ---
+
+func TestUserHandler_Patch_OktaDeprovisioning(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	u := provisionTestUser(t, t.Context(), db, ws.ID())
+
+	// Okta format: path="active", value=false
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":false}]}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/"+u.ID().String(), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(u.ID().String())
+
+	err := handler.Patch(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	saved, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := saved.Members().User(u.ID())
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled)
+}
+
+func TestUserHandler_Patch_AzureADDeprovisioning(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	u := provisionTestUser(t, t.Context(), db, ws.ID())
+
+	// Azure AD format: no path, value is object with active:false
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"active":false}}]}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/"+u.ID().String(), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(u.ID().String())
+
+	err := handler.Patch(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	saved, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := saved.Members().User(u.ID())
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled)
+}
+
+func TestUserHandler_Patch_NoActiveChange(t *testing.T) {
+	db, ws, _, handler := setupHandlerTest(t)
+	u := provisionTestUser(t, t.Context(), db, ws.ID())
+
+	// PATCH with unrelated operation - user should remain active.
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":true}]}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/"+u.ID().String(), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(u.ID().String())
+
+	err := handler.Patch(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	saved, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := saved.Members().User(u.ID())
+	require.NotNil(t, m)
+	assert.False(t, m.Disabled, "user should remain active")
+}
+
+// --- parseFilter helper ---
+
+func TestParseFilter(t *testing.T) {
+	tests := []struct {
+		input   string
+		attr    string
+		op      string
+		val     string
+		wantErr bool
+	}{
+		{`userName eq "alice@example.com"`, "username", "eq", "alice@example.com", false},
+		{`externalId eq "ext-001"`, "externalid", "eq", "ext-001", false},
+		{`badfilter`, "", "", "", true},
+		{`attr ne "x"`, "attr", "ne", "x", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			attr, op, val, err := parseFilter(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.attr, attr)
+				assert.Equal(t, tt.op, op)
+				assert.Equal(t, tt.val, val)
+			}
+		})
+	}
+}
+

--- a/server/internal/adapter/scim/middleware.go
+++ b/server/internal/adapter/scim/middleware.go
@@ -1,0 +1,82 @@
+package scim
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type scimWorkspaceKey struct{}
+
+// ScimBearerAuth returns an Echo middleware that validates a SCIM Bearer token
+// against all workspaces with SCIM enabled. The matched workspace ID is injected
+// into the request context for downstream handlers.
+func ScimBearerAuth(workspaceRepo workspace.Repo) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// 1. Extract Bearer token from Authorization header.
+			auth := c.Request().Header.Get("Authorization")
+			if !strings.HasPrefix(auth, "Bearer ") {
+				return scimErrorResponse(c, http.StatusUnauthorized, "missing or malformed authorization header", "")
+			}
+			token := strings.TrimPrefix(auth, "Bearer ")
+			if token == "" {
+				return scimErrorResponse(c, http.StatusUnauthorized, "missing bearer token", "")
+			}
+
+			// 2. Scan all workspaces with SCIM enabled to find the matching token.
+			ctx := c.Request().Context()
+			allWS, _, err := workspaceRepo.FindAll(ctx, nil, nil)
+			if err != nil {
+				return scimErrorResponse(c, http.StatusUnauthorized, "internal error", "")
+			}
+
+			var matched *workspace.Workspace
+			for _, ws := range allWS {
+				cfg := ws.ScimConfig()
+				if cfg == nil || !cfg.Enabled() || cfg.TokenHash() == "" {
+					continue
+				}
+				if err := bcrypt.CompareHashAndPassword([]byte(cfg.TokenHash()), []byte(token)); err == nil {
+					matched = ws
+					break
+				}
+			}
+
+			if matched == nil {
+				return scimErrorResponse(c, http.StatusUnauthorized, "invalid or expired SCIM token", "")
+			}
+
+			// 3. Inject workspace ID into context.
+			newCtx := context.WithValue(ctx, scimWorkspaceKey{}, matched.ID())
+			c.SetRequest(c.Request().WithContext(newCtx))
+			return next(c)
+		}
+	}
+}
+
+// WorkspaceIDFromContext retrieves the authenticated workspace ID injected by ScimBearerAuth.
+func WorkspaceIDFromContext(ctx context.Context) (workspace.ID, bool) {
+	v := ctx.Value(scimWorkspaceKey{})
+	if v == nil {
+		return workspace.ID{}, false
+	}
+	id, ok := v.(workspace.ID)
+	return id, ok
+}
+
+// scimErrorResponse writes a JSON ScimError response body and returns nil (the response is
+// already committed). Callers should return the result of this function.
+func scimErrorResponse(c echo.Context, status int, detail, scimType string) error {
+	return c.JSON(status, ScimError{
+		Detail:   detail,
+		Schemas:  []string{ScimSchemaError},
+		ScimType: scimType,
+		Status:   fmt.Sprintf("%d", status),
+	})
+}

--- a/server/internal/adapter/scim/middleware_test.go
+++ b/server/internal/adapter/scim/middleware_test.go
@@ -1,0 +1,158 @@
+package scim
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	accountmemory "github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestScimBearerAuth_MissingHeader(t *testing.T) {
+	db := accountmemory.New()
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	mw := ScimBearerAuth(db.Workspace)
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestScimBearerAuth_InvalidToken(t *testing.T) {
+	db := accountmemory.New()
+
+	// Create workspace with SCIM enabled and a known token hash.
+	ownerID := user.NewID()
+	plaintext := "valid-token-abc"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	cfg.SetTokenHash(string(hash))
+
+	ws := workspace.New().
+		NewID().
+		Name("test").
+		Alias("test").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	mw := ScimBearerAuth(db.Workspace)
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err = handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestScimBearerAuth_ValidToken(t *testing.T) {
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	plaintext := "valid-token-abc"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	cfg.SetTokenHash(string(hash))
+
+	ws := workspace.New().
+		NewID().
+		Name("test").
+		Alias("test").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capturedWSID workspace.ID
+	mw := ScimBearerAuth(db.Workspace)
+	handler := mw(func(c echo.Context) error {
+		id, ok := WorkspaceIDFromContext(c.Request().Context())
+		require.True(t, ok, "workspace ID must be in context")
+		capturedWSID = id
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err = handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, ws.ID(), capturedWSID)
+}
+
+func TestScimBearerAuth_DisabledWorkspace(t *testing.T) {
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	plaintext := "valid-token-abc"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	// SCIM not enabled
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(false)
+	cfg.SetTokenHash(string(hash))
+
+	ws := workspace.New().
+		NewID().
+		Name("test").
+		Alias("test").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	mw := ScimBearerAuth(db.Workspace)
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err = handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/server/internal/adapter/scim/model.go
+++ b/server/internal/adapter/scim/model.go
@@ -1,0 +1,85 @@
+package scim
+
+import (
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+)
+
+const (
+	ScimSchemaError        = "urn:ietf:params:scim:api:messages:2.0:Error"
+	ScimSchemaGroup        = "urn:ietf:params:scim:schemas:core:2.0:Group"
+	ScimSchemaListResponse = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+	ScimSchemaPatchOp      = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+	ScimSchemaUser         = "urn:ietf:params:scim:schemas:core:2.0:User"
+)
+
+type ScimEmail struct {
+	Primary bool   `json:"primary,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Value   string `json:"value"`
+}
+
+type ScimError struct {
+	Detail   string   `json:"detail"`
+	Schemas  []string `json:"schemas"`
+	ScimType string   `json:"scimType,omitempty"`
+	Status   string   `json:"status"`
+}
+
+type ScimListResponse struct {
+	ItemsPerPage int         `json:"itemsPerPage"`
+	Resources    interface{} `json:"Resources"`
+	Schemas      []string    `json:"schemas"`
+	StartIndex   int         `json:"startIndex"`
+	TotalResults int         `json:"totalResults"`
+}
+
+type ScimMeta struct {
+	Location     string `json:"location"`
+	ResourceType string `json:"resourceType"`
+}
+
+type ScimName struct {
+	FamilyName string `json:"familyName,omitempty"`
+	Formatted  string `json:"formatted,omitempty"`
+	GivenName  string `json:"givenName,omitempty"`
+}
+
+type ScimOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path,omitempty"`
+	Value interface{} `json:"value"`
+}
+
+type ScimPatchOp struct {
+	Operations []ScimOperation `json:"Operations"`
+	Schemas    []string        `json:"schemas"`
+}
+
+type ScimUser struct {
+	Active     bool        `json:"active"`
+	Emails     []ScimEmail `json:"emails,omitempty"`
+	ExternalID string      `json:"externalId,omitempty"`
+	ID         string      `json:"id"`
+	Meta       ScimMeta    `json:"meta"`
+	Name       ScimName    `json:"name,omitempty"`
+	Schemas    []string    `json:"schemas"`
+	UserName   string      `json:"userName"`
+}
+
+// DomainUserToScimUser converts a domain User and its workspace Member to a SCIM 2.0 User resource.
+func DomainUserToScimUser(u *user.User, member workspace.Member, baseURL string) ScimUser {
+	return ScimUser{
+		Active:     !member.Disabled,
+		Emails:     []ScimEmail{{Primary: true, Type: "work", Value: u.Email()}},
+		ExternalID: member.ExternalID,
+		ID:         u.ID().String(),
+		Meta: ScimMeta{
+			Location:     baseURL + "/scim/v2/Users/" + u.ID().String(),
+			ResourceType: "User",
+		},
+		Name:     ScimName{Formatted: u.Name()},
+		Schemas:  []string{ScimSchemaUser},
+		UserName: u.Email(),
+	}
+}

--- a/server/internal/adapter/scim/router.go
+++ b/server/internal/adapter/scim/router.go
@@ -1,0 +1,28 @@
+package scim
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+)
+
+// RegisterSCIMRouter mounts all SCIM 2.0 routes on the given Echo instance.
+// Discovery endpoints are public; user-management routes require a valid SCIM Bearer token.
+func RegisterSCIMRouter(e *echo.Echo, workspaceRepo workspace.Repo, scimUC interfaces.Scim, baseURL string) {
+	discovery := NewDiscoveryHandler()
+	users := NewUserHandler(scimUC, workspaceRepo, baseURL)
+
+	// Public discovery endpoints (no auth).
+	e.GET("/scim/v2/ServiceProviderConfig", discovery.ServiceProviderConfig)
+	e.GET("/scim/v2/ResourceTypes", discovery.ResourceTypes)
+	e.GET("/scim/v2/Schemas", discovery.Schemas)
+
+	// Authenticated user-management endpoints.
+	scim := e.Group("/scim/v2", ScimBearerAuth(workspaceRepo))
+	scim.GET("/Users", users.List)
+	scim.POST("/Users", users.Create)
+	scim.GET("/Users/:id", users.Get)
+	scim.PUT("/Users/:id", users.Replace)
+	scim.PATCH("/Users/:id", users.Patch)
+	scim.DELETE("/Users/:id", users.Delete)
+}

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/reearth/reearth-accounts/server/internal/adapter"
 	adapterhttp "github.com/reearth/reearth-accounts/server/internal/adapter/http"
+	scimadapter "github.com/reearth/reearth-accounts/server/internal/adapter/scim"
 	otelapp "github.com/reearth/reearth-accounts/server/internal/app/otel"
 	"github.com/reearth/reearth-accounts/server/internal/usecase/interactor"
 	"github.com/reearth/reearth-accounts/server/pkg/user"
@@ -154,6 +155,9 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		SwaggerPass:        cfg.Config.SwaggerBasicPass,
 		Debug:              cfg.Debug || cfg.Config.Dev,
 	})
+
+	scimUC := interactor.NewScim(cfg.Repos)
+	scimadapter.RegisterSCIMRouter(e, cfg.Repos.Workspace, scimUC, cfg.Config.Host)
 
 	return e
 }

--- a/server/internal/usecase/interactor/scim.go
+++ b/server/internal/usecase/interactor/scim.go
@@ -47,6 +47,29 @@ func (i *Scim) DeprovisionScimUser(ctx context.Context, workspaceID workspace.ID
 	})
 }
 
+func (i *Scim) DeprovisionScimUserByUserID(ctx context.Context, workspaceID workspace.ID, userID user.ID) error {
+	return Run0(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return err
+		}
+
+		if !ws.Members().HasUser(userID) {
+			return interfaces.ErrSCIMUserNotFound
+		}
+
+		if ws.Members().IsOnlyOwner(userID) {
+			return interfaces.ErrOwnerCannotLeaveTheWorkspace
+		}
+
+		if err := ws.Members().SetUserDisabled(userID, true); err != nil {
+			return err
+		}
+
+		return i.repos.Workspace.Save(ctx, ws)
+	})
+}
+
 func (i *Scim) GenerateScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (string, error) {
 	return Run1(ctx, operator, i.repos, Usecase().Transaction().WithMaintainableWorkspaces(workspaceID), func(ctx context.Context) (string, error) {
 		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)

--- a/server/internal/usecase/interactor/scim_test.go
+++ b/server/internal/usecase/interactor/scim_test.go
@@ -203,6 +203,100 @@ func TestDeprovisionScimUser_LastOwner(t *testing.T) {
 	assert.ErrorIs(t, err, interfaces.ErrOwnerCannotLeaveTheWorkspace)
 }
 
+func TestDeprovisionScimUserByUserID_OK(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	memberID := user.NewID()
+	member := user.New().ID(memberID).Name("member").Email("member@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, member))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID:  {Role: role.RoleOwner, InvitedBy: ownerID},
+			memberID: {Role: role.RoleWriter, InvitedBy: ownerID, ExternalID: "ext-member-002"},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	err := uc.DeprovisionScimUserByUserID(ctx, ws.ID(), memberID)
+	require.NoError(t, err)
+
+	saved, err := db.Workspace.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+
+	m := saved.Members().User(memberID)
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled, "member must be soft-disabled, not removed")
+}
+
+func TestDeprovisionScimUserByUserID_LastOwner(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID, ExternalID: "ext-owner-002"},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	err := uc.DeprovisionScimUserByUserID(ctx, ws.ID(), ownerID)
+	assert.ErrorIs(t, err, interfaces.ErrOwnerCannotLeaveTheWorkspace)
+}
+
+func TestDeprovisionScimUserByUserID_NotFound(t *testing.T) {
+	ctx := context.Background()
+	db := accountmemory.New()
+
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(ctx, owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(ctx, ws))
+
+	uc := NewScim(db)
+
+	unknownID := user.NewID()
+	err := uc.DeprovisionScimUserByUserID(ctx, ws.ID(), unknownID)
+	assert.ErrorIs(t, err, interfaces.ErrSCIMUserNotFound)
+}
+
 func TestSyncScimGroup_AddAndRemove(t *testing.T) {
 	ctx := context.Background()
 	db := accountmemory.New()

--- a/server/internal/usecase/interfaces/scim.go
+++ b/server/internal/usecase/interfaces/scim.go
@@ -31,6 +31,7 @@ type ScimGroupMember struct {
 
 type Scim interface {
 	DeprovisionScimUser(ctx context.Context, workspaceID workspace.ID, externalID string) error
+	DeprovisionScimUserByUserID(ctx context.Context, workspaceID workspace.ID, userID user.ID) error
 	GenerateScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (string, error)
 	GetScimConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*workspace.ScimConfig, error)
 	GetScimUser(ctx context.Context, workspaceID workspace.ID, userID user.ID) (*user.User, error)


### PR DESCRIPTION
## Why

Part of [D-20] U-D20-05 SCIM Provisioning via Auth0 (eukarya-inc/reearth-dashboard#1373).

This is the third of four PRs for SCIM support. It exposes the SCIM 2.0 protocol over HTTP — the adapter layer that sits in front of the usecase layer added in U-D20-05b.

**New package: `server/internal/adapter/scim/`**

- `model.go` — SCIM 2.0 wire-format types (RFC 7643/7644): `ScimUser`, `ScimListResponse`, `ScimPatchOp`, `ScimError`, and the schema URI constants. `DomainUserToScimUser()` converts domain objects to SCIM resources.
- `middleware.go` — `ScimBearerAuth`: per-workspace bearer token middleware. Extracts the `Authorization: Bearer` header, scans SCIM-enabled workspaces, bcrypt-compares against stored token hashes, and injects the matched `workspace.ID` into context. Fails closed; no dev bypass.
- `handler_discovery.go` — Static RFC 7643 §5 responses for `ServiceProviderConfig`, `ResourceTypes`, `Schemas` (public; no auth). Declares `filter.supported: true`, `patch.supported: true`, bulk/changePassword/sort/etag as false.
- `handler_users.go` — Full Users CRUD: List (with `userName eq`/`externalId eq` filter), Create (201 + Location), Get, Replace, Patch (Okta and Azure AD formats), Delete (soft-deprovision).
- `router.go` — `RegisterSCIMRouter` wires all routes; discovery routes are public, user routes use `ScimBearerAuth`.

**Also:**

- Added `DeprovisionScimUserByUserID` to `interfaces.Scim` and its interactor implementation — needed because DELETE/PATCH URLs carry the user ID, not the external ID.
- Wired `RegisterSCIMRouter` into `app.go`; SCIM routes share the Echo instance but use their own middleware stack independent of JWT auth.

## Checklist

- [x] Verified backward compatibility related to feature modifications (new `/scim/v2/` routes are additive; no existing routes or middleware are changed)
- [x] Confirmed backward compatibility for migrations (no schema changes in this PR)
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed