### PR TITLE
fix(server): parallelize Auth0 enrollment DELETE calls in DisableMFA

### DIFF
--- a/server/internal/infrastructure/auth0/authenticator.go
+++ b/server/internal/infrastructure/auth0/authenticator.go
@@ -161,15 +161,31 @@ func (a *Auth0) DisableMFA(ctx context.Context, sub string) error {
 		return rerror.NewE(i18n.T("failed to list mfa enrollments"))
 	}
 
+	var confirmed []enrollment
 	for _, e := range enrollments {
-		if e.Status != "confirmed" {
-			continue
+		if e.Status == "confirmed" {
+			confirmed = append(confirmed, e)
 		}
-		if err := a.execInto(ctx, http.MethodDelete, "api/v2/guardian/enrollments/"+e.ID, a.token, nil, nil); err != nil {
-			if !a.disableLogging {
-				log.Errorf("auth0: disable mfa: delete enrollment %s: %+v", e.ID, err)
+	}
+
+	if len(confirmed) > 0 {
+		errs := make([]error, len(confirmed))
+		var wg sync.WaitGroup
+		wg.Add(len(confirmed))
+		for i, e := range confirmed {
+			go func() {
+				defer wg.Done()
+				errs[i] = a.execInto(ctx, http.MethodDelete, "api/v2/guardian/enrollments/"+e.ID, a.token, nil, nil)
+			}()
+		}
+		wg.Wait()
+		for i, err := range errs {
+			if err != nil {
+				if !a.disableLogging {
+					log.Errorf("auth0: disable mfa: delete enrollment %s: %+v", confirmed[i].ID, err)
+				}
+				return rerror.NewE(i18n.T("failed to delete mfa enrollment"))
 			}
-			return rerror.NewE(i18n.T("failed to delete mfa enrollment"))
 		}
 	}
 


### PR DESCRIPTION
## Why

Each confirmed MFA enrollment triggered a sequential HTTP DELETE against the Auth0 Guardian API, making total latency O(N × 5 s timeout) per user. For a user with 3 confirmed factors, that's up to ~15 s of wall-clock time.

While the DB transaction wrapper was already removed by #298 (so the connection pool is no longer held), the sequential calls still impose unnecessary latency. All Guardian enrollment DELETEs are independent and idempotent, so they can safely run in parallel.

The fix collects confirmed enrollments first, then fires one goroutine per enrollment using a `sync.WaitGroup` (already imported). The PATCH to update `mfa_enabled` in app_metadata still runs after all DELETEs complete.

Fixes [SCA-03](https://github.com/eukarya-inc/reearth-dashboard/issues/1383)

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values