### PR TITLE
fix(server): cache Auth0 MFA status to bound Management API calls

### DIFF
--- a/server/internal/infrastructure/auth0/authenticator.go
+++ b/server/internal/infrastructure/auth0/authenticator.go
@@ -27,6 +27,19 @@ type Auth0 struct {
 	lock           sync.Mutex
 	current        func() time.Time
 	disableLogging bool
+
+	mfaStatusLock  sync.Mutex
+	mfaStatusCache map[string]mfaStatusCacheEntry
+}
+
+// mfaStatusCacheTTL bounds how often GetMFAStatus hits the Auth0 Management
+// API per user, since that quota is shared with UpdateUser and
+// ResendVerificationEmail across the whole tenant.
+const mfaStatusCacheTTL = 30 * time.Second
+
+type mfaStatusCacheEntry struct {
+	status    gateway.MFAStatus
+	expiresAt time.Time
 }
 
 func currentTime() time.Time {
@@ -198,6 +211,7 @@ func (a *Auth0) DisableMFA(ctx context.Context, sub string) error {
 		return rerror.NewE(i18n.T("failed to update mfa status"))
 	}
 
+	a.setCachedMFAStatus(sub, gateway.MFAStatus{Enrolled: false})
 	return nil
 }
 
@@ -226,10 +240,17 @@ func (a *Auth0) EnableMFA(ctx context.Context, sub string) (string, error) {
 		return "", rerror.NewE(i18n.T("failed to create mfa enrollment ticket"))
 	}
 
