### PR TITLE
perf(server): add wildcard index to avoid workspace-by-user collection scan

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260803120000_add_workspace_members_wildcard_index.go
+++ b/server/internal/infrastructure/mongo/migration/260803120000_add_workspace_members_wildcard_index.go
@@ -1,0 +1,38 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// AddWorkspaceMembersWildcardIndex creates a wildcard index over the
+// workspace.members subdocument.
+//
+// FindByUser/FindByUserWithPagination filter on the dynamic field path
+// "members.<userID>: {$exists: true}". Because members is stored as a map
+// keyed by user ID, no regular index can target that path, so every by-user
+// workspace lookup used to be a full collection scan. A wildcard index
+// indexes every field under a subdocument regardless of key name (requires
+// MongoDB 4.2+), which lets Mongo serve this exact "does key X exist under
+// members" query without any change to the document shape or the query
+// itself, and without needing a backfill since the index is built directly
+// from the existing members maps.
+func AddWorkspaceMembersWildcardIndex(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("workspace")
+
+	name, err := col.Indexes().CreateOne(ctx, workspaceMembersWildcardIndexModel())
+	if err != nil {
+		return fmt.Errorf("failed to create wildcard index on workspace.members: %w", err)
+	}
+	fmt.Printf("Created wildcard index %q on workspace.members\n", name)
+	return nil
+}
+
+func workspaceMembersWildcardIndexModel() mongo.IndexModel {
+	return mongo.IndexModel{
+		Keys: bson.D{{Key: "members.$**", Value: 1}},
+	}
+}

