### PR TITLE
feat(server): add SCIM Groups adapter and admin SCIM endpoints (U-D20-05d)

### DIFF
--- a/server/internal/adapter/http/handlers/workspace_scim_handler.go
+++ b/server/internal/adapter/http/handlers/workspace_scim_handler.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/adapter/http/httpmodel"
+	httpinternal "github.com/reearth/reearth-accounts/server/internal/adapter/http/internal"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+)
+
+// WorkspaceScimHandler handles admin REST endpoints for per-workspace SCIM configuration.
+type WorkspaceScimHandler struct{}
+
+func NewWorkspaceScimHandler() *WorkspaceScimHandler { return &WorkspaceScimHandler{} }
+
+// GenerateToken handles POST /api/workspaces/:id/scim/token.
+// Generates (or rotates) the SCIM bearer token for the workspace.
+// The plaintext token is returned once and never stored; a second call rotates it.
+func (h *WorkspaceScimHandler) GenerateToken(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return httpinternal.NewError(http.StatusNotFound, "workspace not found", nil)
+	}
+
+	plaintext, err := httpinternal.Usecases(c).Scim.GenerateScimToken(ctx, wid, httpinternal.Operator(c))
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, httpmodel.GenerateScimTokenResponse{
+		Token:   plaintext,
+		Warning: "This token will not be shown again. Store it immediately.",
+	})
+}
+
+// GetConfig handles GET /api/workspaces/:id/scim/config.
+// Returns the current SCIM config; token_hash is masked as token_issued bool.
+func (h *WorkspaceScimHandler) GetConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return httpinternal.NewError(http.StatusNotFound, "workspace not found", nil)
+	}
+
+	cfg, err := httpinternal.Usecases(c).Scim.GetScimConfig(ctx, wid, httpinternal.Operator(c))
+	if err != nil {
+		return err
+	}
+
+	scimBaseURL := c.Scheme() + "://" + c.Request().Host + "/scim/v2"
+	return c.JSON(http.StatusOK, httpmodel.NewScimConfigResponse(cfg, scimBaseURL))
+}
+
+// RevokeToken handles DELETE /api/workspaces/:id/scim/token.
+// Clears the stored token hash and disables SCIM for the workspace.
+func (h *WorkspaceScimHandler) RevokeToken(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return httpinternal.NewError(http.StatusNotFound, "workspace not found", nil)
+	}
+
+	if err := httpinternal.Usecases(c).Scim.RevokeScimToken(ctx, wid, httpinternal.Operator(c)); err != nil {
+		return err
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// UpdateConfig handles PUT /api/workspaces/:id/scim/config.
+// Enables/disables SCIM and sets the group→role mapping.
+// Returns 400 if any role value is unrecognised.
+func (h *WorkspaceScimHandler) UpdateConfig(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return httpinternal.NewError(http.StatusNotFound, "workspace not found", nil)
+	}
+
+	req := &httpmodel.UpdateScimConfigRequest{}
+	if err := httpinternal.BindValidate(c, req); err != nil {
+		return err
+	}
+
+	mapping := make(map[string]role.RoleType, len(req.GroupRoleMapping))
+	for groupName, roleStr := range req.GroupRoleMapping {
+		r := role.RoleType(roleStr)
+		if !r.Valid() {
+			return httpinternal.NewError(http.StatusBadRequest, "invalid role: "+roleStr, nil)
+		}
+		mapping[groupName] = r
+	}
+
+	cfg, err := httpinternal.Usecases(c).Scim.UpdateScimConfig(ctx, wid, req.Enabled, mapping, httpinternal.Operator(c))
+	if err != nil {
+		return err
+	}
+
+	scimBaseURL := c.Scheme() + "://" + c.Request().Host + "/scim/v2"
+	return c.JSON(http.StatusOK, httpmodel.NewScimConfigResponse(cfg, scimBaseURL))
+}

