### PR TITLE
feat(server): add regenerateMFARecoveryCode mutation via Auth0

### DIFF
--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -84,6 +84,10 @@ type ComplexityRoot struct {
 		EnrollmentURL func(childComplexity int) int
 	}
 
+	MFARecoveryCodeResult struct {
+		RecoveryCode func(childComplexity int) int
+	}
+
 	MFAStatus struct {
 		Enrolled func(childComplexity int) int
 	}
@@ -113,6 +117,7 @@ type ComplexityRoot struct {
 		FindOrCreate                     func(childComplexity int, input gqlmodel.FindOrCreateInput) int
 		Logout                           func(childComplexity int) int
 		PasswordReset                    func(childComplexity int, input gqlmodel.PasswordResetInput) int
+		RegenerateMFARecoveryCode        func(childComplexity int) int
 		RemoveIntegrationFromWorkspace   func(childComplexity int, input gqlmodel.RemoveIntegrationFromWorkspaceInput) int
 		RemoveIntegrationsFromWorkspace  func(childComplexity int, input gqlmodel.RemoveIntegrationsFromWorkspaceInput) int
 		RemoveMultipleUsersFromWorkspace func(childComplexity int, input gqlmodel.RemoveMultipleUsersFromWorkspaceInput) int
@@ -259,6 +264,7 @@ type MutationResolver interface {
 	FindOrCreate(ctx context.Context, input gqlmodel.FindOrCreateInput) (*gqlmodel.UserPayload, error)
 	Logout(ctx context.Context) (*gqlmodel.Me, error)
 	PasswordReset(ctx context.Context, input gqlmodel.PasswordResetInput) (*bool, error)
+	RegenerateMFARecoveryCode(ctx context.Context) (*gqlmodel.MFARecoveryCodeResult, error)
 	RemoveMyAuth(ctx context.Context, input gqlmodel.RemoveMyAuthInput) (*gqlmodel.UpdateMePayload, error)
 	Signup(ctx context.Context, input gqlmodel.SignupInput) (*gqlmodel.UserPayload, error)
 	SignupOidc(ctx context.Context, input gqlmodel.SignupOIDCInput) (*gqlmodel.UserPayload, error)
@@ -412,6 +418,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.MFAEnrollResult.EnrollmentURL(childComplexity), true
+
+	case "MFARecoveryCodeResult.recoveryCode":
+		if e.complexity.MFARecoveryCodeResult.RecoveryCode == nil {
+			break
+		}
+
+		return e.complexity.MFARecoveryCodeResult.RecoveryCode(childComplexity), true
 
 	case "MFAStatus.enrolled":
 		if e.complexity.MFAStatus.Enrolled == nil {
@@ -587,6 +600,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.PasswordReset(childComplexity, args["input"].(gqlmodel.PasswordResetInput)), true
+	case "Mutation.regenerateMFARecoveryCode":
+		if e.complexity.Mutation.RegenerateMFARecoveryCode == nil {
+			break
+		}
+
+		return e.complexity.Mutation.RegenerateMFARecoveryCode(childComplexity), true
 	case "Mutation.removeIntegrationFromWorkspace":
 		if e.complexity.Mutation.RemoveIntegrationFromWorkspace == nil {
 			break
@@ -1503,6 +1522,10 @@ type MFAStatus {
   enrolled: Boolean!
 }
 
+type MFARecoveryCodeResult {
+  recoveryCode: String!
+}
+
 type UsersWithPagination {
   users: [User!]!
   totalCount: Int!
@@ -1607,6 +1630,7 @@ extend type Mutation {
   findOrCreate(input: FindOrCreateInput!): UserPayload
   logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
+  regenerateMFARecoveryCode: MFARecoveryCodeResult!
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload
@@ -2747,6 +2771,35 @@ func (ec *executionContext) fieldContext_MFAEnrollResult_enrollmentUrl(_ context
 	return fc, nil
 }
 
+func (ec *executionContext) _MFARecoveryCodeResult_recoveryCode(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.MFARecoveryCodeResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MFARecoveryCodeResult_recoveryCode,
+		func(ctx context.Context) (any, error) {
+			return obj.RecoveryCode, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MFARecoveryCodeResult_recoveryCode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MFARecoveryCodeResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _MFAStatus_enrolled(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.MFAStatus) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3373,6 +3426,39 @@ func (ec *executionContext) fieldContext_Mutation_passwordReset(ctx context.Cont
 	if fc.Args, err = ec.field_Mutation_passwordReset_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_regenerateMFARecoveryCode(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_regenerateMFARecoveryCode,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().RegenerateMFARecoveryCode(ctx)
+		},
+		nil,
+		ec.marshalNMFARecoveryCodeResult2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFARecoveryCodeResult,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_regenerateMFARecoveryCode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "recoveryCode":
+				return ec.fieldContext_MFARecoveryCodeResult_recoveryCode(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type MFARecoveryCodeResult", field.Name)
+		},
 	}
 	return fc, nil
 }
@@ -9703,6 +9789,45 @@ func (ec *executionContext) _MFAEnrollResult(ctx context.Context, sel ast.Select
 	return out
 }
 
+var mFARecoveryCodeResultImplementors = []string{"MFARecoveryCodeResult"}
+
+func (ec *executionContext) _MFARecoveryCodeResult(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.MFARecoveryCodeResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mFARecoveryCodeResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MFARecoveryCodeResult")
+		case "recoveryCode":
+			out.Values[i] = ec._MFARecoveryCodeResult_recoveryCode(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var mFAStatusImplementors = []string{"MFAStatus"}
 
 func (ec *executionContext) _MFAStatus(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.MFAStatus) graphql.Marshaler {
@@ -9904,6 +10029,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_passwordReset(ctx, field)
 			})
+		case "regenerateMFARecoveryCode":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_regenerateMFARecoveryCode(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "removeMyAuth":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_removeMyAuth(ctx, field)
@@ -11716,6 +11848,20 @@ func (ec *executionContext) marshalNMFAEnrollResult2ᚖgithubᚗcomᚋreearthᚋ
 		return graphql.Null
 	}
 	return ec._MFAEnrollResult(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNMFARecoveryCodeResult2githubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFARecoveryCodeResult(ctx context.Context, sel ast.SelectionSet, v gqlmodel.MFARecoveryCodeResult) graphql.Marshaler {
+	return ec._MFARecoveryCodeResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNMFARecoveryCodeResult2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFARecoveryCodeResult(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.MFARecoveryCodeResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._MFARecoveryCodeResult(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNMFAStatus2githubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFAStatus(ctx context.Context, sel ast.SelectionSet, v gqlmodel.MFAStatus) graphql.Marshaler {

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -106,6 +106,10 @@ type MFAEnrollResult struct {
 	EnrollmentURL string `json:"enrollmentUrl"`
 }
 
+type MFARecoveryCodeResult struct {
+	RecoveryCode string `json:"recoveryCode"`
+}
+
 type MFAStatus struct {
 	Enrolled bool `json:"enrolled"`
 }

--- a/server/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/internal/adapter/gql/resolver_mutation_user.go
@@ -185,6 +185,14 @@ func (r *mutationResolver) EnableMfa(ctx context.Context) (*gqlmodel.MFAEnrollRe
 	return &gqlmodel.MFAEnrollResult{EnrollmentURL: enrollmentURL}, nil
 }
 
+func (r *mutationResolver) RegenerateMFARecoveryCode(ctx context.Context) (*gqlmodel.MFARecoveryCodeResult, error) {
+	recoveryCode, err := usecases(ctx).User.RegenerateMFARecoveryCode(ctx, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &gqlmodel.MFARecoveryCodeResult{RecoveryCode: recoveryCode}, nil
+}
+
 func (r *mutationResolver) PasswordReset(ctx context.Context, input gqlmodel.PasswordResetInput) (*bool, error) {
 	err := usecases(ctx).User.PasswordReset(ctx, input.Password, input.Token)
 	if err != nil {

--- a/server/internal/infrastructure/auth0/authenticator.go
+++ b/server/internal/infrastructure/auth0/authenticator.go
@@ -235,6 +235,24 @@ func (a *Auth0) GetMFAStatus(ctx context.Context, sub string) (gateway.MFAStatus
 	return gateway.MFAStatus{Enrolled: false}, nil
 }
 
+func (a *Auth0) RegenerateMFARecoveryCode(ctx context.Context, sub string) (string, error) {
+	if err := a.updateToken(ctx); err != nil {
+		return "", err
+	}
+
+	var r struct {
+		RecoveryCode string `json:"recovery_code"`
+	}
+	if err := a.execInto(ctx, http.MethodPost, "api/v2/users/"+sub+"/recovery-code-regeneration", a.token, nil, &r); err != nil {
+		if !a.disableLogging {
+			log.Errorf("auth0: regenerate mfa recovery code: %+v", err)
+		}
+		return "", rerror.NewE(i18n.T("failed to regenerate mfa recovery code"))
+	}
+
+	return r.RecoveryCode, nil
+}
+
 func (a *Auth0) needsFetchToken() bool {
 	if a == nil {
 		return false

--- a/server/internal/infrastructure/auth0/authenticator_test.go
+++ b/server/internal/infrastructure/auth0/authenticator_test.go
@@ -25,6 +25,7 @@ const (
 	expiresIn    = 24 * 60 * 60
 	userName     = "d"
 	userEmail    = "e"
+	recoveryCode = "recovery-code-123"
 )
 
 var (
@@ -67,6 +68,28 @@ func TestAuth0(t *testing.T) {
 	}, r)
 
 	a.current = func() time.Time { return current2 }
+}
+
+func TestAuth0_RegenerateMFARecoveryCode(t *testing.T) {
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = client(t)
+	a.current = func() time.Time { return current }
+	a.disableLogging = true
+
+	got, err := a.RegenerateMFARecoveryCode(context.Background(), userID)
+	assert.NoError(t, err)
+	assert.Equal(t, recoveryCode, got)
+}
+
+func TestAuth0_RegenerateMFARecoveryCode_NoEnrollment(t *testing.T) {
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = client(t)
+	a.current = func() time.Time { return current }
+	a.disableLogging = true
+
+	got, err := a.RegenerateMFARecoveryCode(context.Background(), "no-enrollment")
+	assert.Error(t, err)
+	assert.Empty(t, got)
 }
 
 func res(i interface{}) io.ReadCloser {
@@ -120,6 +143,37 @@ func client(t *testing.T) *http.Client {
 						"username":       userName,
 						"email":          userEmail,
 						"email_verified": true,
+					}),
+					Header: make(http.Header),
+				}
+			}
+
+			if req.Method == http.MethodPost && p == "/api/v2/users/"+userID+"/recovery-code-regeneration" {
+				tok := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+				if token != tok {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: res(map[string]interface{}{
+							"message": "Unauthorized",
+						}),
+						Header: make(http.Header),
+					}
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: res(map[string]interface{}{
+						"recovery_code": recoveryCode,
+					}),
+					Header: make(http.Header),
+				}
+			}
+
+			if req.Method == http.MethodPost && p == "/api/v2/users/no-enrollment/recovery-code-regeneration" {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body: res(map[string]interface{}{
+						"error_description": "Enrollment not found",
 					}),
 					Header: make(http.Header),
 				}

--- a/server/internal/infrastructure/cip/authenticator.go
+++ b/server/internal/infrastructure/cip/authenticator.go
@@ -157,6 +157,10 @@ func (a *Authenticator) GetMFAStatus(_ context.Context, _ string) (gateway.MFASt
 	return gateway.MFAStatus{}, nil
 }
 
+func (a *Authenticator) RegenerateMFARecoveryCode(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
 func toAuthenticatorUser(rec *fbauth.UserRecord) gateway.AuthenticatorUser {
 	out := gateway.AuthenticatorUser{}
 	if rec == nil {

--- a/server/internal/usecase/gateway/authenticator.go
+++ b/server/internal/usecase/gateway/authenticator.go
@@ -24,6 +24,7 @@ type Authenticator interface {
 	DisableMFA(ctx context.Context, sub string) error
 	EnableMFA(ctx context.Context, sub string) (enrollmentURL string, err error)
 	GetMFAStatus(ctx context.Context, sub string) (MFAStatus, error)
+	RegenerateMFARecoveryCode(ctx context.Context, sub string) (recoveryCode string, err error)
 	ResendVerificationEmail(ctx context.Context, userID string) error
 	UpdateUser(context.Context, AuthenticatorUpdateUserParam) (AuthenticatorUser, error)
 }

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -366,6 +366,27 @@ func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (
 	})
 }
 
+func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspace.Operator) (string, error) {
+	if operator == nil || operator.User == nil {
+		return "", interfaces.ErrInvalidOperator
+	}
+	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (string, error) {
+		u, err := i.repos.User.FindByID(ctx, *operator.User)
+		if err != nil {
+			return "", err
+		}
+		a := u.Auths().GetByProvider(user.ProviderAuth0)
+		if a == nil {
+			return "", rerror.NewE(i18n.T("no authenticator found"))
+		}
+		authenticator := i.gateways.AuthenticatorFor(a.Provider)
+		if authenticator == nil {
+			return "", rerror.NewE(i18n.T("no authenticator found"))
+		}
+		return authenticator.RegenerateMFARecoveryCode(ctx, a.Sub)
+	})
+}
+
 func (i *User) DeleteMe(ctx context.Context, userID user.ID, operator *workspace.Operator) (err error) {
 	if operator.User == nil {
 		return interfaces.ErrInvalidOperator

--- a/server/internal/usecase/interactor/user_signup_test.go
+++ b/server/internal/usecase/interactor/user_signup_test.go
@@ -790,6 +790,10 @@ func (m *mockAuthenticator) GetMFAStatus(_ context.Context, _ string) (gateway.M
 	return gateway.MFAStatus{}, nil
 }
 
+func (m *mockAuthenticator) RegenerateMFARecoveryCode(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
 func (m *mockAuthenticator) ResendVerificationEmail(ctx context.Context, userID string) error {
 	m.resendVerificationEmailCalled = true
 	m.resendVerificationEmailUserID = userID

--- a/server/internal/usecase/interactor/user_test.go
+++ b/server/internal/usecase/interactor/user_test.go
@@ -1233,8 +1233,82 @@ func (m *mockAuthenticatorWithError) GetMFAStatus(_ context.Context, _ string) (
 	return gateway.MFAStatus{}, nil
 }
 
+func (m *mockAuthenticatorWithError) RegenerateMFARecoveryCode(_ context.Context, _ string) (string, error) {
+	return "new-recovery-code", nil
+}
+
 func (m *mockAuthenticatorWithError) ResendVerificationEmail(_ context.Context, _ string) error {
 	return nil
+}
+
+func TestUser_RegenerateMFARecoveryCode(t *testing.T) {
+	ctx := context.Background()
+
+	uid := id.NewUserID()
+	wid := id.NewWorkspaceID()
+	u := user.New().
+		ID(uid).
+		Workspace(wid).
+		Name("Test User").
+		Email("test@example.com").
+		Auths([]user.Auth{{Provider: "auth0", Sub: "auth0|123456"}}).
+		MustBuild()
+	ws := workspace.New().
+		ID(wid).
+		Name("Test User").
+		Personal(true).
+		MustBuild()
+
+	newUC := func() (interfaces.User, *workspace.Operator) {
+		r := memory.New()
+		assert.NoError(t, r.User.Save(ctx, u))
+		assert.NoError(t, r.Workspace.Save(ctx, ws))
+
+		mockAuth := &mockAuthenticatorWithError{}
+		g := &gateway.Container{Authenticators: map[gateway.Provider]gateway.Authenticator{gateway.ProviderAuth0: mockAuth}}
+
+		return NewUser(r, g, "", ""), &workspace.Operator{User: &uid}
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		uc, operator := newUC()
+		code, err := uc.RegenerateMFARecoveryCode(ctx, operator)
+		assert.NoError(t, err)
+		assert.Equal(t, "new-recovery-code", code)
+	})
+
+	t.Run("nil operator", func(t *testing.T) {
+		uc, _ := newUC()
+		code, err := uc.RegenerateMFARecoveryCode(ctx, nil)
+		assert.ErrorIs(t, err, interfaces.ErrInvalidOperator)
+		assert.Empty(t, code)
+	})
+
+	t.Run("no auth0 auth record", func(t *testing.T) {
+		r := memory.New()
+		noAuthUID := id.NewUserID()
+		noAuthWID := id.NewWorkspaceID()
+		noAuthUser := user.New().
+			ID(noAuthUID).
+			Workspace(noAuthWID).
+			Name("No Auth User").
+			Email("noauth@example.com").
+			MustBuild()
+		noAuthWs := workspace.New().
+			ID(noAuthWID).
+			Name("No Auth User").
+			Personal(true).
+			MustBuild()
+		assert.NoError(t, r.User.Save(ctx, noAuthUser))
+		assert.NoError(t, r.Workspace.Save(ctx, noAuthWs))
+
+		g := &gateway.Container{Authenticators: map[gateway.Provider]gateway.Authenticator{}}
+		uc := NewUser(r, g, "", "")
+
+		code, err := uc.RegenerateMFARecoveryCode(ctx, &workspace.Operator{User: &noAuthUID})
+		assert.Error(t, err)
+		assert.Empty(t, code)
+	})
 }
 
 func TestUser_UpdateMe_AuthenticatorUpdateUserError(t *testing.T) {

--- a/server/internal/usecase/interactor/user_test.go
+++ b/server/internal/usecase/interactor/user_test.go
@@ -1211,7 +1211,8 @@ func TestUser_UpdateMe_SetPasswordError(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-// mockAuthenticatorWithError is a mock implementation of the Authenticator interface that returns errors
+// mockAuthenticatorWithError is a mock implementation of the Authenticator interface.
+// All methods succeed by default; set updateUserErr to make UpdateUser fail.
 type mockAuthenticatorWithError struct {
 	updateUserErr error
 }

--- a/server/internal/usecase/interfaces/user.go
+++ b/server/internal/usecase/interfaces/user.go
@@ -133,4 +133,5 @@ type User interface {
 	DisableMFA(context.Context, *workspace.Operator) error
 	EnableMFA(context.Context, *workspace.Operator) (enrollmentURL string, err error)
 	GetMFAStatus(context.Context, *workspace.Operator) (gateway.MFAStatus, error)
+	RegenerateMFARecoveryCode(context.Context, *workspace.Operator) (recoveryCode string, err error)
 }

--- a/server/internal/usecase/proxy/user.go
+++ b/server/internal/usecase/proxy/user.go
@@ -212,3 +212,7 @@ func (u *User) EnableMFA(_ context.Context, _ *workspace.Operator) (string, erro
 func (u *User) GetMFAStatus(_ context.Context, _ *workspace.Operator) (gateway.MFAStatus, error) {
 	return gateway.MFAStatus{}, errors.New("GetMFAStatus is not supported in proxy mode")
 }
+
+func (u *User) RegenerateMFARecoveryCode(_ context.Context, _ *workspace.Operator) (string, error) {
+	return "", errors.New("RegenerateMFARecoveryCode is not supported in proxy mode")
+}

--- a/server/pkg/gqlclient/user/mockrepo/mockrepo.go
+++ b/server/pkg/gqlclient/user/mockrepo/mockrepo.go
@@ -250,6 +250,21 @@ func (mr *MockRepoMockRecorder) PasswordReset(ctx, password, token any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordReset", reflect.TypeOf((*MockRepo)(nil).PasswordReset), ctx, password, token)
 }
 
+// RegenerateMFARecoveryCode mocks base method.
+func (m *MockRepo) RegenerateMFARecoveryCode(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegenerateMFARecoveryCode", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegenerateMFARecoveryCode indicates an expected call of RegenerateMFARecoveryCode.
+func (mr *MockRepoMockRecorder) RegenerateMFARecoveryCode(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegenerateMFARecoveryCode", reflect.TypeOf((*MockRepo)(nil).RegenerateMFARecoveryCode), ctx)
+}
+
 // RemoveMyAuth mocks base method.
 func (m *MockRepo) RemoveMyAuth(ctx context.Context, auth string) (*user0.User, error) {
 	m.ctrl.T.Helper()

--- a/server/pkg/gqlclient/user/query.go
+++ b/server/pkg/gqlclient/user/query.go
@@ -143,3 +143,9 @@ type enableMFAMutation struct {
 type disableMFAMutation struct {
 	DisableMFA graphql.Boolean `graphql:"disableMFA"`
 }
+
+type regenerateMFARecoveryCodeMutation struct {
+	RegenerateMFARecoveryCode struct {
+		RecoveryCode graphql.String `graphql:"recoveryCode"`
+	} `graphql:"regenerateMFARecoveryCode"`
+}

--- a/server/pkg/gqlclient/user/repo.go
+++ b/server/pkg/gqlclient/user/repo.go
@@ -79,6 +79,7 @@ type Repo interface {
 	GetMFAStatus(ctx context.Context) (MFAStatus, error)
 	Logout(ctx context.Context) (*user.User, error)
 	PasswordReset(ctx context.Context, password string, token string) error
+	RegenerateMFARecoveryCode(ctx context.Context) (recoveryCode string, err error)
 	RemoveMyAuth(ctx context.Context, auth string) (*user.User, error)
 	Signup(ctx context.Context, userID, name, email, password, secret, workspaceID string, mockAuth bool) (*user.User, error)
 	SignupNoID(ctx context.Context, name, email, password, secret string, mockAuth bool) (*user.User, error)
@@ -710,6 +711,14 @@ func (r *userRepo) GetMFAStatus(ctx context.Context) (MFAStatus, error) {
 		return MFAStatus{}, gqlerror.ReturnAccountsError(ctx, err)
 	}
 	return MFAStatus{Enrolled: bool(q.MfaStatus.Enrolled)}, nil
+}
+
+func (r *userRepo) RegenerateMFARecoveryCode(ctx context.Context) (string, error) {
+	var m regenerateMFARecoveryCodeMutation
+	if err := r.client.Mutate(ctx, &m, nil); err != nil {
+		return "", gqlerror.ReturnAccountsError(ctx, err)
+	}
+	return string(m.RegenerateMFARecoveryCode.RecoveryCode), nil
 }
 
 func (r *userRepo) PasswordReset(ctx context.Context, password string, token string) error {

--- a/server/schemas/user.graphql
+++ b/server/schemas/user.graphql
@@ -45,6 +45,10 @@ type MFAStatus {
   enrolled: Boolean!
 }
 
+type MFARecoveryCodeResult {
+  recoveryCode: String!
+}
+
 type UsersWithPagination {
   users: [User!]!
   totalCount: Int!
@@ -149,6 +153,7 @@ extend type Mutation {
   findOrCreate(input: FindOrCreateInput!): UserPayload
   logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
+  regenerateMFARecoveryCode: MFARecoveryCodeResult!
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload


### PR DESCRIPTION
## Why

Follow-up to #288 (Auth0 MFA toggle). Once a user enrolls in MFA, they need a way to get a fresh recovery code if they lose the one shown at enrollment or already used it. Auth0 manages recovery codes natively (auto-generated at enrollment, auto-regenerated on use) — no local storage of codes is needed, consistent with the existing enableMFA/disableMFA/mfaStatus design, which stores no MFA state locally either.

This adds a `regenerateMFARecoveryCode` mutation that calls Auth0's `POST /api/v2/users/{id}/recovery-code-regeneration` Management API endpoint and returns the new code, mirroring the exact pattern used for `enableMFA`/`disableMFA` at every layer (gateway → auth0/cip infra → usecase interactor/proxy → GraphQL schema/resolver → gqlclient SDK for other services).

Enables a follow-up PR in `reearth-dashboard` (stacked on the still-open #1347 MFA toggle PR) to surface this in the account settings UI.

## Known limitation (not addressed in this PR)

Like `disableMFA` (flagged in `docs/compliance/SEC-03-disable-mfa-no-reauth.md`), this mutation only checks that a session exists — no re-auth/step-up challenge before revealing a fresh recovery code. Same accepted risk class as the existing enable/disable mutations; not fixing here to avoid scope creep.

## Checklist

- [x] Verified backward compatibility related to feature modifications (new mutation only, no breaking changes)
- [x] Confirmed backward compatibility for migrations (no DB schema changes — no local MFA state, same as #288)
- [x] Verified that no PII is included in displayed values