--- a/server/internal/infrastructure/mongo/migration/260803120000_add_workspace_members_wildcard_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/260803120000_add_workspace_members_wildcard_index_test.go
@@ -1,0 +1,72 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestWorkspaceMembersWildcardIndexModel(t *testing.T) {
+	model := workspaceMembersWildcardIndexModel()
+	assert.Equal(t, bson.D{{Key: "members.$**", Value: 1}}, model.Keys)
+}
+
+func TestAddWorkspaceMembersWildcardIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	col := db.Collection("workspace")
+
+	testWorkspace := bson.M{
+		"_id":   primitive.NewObjectID(),
+		"alias": "test-workspace",
+		"name":  "Test Workspace",
+		"email": "test@example.com",
+		"members": bson.M{
+			"user1": bson.M{"role": "owner", "invitedby": "user1", "disabled": false},
+		},
+		"personal": false,
+	}
+	_, err := col.InsertOne(ctx, testWorkspace)
+	assert.NoError(t, err)
+
+	c := mongox.NewClientWithDatabase(db)
+	assert.NoError(t, AddWorkspaceMembersWildcardIndex(ctx, c))
+
+	// index exists
+	cursor, err := col.Indexes().List(ctx)
+	assert.NoError(t, err)
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+	var indexes []bson.M
+	assert.NoError(t, cursor.All(ctx, &indexes))
+
+	found := false
+	for _, index := range indexes {
+		if keys, ok := index["key"].(bson.M); ok {
+			if _, ok := keys["members.$**"]; ok {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "wildcard index on workspace.members should exist")
+
+	// the exact query used by FindByUser should still work correctly with the index in place
+	var result bson.M
+	err = col.FindOne(ctx, bson.M{"members.user1": bson.M{"$exists": true}}).Decode(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, testWorkspace["alias"], result["alias"])
+
+	err = col.FindOne(ctx, bson.M{"members.nonexistentuser": bson.M{"$exists": true}}).Decode(&result)
+	assert.ErrorIs(t, err, mongo.ErrNoDocuments)
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -44,4 +44,5 @@ var migrations = migration.Migrations[DBClient]{
 	260701120001: AddAdminUserEmailIndex,
 	260701120002: AddAdminUserStatusCreatedAtIndex,
 	260708123739: BackfillAdminUserRole,
+	260803120000: AddWorkspaceMembersWildcardIndex,
 }

--- a/server/internal/infrastructure/mongo/workspace_test.go
+++ b/server/internal/infrastructure/mongo/workspace_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/reearth/reearthx/mongox/mongotest"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	mongodriver "go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestWorkspace_FindByID(t *testing.T) {
@@ -322,6 +324,43 @@ func TestWorkspace_FindByUserWithPagination(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorkspace_FindByUser_WithWildcardIndex applies the same wildcard index
+// the AddWorkspaceMembersWildcardIndex migration creates on workspace.members
+// (see internal/infrastructure/mongo/migration) and verifies FindByUser /
+// FindByUserWithPagination still return the correct workspaces once it's in
+// place, so the SCA-01 fix doesn't just create an index but actually keeps
+// the by-user lookup functionally correct.
+func TestWorkspace_FindByUser_WithWildcardIndex(t *testing.T) {
+	u := user.New().Name("aaa").NewID().Email("aaa@bbb.com").MustBuild()
+	other := user.New().Name("bbb").NewID().Email("bbb@ccc.com").MustBuild()
+	ws1 := workspace.New().NewID().Name("hoge").Members(map[user.ID]workspace.Member{u.ID(): {Role: role.RoleOwner, InvitedBy: u.ID()}}).MustBuild()
+	ws2 := workspace.New().NewID().Name("foo").Members(map[user.ID]workspace.Member{u.ID(): {Role: role.RoleOwner, InvitedBy: u.ID()}}).MustBuild()
+
+	init := mongotest.Connect(t)
+	db := init(t)
+	client := mongox.NewClientWithDatabase(db)
+
+	indexModel := mongodriver.IndexModel{Keys: bson.D{{Key: "members.$**", Value: 1}}}
+	_, err := db.Collection("workspace").Indexes().CreateOne(context.Background(), indexModel)
+	assert.NoError(t, err)
+
+	repo := NewWorkspace(client)
+	ctx := context.Background()
+	assert.NoError(t, repo.SaveAll(ctx, workspace.List{ws1, ws2}))
+
+	got, err := repo.FindByUser(ctx, u.ID())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, workspace.List{ws1, ws2}.IDs(), got.IDs())
+
+	got, err = repo.FindByUser(ctx, other.ID())
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+
+	gotPage, _, err := repo.FindByUserWithPagination(ctx, u.ID(), nil)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, workspace.List{ws1, ws2}.IDs(), gotPage.IDs())
 }
 
 func TestWorkspace_Remove(t *testing.T) {


### PR DESCRIPTION
## Why

Fixes the CRITICAL finding SCA-01 from https://github.com/eukarya-inc/compliance/issues/100:

`Workspace.FindByUser` / `FindByUserWithPagination` filter on the dynamic
field path `members.<userID>: {$exists: true}`. Because `members` is stored
as a MongoDB map keyed by user ID, no regular index can target that path, so
every by-user workspace lookup did a full collection scan.

This lookup isn't just a "list my workspaces" query — `generateUserOperator`
(`internal/app/auth.go`) calls it on every authenticated request to build the
operator's `ReadableWorkspaces`/`WritableWorkspaces`/`MaintainableWorkspaces`/`OwningWorkspaces`
sets, which every `WithReadableWorkspaces()`/`WithWritableWorkspaces()` check
in the interactor layer relies on. At scale (~100k workspaces) this becomes a
COLLSCAN on the hot path other Re:Earth services call for `getMe`.

Considered denormalizing into a `member_user_ids` array with a regular index
instead, but rejected it: keeping a duplicate copy of membership data in sync
with `members` risks drift (partial writes, direct DB scripts) feeding wrong
permissions into that same authorization path. A wildcard index on
`members.$**` indexes the existing map directly — no schema change, no
backfill, no duplicated state, and no change to the query itself.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations (index-only migration, no data or document shape change, no backfill)
- [x] Verified that no PII is included in any values that may be displayed