--- a/server/internal/adapter/http/handlers/workspace_scim_handler_test.go
+++ b/server/internal/adapter/http/handlers/workspace_scim_handler_test.go
@@ -1,0 +1,283 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/adapter"
+	"github.com/reearth/reearth-accounts/server/internal/adapter/http/handlers"
+	"github.com/reearth/reearth-accounts/server/internal/adapter/http/httpmodel"
+	accountmemory "github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interactor"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupScimAdminTest creates a SCIM-enabled workspace, an owner operator, and an
+// interfaces.Container with the real Scim interactor backed by in-memory repos.
+func setupScimAdminTest(t *testing.T) (
+	db *repo.Container,
+	ws *workspace.Workspace,
+	ownerID user.ID,
+	ownerOp *workspace.Operator,
+	uc *interfaces.Container,
+) {
+	t.Helper()
+	db = accountmemory.New()
+
+	ownerID = user.NewID()
+	owner := user.New().ID(ownerID).Name("Owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+
+	ws = workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	ownerOp = &workspace.Operator{
+		User:             &ownerID,
+		OwningWorkspaces: id.WorkspaceIDList{ws.ID()},
+	}
+
+	scimUC := interactor.NewScim(db)
+	uc = &interfaces.Container{Scim: scimUC}
+	return
+}
+
+// newScimAdminContext creates an Echo context with the usecases and operator attached.
+func newScimAdminContext(
+	t *testing.T,
+	e *echo.Echo,
+	method, path string,
+	body string,
+	wsID workspace.ID,
+	op *workspace.Operator,
+	uc *interfaces.Container,
+) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+
+	ctx := adapter.AttachUsecases(req.Context(), uc)
+	ctx = adapter.AttachOperator(ctx, op)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(wsID.String())
+	return c, rec
+}
+
+// TestGenerateToken_Owner verifies that an owner can generate a SCIM token.
+func TestGenerateToken_Owner(t *testing.T) {
+	db, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	c, rec := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+
+	require.NoError(t, h.GenerateToken(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp httpmodel.GenerateScimTokenResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Token)
+	assert.NotEmpty(t, resp.Warning)
+
+	// Verify the hash was stored.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	assert.NotEmpty(t, finalWS.ScimConfig().TokenHash())
+}
+
+// TestGenerateToken_NonMaintainer verifies that a non-member gets 403.
+func TestGenerateToken_NonMaintainer(t *testing.T) {
+	_, ws, _, _, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	strangerID := user.NewID()
+	strangerOp := &workspace.Operator{
+		User:               &strangerID,
+		ReadableWorkspaces: id.WorkspaceIDList{},
+	}
+
+	c, rec := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), strangerOp, uc)
+
+	// The error is returned from the handler, not committed directly (no CustomHTTPErrorHandler in unit test).
+	err := h.GenerateToken(c)
+	require.Error(t, err)
+
+	// When routed via CustomHTTPErrorHandler, ErrOperationDenied maps to 403.
+	// In unit test, confirm it's the right error.
+	assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	_ = rec // recorder not used — handler returned an error, not a response
+}
+
+// TestRotateToken verifies that a second GenerateToken call rotates (replaces) the hash.
+func TestRotateToken(t *testing.T) {
+	db, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	// First call.
+	c1, rec1 := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GenerateToken(c1))
+	var first httpmodel.GenerateScimTokenResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &first))
+
+	firstHash, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	hash1 := firstHash.ScimConfig().TokenHash()
+
+	// Second call — should rotate.
+	c2, rec2 := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GenerateToken(c2))
+	var second httpmodel.GenerateScimTokenResponse
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &second))
+
+	secondHash, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	hash2 := secondHash.ScimConfig().TokenHash()
+
+	assert.NotEqual(t, first.Token, second.Token, "tokens must differ after rotation")
+	assert.NotEqual(t, hash1, hash2, "stored hash must change after rotation")
+}
+
+// TestRevokeToken verifies that RevokeToken clears the hash and disables SCIM.
+func TestRevokeToken(t *testing.T) {
+	db, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	// First generate a token.
+	c1, _ := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GenerateToken(c1))
+
+	// Now revoke.
+	c2, rec2 := newScimAdminContext(t, e, http.MethodDelete, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.RevokeToken(c2))
+	assert.Equal(t, http.StatusNoContent, rec2.Code)
+
+	// Token hash must be empty and SCIM must be disabled.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	assert.Empty(t, finalWS.ScimConfig().TokenHash())
+	assert.False(t, finalWS.ScimConfig().Enabled())
+}
+
+// TestUpdateConfig_ValidRoles verifies that a valid role mapping is stored.
+func TestUpdateConfig_ValidRoles(t *testing.T) {
+	db, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	body := `{"enabled":true,"group_role_mapping":{"Engineering":"maintainer","Readers":"reader"}}`
+	c, rec := newScimAdminContext(t, e, http.MethodPut, "/api/workspaces/"+ws.ID().String()+"/scim/config", body, ws.ID(), ownerOp, uc)
+
+	require.NoError(t, h.UpdateConfig(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp httpmodel.ScimConfigResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.True(t, resp.Enabled)
+	assert.Equal(t, "maintainer", resp.GroupRoleMapping["Engineering"])
+	assert.Equal(t, "reader", resp.GroupRoleMapping["Readers"])
+
+	// Verify persisted.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	assert.Equal(t, role.RoleMaintainer, finalWS.ScimConfig().GroupRoleMapping()["Engineering"])
+}
+
+// TestUpdateConfig_InvalidRole verifies that an unrecognised role returns 400.
+func TestUpdateConfig_InvalidRole(t *testing.T) {
+	_, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	body := `{"enabled":true,"group_role_mapping":{"Admins":"superadmin"}}`
+	c, rec := newScimAdminContext(t, e, http.MethodPut, "/api/workspaces/"+ws.ID().String()+"/scim/config", body, ws.ID(), ownerOp, uc)
+
+	err := h.UpdateConfig(c)
+	require.Error(t, err)
+
+	// Should be a 400 ErrorResponse.
+	var er interface{ Error() string }
+	require.ErrorAs(t, err, &er)
+	_ = rec // handler returns error, not a response
+}
+
+// TestGetConfig_MasksHash verifies that the response uses token_issued instead of the raw hash.
+func TestGetConfig_MasksHash(t *testing.T) {
+	_, ws, _, ownerOp, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	// Before any token is generated.
+	c1, rec1 := newScimAdminContext(t, e, http.MethodGet, "/api/workspaces/"+ws.ID().String()+"/scim/config", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GetConfig(c1))
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	var before httpmodel.ScimConfigResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &before))
+	assert.False(t, before.TokenIssued, "token_issued must be false before generating a token")
+	assert.NotContains(t, rec1.Body.String(), "tokenHash", "raw hash must never appear in response")
+
+	// Generate a token.
+	c2, _ := newScimAdminContext(t, e, http.MethodPost, "/api/workspaces/"+ws.ID().String()+"/scim/token", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GenerateToken(c2))
+
+	// After token is generated.
+	c3, rec3 := newScimAdminContext(t, e, http.MethodGet, "/api/workspaces/"+ws.ID().String()+"/scim/config", "", ws.ID(), ownerOp, uc)
+	require.NoError(t, h.GetConfig(c3))
+	assert.Equal(t, http.StatusOK, rec3.Code)
+
+	var after httpmodel.ScimConfigResponse
+	require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &after))
+	assert.True(t, after.TokenIssued, "token_issued must be true after token generation")
+	assert.NotContains(t, rec3.Body.String(), "$2a$", "bcrypt hash must never appear in response")
+}
+
+// TestGetConfig_NonMaintainer verifies that a non-maintainer cannot read the config.
+func TestGetConfig_NonMaintainer(t *testing.T) {
+	_, ws, _, _, uc := setupScimAdminTest(t)
+	h := handlers.NewWorkspaceScimHandler()
+	e := echo.New()
+
+	strangerID := user.NewID()
+	strangerOp := &workspace.Operator{
+		User: &strangerID,
+	}
+
+	c, _ := newScimAdminContext(t, e, http.MethodGet, "/api/workspaces/"+ws.ID().String()+"/scim/config", "", ws.ID(), strangerOp, uc)
+
+	err := h.GetConfig(c)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+}