+	// Enrollment stays "pending" until the user completes the ticket flow, so
+	// the cached status (if any) is now stale rather than known-true.
+	a.invalidateMFAStatusCache(sub)
 	return r.TicketURL, nil
 }
 
 func (a *Auth0) GetMFAStatus(ctx context.Context, sub string) (gateway.MFAStatus, error) {
+	if status, ok := a.cachedMFAStatus(sub); ok {
+		return status, nil
+	}
+
 	if err := a.updateToken(ctx); err != nil {
 		return gateway.MFAStatus{}, err
 	}
@@ -242,13 +263,51 @@ func (a *Auth0) GetMFAStatus(ctx context.Context, sub string) (gateway.MFAStatus
 		return gateway.MFAStatus{}, rerror.NewE(i18n.T("failed to get mfa status"))
 	}
 
+	status := gateway.MFAStatus{}
 	for _, e := range enrollments {
 		if e.Status == "confirmed" {
-			return gateway.MFAStatus{Enrolled: true}, nil
+			status.Enrolled = true
+			break
 		}
 	}
 
-	return gateway.MFAStatus{Enrolled: false}, nil
+	a.setCachedMFAStatus(sub, status)
+	return status, nil
+}
+
+func (a *Auth0) now() time.Time {
+	if a.current == nil {
+		a.current = currentTime
+	}
+	return a.current()
+}
+
+func (a *Auth0) cachedMFAStatus(sub string) (gateway.MFAStatus, bool) {
+	a.mfaStatusLock.Lock()
+	defer a.mfaStatusLock.Unlock()
+
+	entry, ok := a.mfaStatusCache[sub]
+	if !ok || !a.now().Before(entry.expiresAt) {
+		return gateway.MFAStatus{}, false
+	}
+	return entry.status, true
+}
+
+func (a *Auth0) setCachedMFAStatus(sub string, status gateway.MFAStatus) {
+	a.mfaStatusLock.Lock()
+	defer a.mfaStatusLock.Unlock()
+
+	if a.mfaStatusCache == nil {
+		a.mfaStatusCache = map[string]mfaStatusCacheEntry{}
+	}
+	a.mfaStatusCache[sub] = mfaStatusCacheEntry{status: status, expiresAt: a.now().Add(mfaStatusCacheTTL)}
+}
+
+func (a *Auth0) invalidateMFAStatusCache(sub string) {
+	a.mfaStatusLock.Lock()
+	defer a.mfaStatusLock.Unlock()
+
+	delete(a.mfaStatusCache, sub)
 }
 
 func (a *Auth0) RegenerateMFARecoveryCode(ctx context.Context, sub string) (string, error) {

--- a/server/internal/infrastructure/auth0/mfa_status_cache_test.go
+++ b/server/internal/infrastructure/auth0/mfa_status_cache_test.go
@@ -1,0 +1,146 @@
+package auth0
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mfaClient mocks the Auth0 endpoints touched by GetMFAStatus/EnableMFA/DisableMFA
+// and counts how many times the enrollments list endpoint is hit, so tests can
+// assert that the per-sub cache actually bounds Management API traffic.
+func mfaClient(enrolledSub string, enrollmentCalls *int32) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+			p := req.URL.Path
+
+			if req.Method == http.MethodPost && p == "/oauth/token" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: res(map[string]interface{}{
+						"access_token": token,
+						"expires_in":   expiresIn,
+					}),
+					Header: make(http.Header),
+				}
+			}
+
+			if req.Method == http.MethodGet && strings.HasSuffix(p, "/enrollments") {
+				atomic.AddInt32(enrollmentCalls, 1)
+				sub := strings.TrimSuffix(strings.TrimPrefix(p, "/api/v2/users/"), "/enrollments")
+				var enrollments []map[string]string
+				if sub == enrolledSub {
+					enrollments = []map[string]string{{"id": "enr-1", "status": "confirmed"}}
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: res(enrollments), Header: make(http.Header)}
+			}
+
+			if req.Method == http.MethodDelete && strings.HasPrefix(p, "/api/v2/guardian/enrollments/") {
+				return &http.Response{StatusCode: http.StatusOK, Body: res(map[string]interface{}{}), Header: make(http.Header)}
+			}
+
+			if req.Method == http.MethodPatch && strings.HasPrefix(p, "/api/v2/users/") {
+				return &http.Response{StatusCode: http.StatusOK, Body: res(map[string]interface{}{}), Header: make(http.Header)}
+			}
+
+			if req.Method == http.MethodPost && p == "/api/v2/guardian/enrollments/ticket" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       res(map[string]interface{}{"ticket_url": "https://example.com/ticket"}),
+					Header:     make(http.Header),
+				}
+			}
+
+			return &http.Response{StatusCode: http.StatusNotFound, Body: res(map[string]interface{}{"message": "not found"}), Header: make(http.Header)}
+		}),
+	}
+}
+
+func TestAuth0_GetMFAStatus_CachesWithinTTL(t *testing.T) {
+	var calls int32
+	sub := "mfa-enrolled-sub"
+
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = mfaClient(sub, &calls)
+	a.current = func() time.Time { return current }
+	a.disableLogging = true
+
+	status, err := a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.True(t, status.Enrolled)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+	status, err = a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.True(t, status.Enrolled)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "second call within TTL should be served from cache")
+}
+
+func TestAuth0_GetMFAStatus_RefetchesAfterTTLExpires(t *testing.T) {
+	var calls int32
+	sub := "mfa-not-enrolled-sub"
+
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = mfaClient(sub, &calls)
+	now := current
+	a.current = func() time.Time { return now }
+	a.disableLogging = true
+
+	_, err := a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+	now = now.Add(mfaStatusCacheTTL + time.Second)
+	_, err = a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "cache entry should have expired")
+}
+
+func TestAuth0_DisableMFA_UpdatesCacheWithoutRefetch(t *testing.T) {
+	var calls int32
+	sub := "mfa-enrolled-sub"
+
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = mfaClient(sub, &calls)
+	a.current = func() time.Time { return current }
+	a.disableLogging = true
+
+	status, err := a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.True(t, status.Enrolled)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+	assert.NoError(t, a.DisableMFA(context.Background(), sub))
+
+	status, err = a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.False(t, status.Enrolled, "disabling mfa should update the cached status")
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "status after disable should come from cache, not another enrollments call")
+}
+
+func TestAuth0_EnableMFA_InvalidatesCache(t *testing.T) {
+	var calls int32
+	sub := "mfa-not-enrolled-sub"
+
+	a := New(domain, clientID, clientSecret, 0)
+	a.client = mfaClient("some-other-enrolled-sub", &calls)
+	a.current = func() time.Time { return current }
+	a.disableLogging = true
+
+	status, err := a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.False(t, status.Enrolled)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+	_, err = a.EnableMFA(context.Background(), sub)
+	assert.NoError(t, err)
+
+	_, err = a.GetMFAStatus(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "enabling mfa should invalidate the cache and force a refetch")
+}


### PR DESCRIPTION
## Why

Fixes eukarya-inc/reearth-dashboard#1384 (SCA-04).

`mfaStatus` issued an uncached `GET /api/v2/users/{sub}/enrollments` call
to the Auth0 Management API on every query. That quota is shared
tenant-wide with `UpdateUser` and `ResendVerificationEmail`, so sustained
`mfaStatus` traffic could exhaust the bucket and return 429s for
unrelated account operations across the whole platform.

This adds a per-`sub`, 30s TTL in-memory cache in front of
`GetMFAStatus`:
- `DisableMFA` writes the known post-disable state (`Enrolled: false`)
  directly into the cache instead of leaving it stale.
- `EnableMFA` invalidates the cache entry, since issuing an enrollment
  ticket doesn't mean the enrollment is confirmed yet — the next status
  check should hit Auth0 for the real state.

Chosen over mirroring `mfa_enabled` into the local user record because
that would require a schema/migration change across both the Mongo and
Postgres backends for a MEDIUM-severity scalability fix; the cache
bounds Management API traffic without touching persistence.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in any values that may be displayed