--- a/server/internal/adapter/http/httpmodel/workspace_scim.go
+++ b/server/internal/adapter/http/httpmodel/workspace_scim.go
@@ -1,0 +1,41 @@
+package httpmodel
+
+import "github.com/reearth/reearth-accounts/server/pkg/workspace"
+
+// GenerateScimTokenResponse is the response for POST /api/workspaces/:id/scim/token.
+type GenerateScimTokenResponse struct {
+	Token   string `json:"token"`
+	Warning string `json:"warning"`
+}
+
+// ScimConfigResponse is the response for GET and PUT /api/workspaces/:id/scim/config.
+type ScimConfigResponse struct {
+	Enabled          bool              `json:"enabled"`
+	GroupRoleMapping map[string]string `json:"group_role_mapping"`
+	ScimBaseURL      string            `json:"scim_base_url"`
+	TokenIssued      bool              `json:"token_issued"`
+}
+
+// UpdateScimConfigRequest is the request body for PUT /api/workspaces/:id/scim/config.
+type UpdateScimConfigRequest struct {
+	Enabled          bool              `json:"enabled"`
+	GroupRoleMapping map[string]string `json:"group_role_mapping"`
+}
+
+// NewScimConfigResponse converts a domain ScimConfig to a ScimConfigResponse.
+// The token hash is masked: token_issued is true when a hash exists, but the raw hash is never included.
+func NewScimConfigResponse(cfg *workspace.ScimConfig, scimBaseURL string) ScimConfigResponse {
+	resp := ScimConfigResponse{
+		GroupRoleMapping: map[string]string{},
+		ScimBaseURL:      scimBaseURL,
+	}
+	if cfg == nil {
+		return resp
+	}
+	resp.Enabled = cfg.Enabled()
+	resp.TokenIssued = cfg.TokenHash() != ""
+	for k, v := range cfg.GroupRoleMapping() {
+		resp.GroupRoleMapping[k] = string(v)
+	}
+	return resp
+}

--- a/server/internal/adapter/http/router.go
+++ b/server/internal/adapter/http/router.go
@@ -114,6 +114,13 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 	api.DELETE("/workspaces/:id/integrations", wh.RemoveIntegrations, required)
 	api.POST("/workspaces/:id/transfer-ownership", wh.TransferOwnership, required)
 
+	// --- Workspace SCIM admin ---
+	sh := handlers.NewWorkspaceScimHandler()
+	api.POST("/workspaces/:id/scim/token", sh.GenerateToken, required)
+	api.DELETE("/workspaces/:id/scim/token", sh.RevokeToken, required)
+	api.PUT("/workspaces/:id/scim/config", sh.UpdateConfig, required)
+	api.GET("/workspaces/:id/scim/config", sh.GetConfig, required)
+
 	// --- Permission ---
 	ph := handlers.NewPermissionHandler()
 	// OptionalAuth resolves a JWT/mock user (attaching it for APIKeyOrAuth and the

--- a/server/internal/adapter/scim/handler_groups.go
+++ b/server/internal/adapter/scim/handler_groups.go
@@ -1,0 +1,422 @@
+package scim
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearthx/rerror"
+)
+
+// GroupHandler handles SCIM 2.0 /scim/v2/Groups routes.
+type GroupHandler struct {
+	baseURL       string
+	scimUC        interfaces.Scim
+	workspaceRepo workspace.Repo
+}
+
+// NewGroupHandler constructs a GroupHandler.
+func NewGroupHandler(scimUC interfaces.Scim, workspaceRepo workspace.Repo, baseURL string) *GroupHandler {
+	return &GroupHandler{
+		baseURL:       baseURL,
+		scimUC:        scimUC,
+		workspaceRepo: workspaceRepo,
+	}
+}
+
+// Create handles POST /scim/v2/Groups — ensure group→role mapping exists, upsert members.
+func (h *GroupHandler) Create(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	var body ScimGroup
+	if err := c.Bind(&body); err != nil {
+		return scimErrorResponse(c, http.StatusBadRequest, "invalid request body", "invalidValue")
+	}
+
+	members := h.wireToInterfaceMembers(body.Members)
+	if err := h.scimUC.SyncScimGroup(ctx, wsID, "", body.DisplayName, members); err != nil {
+		return h.mapError(c, err)
+	}
+
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	group := h.buildGroup(ws, wsID, body.DisplayName)
+	c.Response().Header().Set("Location", group.Meta.Location)
+	return c.JSON(http.StatusCreated, group)
+}
+
+// Delete handles DELETE /scim/v2/Groups/:id — remove the group mapping (no deprovisioning).
+func (h *GroupHandler) Delete(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	groupID := c.Param("id")
+	_, groupName, err := parseGroupID(groupID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "group not found", "")
+	}
+
+	if err := h.scimUC.DeleteScimGroup(ctx, wsID, groupName); err != nil {
+		return h.mapError(c, err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// Get handles GET /scim/v2/Groups/:id.
+func (h *GroupHandler) Get(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	groupID := c.Param("id")
+	_, groupName, err := parseGroupID(groupID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "group not found", "")
+	}
+
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	return c.JSON(http.StatusOK, h.buildGroup(ws, wsID, groupName))
+}
+
+// List handles GET /scim/v2/Groups — returns one group per occupied role bucket.
+func (h *GroupHandler) List(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	groups := h.buildGroupList(ws)
+	return c.JSON(http.StatusOK, ScimListResponse{
+		ItemsPerPage: len(groups),
+		Resources:    groups,
+		Schemas:      []string{ScimSchemaListResponse},
+		StartIndex:   1,
+		TotalResults: len(groups),
+	})
+}
+
+// Patch handles PATCH /scim/v2/Groups/:id — add/remove members or rename group.
+// Okta format: {"op":"add","path":"members","value":[{...}]}
+// Both add and remove ops translate to SyncScimGroup calls.
+func (h *GroupHandler) Patch(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	groupID := c.Param("id")
+	_, groupName, err := parseGroupID(groupID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "group not found", "")
+	}
+
+	var patchOp ScimPatchOp
+	if err := c.Bind(&patchOp); err != nil {
+		return scimErrorResponse(c, http.StatusBadRequest, "invalid request body", "invalidValue")
+	}
+
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	// Build current member list for this group so we can apply deltas.
+	currentMembers := h.currentGroupMembers(ws, groupName)
+
+	for _, op := range patchOp.Operations {
+		opLower := strings.ToLower(op.Op)
+		pathLower := strings.ToLower(op.Path)
+
+		switch {
+		case opLower == "add" && pathLower == "members":
+			added := h.extractInterfaceMembers(op.Value)
+			currentMembers = h.mergeMembers(currentMembers, added)
+		case opLower == "remove" && pathLower == "members":
+			removed := h.extractInterfaceMembers(op.Value)
+			currentMembers = h.subtractMembers(currentMembers, removed)
+		case opLower == "replace" && pathLower == "displayname":
+			if name, ok := op.Value.(string); ok && name != "" {
+				groupName = name
+			}
+		}
+	}
+
+	if err := h.scimUC.SyncScimGroup(ctx, wsID, groupID, groupName, currentMembers); err != nil {
+		return h.mapError(c, err)
+	}
+
+	ws, err = h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	return c.JSON(http.StatusOK, h.buildGroup(ws, wsID, groupName))
+}
+
+// Replace handles PUT /scim/v2/Groups/:id — full replace of all group members.
+func (h *GroupHandler) Replace(c echo.Context) error {
+	ctx := c.Request().Context()
+	wsID, ok := WorkspaceIDFromContext(ctx)
+	if !ok {
+		return scimErrorResponse(c, http.StatusUnauthorized, "workspace not resolved", "")
+	}
+
+	groupID := c.Param("id")
+	_, groupName, err := parseGroupID(groupID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusNotFound, "group not found", "")
+	}
+
+	var body ScimGroup
+	if err := c.Bind(&body); err != nil {
+		return scimErrorResponse(c, http.StatusBadRequest, "invalid request body", "invalidValue")
+	}
+
+	members := h.wireToInterfaceMembers(body.Members)
+	if err := h.scimUC.SyncScimGroup(ctx, wsID, groupID, groupName, members); err != nil {
+		return h.mapError(c, err)
+	}
+
+	ws, err := h.workspaceRepo.FindByID(ctx, wsID)
+	if err != nil {
+		return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+	}
+
+	return c.JSON(http.StatusOK, h.buildGroup(ws, wsID, groupName))
+}
+
+// --- helpers ---
+
+// buildGroupList returns one ScimGroup per role bucket that has at least one active member.
+func (h *GroupHandler) buildGroupList(ws *workspace.Workspace) []ScimGroup {
+	members := ws.Members().Users()
+	if len(members) == 0 {
+		return []ScimGroup{}
+	}
+
+	// Reverse the groupRoleMapping: role → group name.
+	roleToGroup := make(map[role.RoleType]string)
+	if cfg := ws.ScimConfig(); cfg != nil {
+		for gName, r := range cfg.GroupRoleMapping() {
+			roleToGroup[r] = gName
+		}
+	}
+
+	type entry struct {
+		name    string
+		members []ScimGroupMember
+	}
+	buckets := make(map[role.RoleType]*entry)
+
+	wsID := ws.ID()
+	for uid, m := range members {
+		if m.Disabled {
+			continue
+		}
+		b, exists := buckets[m.Role]
+		if !exists {
+			gName, ok := roleToGroup[m.Role]
+			if !ok {
+				gName = string(m.Role)
+			}
+			b = &entry{name: gName}
+			buckets[m.Role] = b
+		}
+		b.members = append(b.members, ScimGroupMember{Value: uid.String()})
+	}
+
+	groups := make([]ScimGroup, 0, len(buckets))
+	for _, b := range buckets {
+		gid := makeGroupID(wsID, b.name)
+		groups = append(groups, ScimGroup{
+			DisplayName: b.name,
+			ID:          gid,
+			Members:     b.members,
+			Meta: ScimMeta{
+				Location:     h.baseURL + "/scim/v2/Groups/" + gid,
+				ResourceType: "Group",
+			},
+			Schemas: []string{ScimSchemaGroup},
+		})
+	}
+	return groups
+}
+
+// buildGroup constructs a ScimGroup for the given group name within a workspace.
+// The group's role is resolved via GroupRoleMapping; unmapped names default to RoleReader.
+func (h *GroupHandler) buildGroup(ws *workspace.Workspace, wsID workspace.ID, groupName string) ScimGroup {
+	groupRole := role.RoleReader
+	if cfg := ws.ScimConfig(); cfg != nil {
+		if mapping := cfg.GroupRoleMapping(); mapping != nil {
+			if r, ok := mapping[groupName]; ok {
+				groupRole = r
+			}
+		}
+	}
+
+	var scimMembers []ScimGroupMember
+	for uid, m := range ws.Members().Users() {
+		if !m.Disabled && m.Role == groupRole {
+			scimMembers = append(scimMembers, ScimGroupMember{Value: uid.String()})
+		}
+	}
+
+	gid := makeGroupID(wsID, groupName)
+	return ScimGroup{
+		DisplayName: groupName,
+		ID:          gid,
+		Members:     scimMembers,
+		Meta: ScimMeta{
+			Location:     h.baseURL + "/scim/v2/Groups/" + gid,
+			ResourceType: "Group",
+		},
+		Schemas: []string{ScimSchemaGroup},
+	}
+}
+
+// currentGroupMembers returns all workspace members belonging to the given group's role bucket.
+func (h *GroupHandler) currentGroupMembers(ws *workspace.Workspace, groupName string) []interfaces.ScimGroupMember {
+	groupRole := role.RoleReader
+	if cfg := ws.ScimConfig(); cfg != nil {
+		if mapping := cfg.GroupRoleMapping(); mapping != nil {
+			if r, ok := mapping[groupName]; ok {
+				groupRole = r
+			}
+		}
+	}
+
+	var out []interfaces.ScimGroupMember
+	for uid, m := range ws.Members().Users() {
+		if m.Role == groupRole {
+			uid := uid
+			out = append(out, interfaces.ScimGroupMember{
+				ExternalID: m.ExternalID,
+				UserID:     &uid,
+			})
+		}
+	}
+	return out
+}
+
+// wireToInterfaceMembers converts SCIM wire members (Value = user ID string) to usecase members.
+func (h *GroupHandler) wireToInterfaceMembers(wire []ScimGroupMember) []interfaces.ScimGroupMember {
+	out := make([]interfaces.ScimGroupMember, 0, len(wire))
+	for _, m := range wire {
+		uid, err := user.IDFrom(m.Value)
+		if err != nil {
+			continue
+		}
+		out = append(out, interfaces.ScimGroupMember{UserID: &uid})
+	}
+	return out
+}
+
+// extractInterfaceMembers parses a PATCH op value into usecase members.
+// Supports []interface{} where each item is map[string]interface{} with a "value" key.
+func (h *GroupHandler) extractInterfaceMembers(v interface{}) []interfaces.ScimGroupMember {
+	list, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []interfaces.ScimGroupMember
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		val, _ := m["value"].(string)
+		if val == "" {
+			continue
+		}
+		uid, err := user.IDFrom(val)
+		if err != nil {
+			continue
+		}
+		out = append(out, interfaces.ScimGroupMember{UserID: &uid})
+	}
+	return out
+}
+
+// mergeMembers appends newMembers to existing without duplicates (by UserID).
+func (h *GroupHandler) mergeMembers(existing, newMembers []interfaces.ScimGroupMember) []interfaces.ScimGroupMember {
+	seen := make(map[user.ID]struct{}, len(existing))
+	for _, m := range existing {
+		if m.UserID != nil {
+			seen[*m.UserID] = struct{}{}
+		}
+	}
+	result := append([]interfaces.ScimGroupMember(nil), existing...)
+	for _, m := range newMembers {
+		if m.UserID == nil {
+			continue
+		}
+		if _, ok := seen[*m.UserID]; !ok {
+			seen[*m.UserID] = struct{}{}
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// subtractMembers removes toRemove entries from existing (matched by UserID).
+func (h *GroupHandler) subtractMembers(existing, toRemove []interfaces.ScimGroupMember) []interfaces.ScimGroupMember {
+	removeSet := make(map[user.ID]struct{}, len(toRemove))
+	for _, m := range toRemove {
+		if m.UserID != nil {
+			removeSet[*m.UserID] = struct{}{}
+		}
+	}
+	var result []interfaces.ScimGroupMember
+	for _, m := range existing {
+		if m.UserID != nil {
+			if _, skip := removeSet[*m.UserID]; skip {
+				continue
+			}
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+// mapError converts domain errors to SCIM HTTP error responses.
+func (h *GroupHandler) mapError(c echo.Context, err error) error {
+	if errors.Is(err, rerror.ErrNotFound) {
+		return scimErrorResponse(c, http.StatusNotFound, "group not found", "")
+	}
+	if errors.Is(err, interfaces.ErrOwnerCannotLeaveTheWorkspace) {
+		return scimErrorResponse(c, http.StatusConflict, "cannot remove the last owner", "")
+	}
+	if errors.Is(err, interfaces.ErrSCIMNotEnabled) {
+		return scimErrorResponse(c, http.StatusForbidden, "SCIM is not enabled for this workspace", "")
+	}
+	return scimErrorResponse(c, http.StatusInternalServerError, "internal server error", "")
+}

--- a/server/internal/adapter/scim/handler_groups_test.go
+++ b/server/internal/adapter/scim/handler_groups_test.go
@@ -1,0 +1,352 @@
+package scim
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	accountmemory "github.com/reearth/reearth-accounts/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/interactor"
+	"github.com/reearth/reearth-accounts/server/internal/usecase/repo"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupGroupHandlerTest creates a fresh in-memory DB, a SCIM-enabled workspace with a group→role mapping,
+// and a GroupHandler ready to use.
+func setupGroupHandlerTest(t *testing.T) (
+	db *repo.Container,
+	ws *workspace.Workspace,
+	ownerID user.ID,
+	handler *GroupHandler,
+) {
+	t.Helper()
+	db = accountmemory.New()
+
+	ownerID = user.NewID()
+	owner := user.New().ID(ownerID).Name("Owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	cfg.SetGroupRoleMapping(map[string]role.RoleType{
+		"Engineering": role.RoleMaintainer,
+		"Readers":     role.RoleReader,
+	})
+
+	ws = workspace.New().
+		NewID().
+		Name("enterprise").
+		Alias("enterprise").
+		Members(map[user.ID]workspace.Member{
+			ownerID: {Role: role.RoleOwner, InvitedBy: ownerID},
+		}).
+		ScimConfig(cfg).
+		MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	scimUC := interactor.NewScim(db)
+	handler = NewGroupHandler(scimUC, db.Workspace, testBaseURL)
+	return
+}
+
+// TestListGroups verifies that List returns one group per occupied role bucket.
+func TestListGroups(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Add a maintainer so the "Engineering" bucket is occupied.
+	maintainerID := user.NewID()
+	maintainer := user.New().ID(maintainerID).Name("Bob").Email("bob@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), maintainer))
+
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().Join(maintainer, role.RoleMaintainer, ownerID))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, handler.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// Owner (role.RoleOwner) has 1 bucket; maintainer (Engineering) has 1 bucket → 2 total.
+	assert.Equal(t, 2, resp.TotalResults)
+}
+
+// TestListGroups_Empty verifies that an empty workspace returns an empty group list.
+func TestListGroups_Empty(t *testing.T) {
+	// Create workspace with no non-disabled members aside from the owner.
+	db := accountmemory.New()
+	ownerID := user.NewID()
+	owner := user.New().ID(ownerID).Name("Owner").Email("owner@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), owner))
+
+	cfg := workspace.NewScimConfig()
+	cfg.SetEnabled(true)
+	ws := workspace.New().NewID().Name("e").Alias("e").
+		Members(map[user.ID]workspace.Member{}).
+		ScimConfig(cfg).MustBuild()
+	require.NoError(t, db.Workspace.Save(t.Context(), ws))
+
+	handler := NewGroupHandler(interactor.NewScim(db), db.Workspace, testBaseURL)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, handler.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ScimListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.TotalResults)
+}
+
+// TestGetGroup verifies that Get returns the correct group by decoded ID.
+func TestGetGroup(t *testing.T) {
+	_, ws, _, handler := setupGroupHandlerTest(t)
+
+	gid := makeGroupID(ws.ID(), "Engineering")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups/"+gid, nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Get(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var group ScimGroup
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &group))
+	assert.Equal(t, "Engineering", group.DisplayName)
+	assert.Equal(t, gid, group.ID)
+}
+
+// TestGetGroup_InvalidID verifies that an unparseable group ID returns 404.
+func TestGetGroup_InvalidID(t *testing.T) {
+	_, ws, _, handler := setupGroupHandlerTest(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups/not-base64!!!", nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("not-base64!!!")
+
+	require.NoError(t, handler.Get(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestPatchGroup_AddMembers verifies that op:add path:members adds the member and calls SyncScimGroup.
+func TestPatchGroup_AddMembers(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Create a new user to add to the Engineering group.
+	newUserID := user.NewID()
+	newUser := user.New().ID(newUserID).Name("Alice").Email("alice@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), newUser))
+
+	// Add them to the workspace as a reader first so they're members.
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().Join(newUser, role.RoleReader, ownerID))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	gid := makeGroupID(ws.ID(), "Engineering")
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"add","path":"members","value":[{"value":"` + newUserID.String() + `"}]}]}`
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Patch(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the user is now in the Engineering group (RoleMaintainer).
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	assert.Equal(t, role.RoleMaintainer, finalWS.Members().UserRole(newUserID))
+}
+
+// TestPatchGroup_RemoveMembers verifies that op:remove path:members soft-disables the member.
+func TestPatchGroup_RemoveMembers(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Provision a reader-role member.
+	readerID := user.NewID()
+	reader := user.New().ID(readerID).Name("Reader").Email("reader@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), reader))
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().Join(reader, role.RoleReader, ownerID))
+	require.NoError(t, updatedWS.Members().SetUserExternalID(readerID, "ext-reader"))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	gid := makeGroupID(ws.ID(), "Readers")
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"remove","path":"members","value":[{"value":"` + readerID.String() + `"}]}]}`
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Patch(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// The member should now be disabled.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := finalWS.Members().User(readerID)
+	require.NotNil(t, m)
+	assert.True(t, m.Disabled)
+}
+
+// TestPatchGroup_RemoveLastOwner verifies that the last-owner guard prevents the last owner
+// from being disabled even when they are excluded from the incoming member list.
+// SyncScimGroup silently preserves the owner (returns 200) rather than rejecting with 409.
+func TestPatchGroup_RemoveLastOwner(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Give the owner an ExternalID so the soft-disable path runs.
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().SetUserExternalID(ownerID, "ext-owner"))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	// The owner is in the "owner" role bucket (no mapping — falls back to role name).
+	ownerGroupName := string(role.RoleOwner)
+	gid := makeGroupID(ws.ID(), ownerGroupName)
+	// Send an empty member list to try to remove all members.
+	body := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"remove","path":"members","value":[{"value":"` + ownerID.String() + `"}]}]}`
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Patch(c))
+	// SyncScimGroup silently preserves the last owner (does not return 409).
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the owner is still active.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	m := finalWS.Members().User(ownerID)
+	require.NotNil(t, m)
+	assert.False(t, m.Disabled, "last owner must NOT be disabled by SyncScimGroup")
+}
+
+// TestDeleteGroup verifies that Delete removes the group mapping without deprovisioning members.
+func TestDeleteGroup(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Add a maintainer member that should NOT be deprovisioned after delete.
+	maintainerID := user.NewID()
+	maintainer := user.New().ID(maintainerID).Name("Maintainer").Email("maintainer@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), maintainer))
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().Join(maintainer, role.RoleMaintainer, ownerID))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	gid := makeGroupID(ws.ID(), "Engineering")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/scim/v2/Groups/"+gid, nil)
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Delete(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Mapping should be removed.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	mapping := finalWS.ScimConfig().GroupRoleMapping()
+	_, stillInMapping := mapping["Engineering"]
+	assert.False(t, stillInMapping, "Engineering group should have been removed from mapping")
+
+	// Members should NOT have been deprovisioned.
+	m := finalWS.Members().User(maintainerID)
+	require.NotNil(t, m)
+	assert.False(t, m.Disabled, "member should NOT be deprovisioned after group delete")
+}
+
+// TestReplaceGroup verifies that Replace does a full member sync.
+func TestReplaceGroup(t *testing.T) {
+	db, ws, ownerID, handler := setupGroupHandlerTest(t)
+
+	// Provision one existing maintainer and one new user to replace with.
+	existingID := user.NewID()
+	existing := user.New().ID(existingID).Name("Existing").Email("existing@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), existing))
+
+	newUserID := user.NewID()
+	newUser := user.New().ID(newUserID).Name("NewUser").Email("newuser@example.com").Workspace(user.NewWorkspaceID()).MustBuild()
+	require.NoError(t, db.User.Save(t.Context(), newUser))
+
+	updatedWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	require.NoError(t, updatedWS.Members().Join(existing, role.RoleMaintainer, ownerID))
+	require.NoError(t, updatedWS.Members().SetUserExternalID(existingID, "ext-existing"))
+	require.NoError(t, updatedWS.Members().Join(newUser, role.RoleReader, ownerID))
+	require.NoError(t, db.Workspace.Save(t.Context(), updatedWS))
+
+	gid := makeGroupID(ws.ID(), "Engineering")
+	// Replace Engineering group with only newUser.
+	body := `{"displayName":"Engineering","schemas":["` + ScimSchemaGroup + `"],"members":[{"value":"` + newUserID.String() + `"}]}`
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/"+gid, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = contextWithWorkspace(req, ws.ID())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(gid)
+
+	require.NoError(t, handler.Replace(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// existingID (had ExternalID) should now be disabled; newUserID should be maintainer.
+	finalWS, err := db.Workspace.FindByID(t.Context(), ws.ID())
+	require.NoError(t, err)
+	existingMember := finalWS.Members().User(existingID)
+	require.NotNil(t, existingMember)
+	assert.True(t, existingMember.Disabled, "old member should be disabled after full replace")
+	assert.Equal(t, role.RoleMaintainer, finalWS.Members().UserRole(newUserID))
+}

--- a/server/internal/adapter/scim/model.go
+++ b/server/internal/adapter/scim/model.go
@@ -1,6 +1,10 @@
 package scim
 
 import (
+	"encoding/base64"
+	"errors"
+	"strings"
+
 	"github.com/reearth/reearth-accounts/server/pkg/user"
 	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 )
@@ -24,6 +28,20 @@ type ScimError struct {
 	Schemas  []string `json:"schemas"`
 	ScimType string   `json:"scimType,omitempty"`
 	Status   string   `json:"status"`
+}
+
+type ScimGroup struct {
+	DisplayName string            `json:"displayName"`
+	ExternalID  string            `json:"externalId,omitempty"`
+	ID          string            `json:"id"`
+	Members     []ScimGroupMember `json:"members,omitempty"`
+	Meta        ScimMeta          `json:"meta"`
+	Schemas     []string          `json:"schemas"`
+}
+
+type ScimGroupMember struct {
+	Display string `json:"display,omitempty"`
+	Value   string `json:"value"` // reearth-accounts user ID
 }
 
 type ScimListResponse struct {
@@ -82,4 +100,23 @@ func DomainUserToScimUser(u *user.User, member workspace.Member, baseURL string)
 		Schemas:  []string{ScimSchemaUser},
 		UserName: u.Email(),
 	}
+}
+
+// makeGroupID encodes a workspaceID+groupName pair as a URL-safe base64 string.
+func makeGroupID(workspaceID workspace.ID, groupName string) string {
+	raw := workspaceID.String() + ":" + groupName
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+// parseGroupID decodes a group ID produced by makeGroupID into its components.
+func parseGroupID(groupID string) (workspaceIDStr, groupName string, err error) {
+	raw, err := base64.RawURLEncoding.DecodeString(groupID)
+	if err != nil {
+		return "", "", errors.New("invalid group ID")
+	}
+	parts := strings.SplitN(string(raw), ":", 2)
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid group ID format")
+	}
+	return parts[0], parts[1], nil
 }

--- a/server/internal/adapter/scim/router.go
+++ b/server/internal/adapter/scim/router.go
@@ -7,17 +7,18 @@ import (
 )
 
 // RegisterSCIMRouter mounts all SCIM 2.0 routes on the given Echo instance.
-// Discovery endpoints are public; user-management routes require a valid SCIM Bearer token.
+// Discovery endpoints are public; user-management and group routes require a valid SCIM Bearer token.
 func RegisterSCIMRouter(e *echo.Echo, workspaceRepo workspace.Repo, scimUC interfaces.Scim, baseURL string) {
 	discovery := NewDiscoveryHandler()
 	users := NewUserHandler(scimUC, workspaceRepo, baseURL)
+	groups := NewGroupHandler(scimUC, workspaceRepo, baseURL)
 
 	// Public discovery endpoints (no auth).
 	e.GET("/scim/v2/ServiceProviderConfig", discovery.ServiceProviderConfig)
 	e.GET("/scim/v2/ResourceTypes", discovery.ResourceTypes)
 	e.GET("/scim/v2/Schemas", discovery.Schemas)
 
-	// Authenticated user-management endpoints.
+	// Authenticated user-management and group endpoints.
 	scim := e.Group("/scim/v2", ScimBearerAuth(workspaceRepo))
 	scim.GET("/Users", users.List)
 	scim.POST("/Users", users.Create)
@@ -25,4 +26,11 @@ func RegisterSCIMRouter(e *echo.Echo, workspaceRepo workspace.Repo, scimUC inter
 	scim.PUT("/Users/:id", users.Replace)
 	scim.PATCH("/Users/:id", users.Patch)
 	scim.DELETE("/Users/:id", users.Delete)
+
+	scim.GET("/Groups", groups.List)
+	scim.POST("/Groups", groups.Create)
+	scim.GET("/Groups/:id", groups.Get)
+	scim.PUT("/Groups/:id", groups.Replace)
+	scim.PATCH("/Groups/:id", groups.Patch)
+	scim.DELETE("/Groups/:id", groups.Delete)
 }

--- a/server/internal/usecase/interactor/scim.go
+++ b/server/internal/usecase/interactor/scim.go
@@ -103,22 +103,64 @@ func (i *Scim) GenerateScimToken(ctx context.Context, workspaceID workspace.ID, 
 	})
 }
 
+func (i *Scim) DeleteScimGroup(ctx context.Context, workspaceID workspace.ID, groupName string) error {
+	return Run0(ctx, nil, i.repos, Usecase().Transaction(), func(ctx context.Context) error {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return err
+		}
+
+		cfg := ws.ScimConfig()
+		if cfg == nil {
+			return nil
+		}
+
+		mapping := cfg.GroupRoleMapping()
+		delete(mapping, groupName)
+		cfg.SetGroupRoleMapping(mapping)
+		ws.SetScimConfig(cfg)
+
+		return i.repos.Workspace.Save(ctx, ws)
+	})
+}
+
 func (i *Scim) GetScimConfig(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (*workspace.ScimConfig, error) {
-	ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
-	if err != nil {
-		return nil, err
-	}
+	return Run1(ctx, operator, i.repos, Usecase().WithMaintainableWorkspaces(workspaceID), func(ctx context.Context) (*workspace.ScimConfig, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return nil, err
+		}
 
-	cfg := ws.ScimConfig()
-	if cfg == nil {
-		return nil, nil
-	}
+		cfg := ws.ScimConfig()
+		if cfg == nil {
+			return nil, nil
+		}
 
-	if cfg.TokenHash() != "" {
-		cfg.SetTokenHash("***")
-	}
+		if cfg.TokenHash() != "" {
+			cfg.SetTokenHash("***")
+		}
 
-	return cfg, nil
+		return cfg, nil
+	})
+}
+
+func (i *Scim) RevokeScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error {
+	return Run0(ctx, operator, i.repos, Usecase().Transaction().WithMaintainableWorkspaces(workspaceID), func(ctx context.Context) error {
+		ws, err := i.repos.Workspace.FindByID(ctx, workspaceID)
+		if err != nil {
+			return err
+		}
+
+		cfg := ws.ScimConfig()
+		if cfg == nil {
+			return nil
+		}
+		cfg.SetEnabled(false)
+		cfg.SetTokenHash("")
+		ws.SetScimConfig(cfg)
+
+		return i.repos.Workspace.Save(ctx, ws)
+	})
 }
 
 func (i *Scim) GetScimUser(ctx context.Context, workspaceID workspace.ID, userID user.ID) (*user.User, error) {

--- a/server/internal/usecase/interfaces/scim.go
+++ b/server/internal/usecase/interfaces/scim.go
@@ -30,6 +30,7 @@ type ScimGroupMember struct {
 }
 
 type Scim interface {
+	DeleteScimGroup(ctx context.Context, workspaceID workspace.ID, groupName string) error
 	DeprovisionScimUser(ctx context.Context, workspaceID workspace.ID, externalID string) error
 	DeprovisionScimUserByUserID(ctx context.Context, workspaceID workspace.ID, userID user.ID) error
 	GenerateScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) (string, error)
@@ -37,6 +38,7 @@ type Scim interface {
 	GetScimUser(ctx context.Context, workspaceID workspace.ID, userID user.ID) (*user.User, error)
 	ListScimUsers(ctx context.Context, workspaceID workspace.ID, filter string) ([]*user.User, error)
 	ProvisionScimUser(ctx context.Context, param ProvisionScimUserParam) (*user.User, error)
+	RevokeScimToken(ctx context.Context, workspaceID workspace.ID, operator *workspace.Operator) error
 	SyncScimGroup(ctx context.Context, workspaceID workspace.ID, groupID, groupName string, members []ScimGroupMember) error
 	UpdateScimConfig(ctx context.Context, workspaceID workspace.ID, enabled bool, groupRoleMapping map[string]role.RoleType, operator *workspace.Operator) (*workspace.ScimConfig, error)
 }

--- a/server/pkg/workspace/member.go
+++ b/server/pkg/workspace/member.go
@@ -358,6 +358,9 @@ func (m *Members) SetUserExternalID(u UserID, externalID string) error {
 }
 
 func (m *Members) UserByExternalID(externalID string) (UserID, bool) {
+	if externalID == "" {
+		return UserID{}, false
+	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 


### PR DESCRIPTION
## Why

Part of [D-20] U-D20-05 SCIM Provisioning via Auth0 (eukarya-inc/reearth-dashboard#1373).

This is the fourth (final) PR for SCIM support. It completes the SCIM surface with the Groups resource and the admin REST endpoints that let workspace owners enable SCIM, generate a bearer token, and configure the group→role mapping.

**SCIM Groups adapter (`server/internal/adapter/scim/handler_groups.go`)**

- Full CRUD for `/scim/v2/Groups`: List, Create, Get, Replace, Patch, Delete
- `List` returns one group per occupied role bucket (roles with at least one active member)
- `ScimGroup.ID` is derived from `workspaceID + ":" + groupName` encoded as URL-safe base64 (`makeGroupID` / `parseGroupID`)
- `PATCH` (`op:add` and `op:remove` on `members`) translates to `SyncScimGroup` calls by merging/subtracting deltas from the current group member list — enforces the last-owner guard
- `DELETE` removes the group from `GroupRoleMapping` without deprovisioning members
- `Create` / `Replace` do a full sync via `SyncScimGroup`
- Routes registered in `RegisterSCIMRouter` under the existing SCIM bearer-auth group

**Admin REST endpoints (`server/internal/adapter/http/handlers/workspace_scim_handler.go`)**

| Method | Path | Action |
|---|---|---|
| `POST` | `/api/workspaces/:id/scim/token` | Generate or rotate bearer token (plaintext returned once) |
| `DELETE` | `/api/workspaces/:id/scim/token` | Revoke token, disable SCIM |
| `PUT` | `/api/workspaces/:id/scim/config` | Enable/disable SCIM + group→role mapping (400 on unknown role) |
| `GET` | `/api/workspaces/:id/scim/config` | Read config (`token_issued` bool, raw hash never returned) |

All endpoints require `required` (JWT) middleware; owner/maintainer enforced via `WithMaintainableWorkspaces` in the interactor.

**Bug fix: `workspace.Members.UserByExternalID`**

`UserByExternalID("")` previously matched any member with an empty `ExternalID`, causing spurious role updates in `SyncScimGroup` when handling members without an assigned ExternalID. Fixed by returning `(_, false)` for empty inputs, consistent with the "not assigned" semantic.

**New usecase methods**
- `interfaces.Scim.DeleteScimGroup` — removes group mapping without deprovisioning
- `interfaces.Scim.RevokeScimToken` — clears token hash + disables SCIM
- `GetScimConfig` now enforces `WithMaintainableWorkspaces` via `Run1`

## Checklist

- [x] Verified backward compatibility related to feature modifications (new SCIM group routes and admin endpoints are additive; existing routes unchanged; `UserByExternalID` fix only affects members with non-empty ExternalIDs in practice)
- [x] Confirmed backward compatibility for migrations (no schema changes in this PR)
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed