### PR TITLE
fix(server): add workspace self-role update endpoint and fix GET /api/users/{id}

### DIFF
--- a/server/e2e/rest_workspace_test.go
+++ b/server/e2e/rest_workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/reearth/reearth-accounts/server/internal/app"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestREST_WorkspaceCRUD(t *testing.T) {
@@ -20,7 +21,7 @@ func TestREST_WorkspaceCRUD(t *testing.T) {
 	wid := wsObj.Value("id").String().Raw()
 
 	// Get
-	exp.GET("/api/workspaces/" + wid).
+	exp.GET("/api/workspaces/"+wid).
 		Expect().Status(http.StatusOK).JSON().Object().HasValue("id", wid)
 
 	// Add a second seeded user as writer.
@@ -81,7 +82,7 @@ func TestREST_RealJWT_WorkspaceCRUD(t *testing.T) {
 	wid := wsObj.Value("id").String().Raw()
 
 	// Get
-	exp.GET("/api/workspaces/" + wid).
+	exp.GET("/api/workspaces/"+wid).
 		WithHeader("Authorization", bearer).
 		Expect().Status(http.StatusOK).JSON().Object().HasValue("id", wid)
 
@@ -95,12 +96,12 @@ func TestREST_RealJWT_WorkspaceCRUD(t *testing.T) {
 		Value("members").Array().Length().IsEqual(2)
 
 	// Delete
-	exp.DELETE("/api/workspaces/" + wid).
+	exp.DELETE("/api/workspaces/"+wid).
 		WithHeader("Authorization", bearer).
 		Expect().Status(http.StatusNoContent)
 
 	// Confirm gone
-	exp.GET("/api/workspaces/" + wid).
+	exp.GET("/api/workspaces/"+wid).
 		WithHeader("Authorization", bearer).
 		Expect().Status(http.StatusNotFound)
 }
@@ -115,4 +116,54 @@ func TestREST_RealJWT_WorkspaceListByUser(t *testing.T) {
 	exp.GET("/api/workspaces").WithQuery("user_id", jwtPrimaryUID.String()).
 		WithHeader("Authorization", "Bearer "+token).
 		Expect().Status(http.StatusOK).JSON().Array().NotEmpty()
+}
+
+// TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard covers PATCH
+// /api/service/workspaces/:id/members/:user_id: JWT-authenticated like the
+// regular member route, but a Maintainer/Owner may use it to change their own
+// role (including to Owner), unlike the self-demote guard on
+// PATCH /api/workspaces/:id/members/:user_id.
+func TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard(t *testing.T) {
+	key, cleanup := installRealJWT(t)
+	defer cleanup()
+
+	exp, _ := StartServer(t, realAuthConfig(), false, seedJWTUsers(realJWTWorkspaceSub))
+	token := signTestToken(t, key, realJWTWorkspaceSub)
+	bearer := "Bearer " + token
+
+	wsObj := exp.POST("/api/workspaces").
+		WithHeader("Authorization", bearer).
+		WithJSON(map[string]any{"alias": "service-role-team", "name": "Service Role Team"}).
+		Expect().Status(http.StatusOK).JSON().Object()
+	wid := wsObj.Value("id").String().Raw()
+
+	// No JWT at all is rejected, same as any other JWT-required route.
+	exp.PATCH("/api/service/workspaces/" + wid + "/members/" + jwtPrimaryUID.String()).
+		WithJSON(map[string]any{"role": "maintainer"}).
+		Expect().Status(http.StatusUnauthorized)
+
+	// jwtPrimaryUID is this workspace's Owner; on the regular member route this
+	// exact change (Owner -> Maintainer, self) is blocked by the self-demote guard.
+	exp.PATCH("/api/workspaces/"+wid+"/members/"+jwtPrimaryUID.String()).
+		WithHeader("Authorization", bearer).
+		WithJSON(map[string]any{"role": "maintainer"}).
+		Expect().Status(http.StatusForbidden)
+
+	// The service route has no such guard for a Maintainer/Owner acting on
+	// their own role, so the identical change succeeds here.
+	members := exp.PATCH("/api/service/workspaces/"+wid+"/members/"+jwtPrimaryUID.String()).
+		WithHeader("Authorization", bearer).
+		WithJSON(map[string]any{"role": "maintainer"}).
+		Expect().Status(http.StatusOK).JSON().Object().
+		Value("members").Array().Raw()
+
+	found := false
+	for _, m := range members {
+		member, ok := m.(map[string]any)
+		if ok && member["user_id"] == jwtPrimaryUID.String() {
+			found = true
+			assert.Equal(t, "maintainer", member["role"])
+		}
+	}
+	assert.True(t, found, "expected jwtPrimaryUID in members")
 }

--- a/server/e2e/rest_workspace_test.go
+++ b/server/e2e/rest_workspace_test.go
@@ -121,8 +121,10 @@ func TestREST_RealJWT_WorkspaceListByUser(t *testing.T) {
 // TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard covers PATCH
 // /api/service/workspaces/:id/members/:user_id: JWT-authenticated like the
 // regular member route, but a Maintainer/Owner may use it to change their own
-// role (including to Owner), unlike the self-demote guard on
-// PATCH /api/workspaces/:id/members/:user_id.
+// role, unlike the self-demote guard on PATCH /api/workspaces/:id/members/:user_id
+// — as long as it isn't the workspace's last remaining Owner (that's still
+// blocked unconditionally, on both routes) and doesn't grant Owner (only
+// TransferOwnership can do that).
 func TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard(t *testing.T) {
 	key, cleanup := installRealJWT(t)
 	defer cleanup()
@@ -142,15 +144,33 @@ func TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard(t *testing.
 		WithJSON(map[string]any{"role": "maintainer"}).
 		Expect().Status(http.StatusUnauthorized)
 
-	// jwtPrimaryUID is this workspace's Owner; on the regular member route this
-	// exact change (Owner -> Maintainer, self) is blocked by the self-demote guard.
+	// jwtPrimaryUID is currently the sole Owner: demoting them (self or via the
+	// service route) is blocked everywhere, since it would leave the workspace
+	// ownerless.
+	exp.PATCH("/api/service/workspaces/"+wid+"/members/"+jwtPrimaryUID.String()).
+		WithHeader("Authorization", bearer).
+		WithJSON(map[string]any{"role": "maintainer"}).
+		Expect().Status(http.StatusForbidden)
+
+	// Add jwtSecondUID as a co-owner, so jwtPrimaryUID is no longer the sole Owner.
+	exp.POST("/api/workspaces/"+wid+"/members").
+		WithHeader("Authorization", bearer).
+		WithJSON(map[string]any{"users": []map[string]any{
+			{"user_id": jwtSecondUID.String(), "role": "owner"},
+		}}).
+		Expect().Status(http.StatusOK)
+
+	// Now jwtPrimaryUID is one of two owners; on the regular member route,
+	// stepping down (self, Owner -> Maintainer) is still blocked by the
+	// self-demote guard regardless of co-owners.
 	exp.PATCH("/api/workspaces/"+wid+"/members/"+jwtPrimaryUID.String()).
 		WithHeader("Authorization", bearer).
 		WithJSON(map[string]any{"role": "maintainer"}).
 		Expect().Status(http.StatusForbidden)
 
 	// The service route has no such guard for a Maintainer/Owner acting on
-	// their own role, so the identical change succeeds here.
+	// their own role (and jwtSecondUID remains Owner, so this is safe), so the
+	// identical change succeeds here.
 	members := exp.PATCH("/api/service/workspaces/"+wid+"/members/"+jwtPrimaryUID.String()).
 		WithHeader("Authorization", bearer).
 		WithJSON(map[string]any{"role": "maintainer"}).

--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -165,7 +165,7 @@ func (h *UserHandler) Get(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(res) == 0 || res[0] == nil {
+	if len(res) == 0 {
 		return rerror.ErrNotFound
 	}
 

--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -165,7 +165,7 @@ func (h *UserHandler) Get(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(res) == 0 {
+	if len(res) == 0 || res[0] == nil {
 		return rerror.ErrNotFound
 	}
 

--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -167,7 +168,13 @@ func (h *UserHandler) Get(c echo.Context) error {
 	if len(res) == 0 {
 		return rerror.ErrNotFound
 	}
-	return c.JSON(http.StatusOK, httpmodel.NewUserResponse(res[0]))
+
+	userResponses := httpmodel.NewUserResponses(res)
+	if err := applyPermittablesToResponses(ctx, c, userResponses, res); err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, userResponses[0])
 }
 
 // List godoc
@@ -265,58 +272,70 @@ func (h *UserHandler) ListAll(c echo.Context) error {
 	}
 
 	userResponses := httpmodel.NewUserResponses(res.Users)
-
-	if len(res.Users) > 0 {
-		userIDs := make(user.IDList, 0, len(res.Users))
-		for _, u := range res.Users {
-			userIDs = append(userIDs, u.ID())
-		}
-		perms, err := httpinternal.Usecases(c).Permittable.FindByUserIDs(ctx, userIDs)
-		if err != nil {
-			return err
-		}
-
-		// Build role name map (ULID → name) for resolving platform roles and workspace roles.
-		roleNames := map[string]string{}
-		if uc := httpinternal.Usecases(c); uc.Role != nil {
-			if roles, err := uc.Role.FindAll(ctx); err == nil {
-				for _, r := range roles {
-					roleNames[r.ID().String()] = r.Name()
-				}
-			}
-		}
-
-		// Build workspace info map (ULID → {Name, Alias}) for all workspaces referenced
-		// in the permittable workspace roles.
-		wsInfo := map[string]httpmodel.WorkspaceInfo{}
-		wsIDSet := map[string]bool{}
-		for _, p := range perms {
-			for _, wr := range p.WorkspaceRoles() {
-				wsIDSet[wr.ID().String()] = true
-			}
-		}
-		if len(wsIDSet) > 0 {
-			wsIDs := make(workspace.IDList, 0, len(wsIDSet))
-			for sid := range wsIDSet {
-				wid, err := id.WorkspaceIDFrom(sid)
-				if err == nil {
-					wsIDs = append(wsIDs, wid)
-				}
-			}
-			if wsList, err := httpinternal.Usecases(c).Workspace.Fetch(ctx, wsIDs, nil); err == nil {
-				for _, ws := range wsList {
-					wsInfo[ws.ID().String()] = httpmodel.WorkspaceInfo{
-						Name:  ws.Name(),
-						Alias: ws.Alias(),
-					}
-				}
-			}
-		}
-
-		httpmodel.ApplyPermittables(userResponses, perms, roleNames, wsInfo)
+	if err := applyPermittablesToResponses(ctx, c, userResponses, res.Users); err != nil {
+		return err
 	}
 
 	return c.JSON(http.StatusOK, httpinternal.NewPageResult(userResponses, page, size, res.TotalCount))
+}
+
+// applyPermittablesToResponses enriches user responses with platform_roles/workspaces,
+// batch-fetching Permittable records (and resolving role/workspace names) for however
+// many users are passed in. Shared by ListAll (many users) and Get (a single user) so
+// both expose the same fields.
+func applyPermittablesToResponses(ctx context.Context, c echo.Context, userResponses []*httpmodel.UserResponse, users user.List) error {
+	if len(users) == 0 {
+		return nil
+	}
+
+	userIDs := make(user.IDList, 0, len(users))
+	for _, u := range users {
+		userIDs = append(userIDs, u.ID())
+	}
+	perms, err := httpinternal.Usecases(c).Permittable.FindByUserIDs(ctx, userIDs)
+	if err != nil {
+		return err
+	}
+
+	// Build role name map (ULID → name) for resolving platform roles and workspace roles.
+	roleNames := map[string]string{}
+	if uc := httpinternal.Usecases(c); uc.Role != nil {
+		if roles, err := uc.Role.FindAll(ctx); err == nil {
+			for _, r := range roles {
+				roleNames[r.ID().String()] = r.Name()
+			}
+		}
+	}
+
+	// Build workspace info map (ULID → {Name, Alias}) for all workspaces referenced
+	// in the permittable workspace roles.
+	wsInfo := map[string]httpmodel.WorkspaceInfo{}
+	wsIDSet := map[string]bool{}
+	for _, p := range perms {
+		for _, wr := range p.WorkspaceRoles() {
+			wsIDSet[wr.ID().String()] = true
+		}
+	}
+	if len(wsIDSet) > 0 {
+		wsIDs := make(workspace.IDList, 0, len(wsIDSet))
+		for sid := range wsIDSet {
+			wid, err := id.WorkspaceIDFrom(sid)
+			if err == nil {
+				wsIDs = append(wsIDs, wid)
+			}
+		}
+		if wsList, err := httpinternal.Usecases(c).Workspace.Fetch(ctx, wsIDs, nil); err == nil {
+			for _, ws := range wsList {
+				wsInfo[ws.ID().String()] = httpmodel.WorkspaceInfo{
+					Name:  ws.Name(),
+					Alias: ws.Alias(),
+				}
+			}
+		}
+	}
+
+	httpmodel.ApplyPermittables(userResponses, perms, roleNames, wsInfo)
+	return nil
 }
 
 // Search godoc

--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -171,8 +171,13 @@ func (h *UserHandler) Get(c echo.Context) error {
 	}
 
 	userResponses := httpmodel.NewUserResponses(res)
-	if err := applyPermittablesToResponses(ctx, c, userResponses, res); err != nil {
-		return err
+
+	// platform_roles/workspaces expose cross-tenant role and membership info, so
+	// only enrich when the caller is requesting their own record.
+	if me := httpinternal.User(c); me != nil && me.ID() == uid {
+		if err := applyPermittablesToResponses(ctx, c, userResponses, res); err != nil {
+			return err
+		}
 	}
 
 	return c.JSON(http.StatusOK, userResponses[0])

--- a/server/internal/adapter/http/handlers/user.go
+++ b/server/internal/adapter/http/handlers/user.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -165,7 +166,7 @@ func (h *UserHandler) Get(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(res) == 0 {
+	if len(res) == 0 || res[0] == nil {
 		return rerror.ErrNotFound
 	}
 
@@ -293,7 +294,7 @@ func applyPermittablesToResponses(ctx context.Context, c echo.Context, userRespo
 		userIDs = append(userIDs, u.ID())
 	}
 	perms, err := httpinternal.Usecases(c).Permittable.FindByUserIDs(ctx, userIDs)
-	if err != nil {
+	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
 		return err
 	}
 

--- a/server/internal/adapter/http/handlers/workspace.go
+++ b/server/internal/adapter/http/handlers/workspace.go
@@ -352,6 +352,38 @@ func (h *WorkspaceHandler) UpdateMember(c echo.Context) error {
 	return c.JSON(http.StatusOK, httpmodel.NewWorkspaceResponse(w))
 }
 
+// UpdateMemberViaService godoc
+// @Tags Workspace
+// @Summary Update a member's role, bypassing the self-promotion guard
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "workspace ID"
+// @Param user_id path string true "user ID"
+// @Param body body httpmodel.UpdateMemberRequest true "new role"
+// @Success 200 {object} httpmodel.WorkspaceResponse
+// @Router /api/service/workspaces/{id}/members/{user_id} [patch]
+func (h *WorkspaceHandler) UpdateMemberViaService(c echo.Context) error {
+	ctx := c.Request().Context()
+	wid, err := id.WorkspaceIDFrom(c.Param("id"))
+	if err != nil {
+		return badRequest("invalid workspace id")
+	}
+	uid, err := id.UserIDFrom(c.Param("user_id"))
+	if err != nil {
+		return badRequest("invalid user id")
+	}
+	req := &httpmodel.UpdateMemberRequest{}
+	if err := httpinternal.BindValidate(c, req); err != nil {
+		return err
+	}
+	w, err := httpinternal.Usecases(c).Workspace.UpdateUserMemberViaService(ctx, wid, uid, httpmodel.ParseRole(req.Role), httpinternal.Operator(c))
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, httpmodel.NewWorkspaceResponse(w))
+}
+
 // RemoveMember godoc
 // @Tags Workspace
 // @Summary Remove a user member

--- a/server/internal/adapter/http/router.go
+++ b/server/internal/adapter/http/router.go
@@ -131,6 +131,11 @@ func RegisterRESTRouter(e *echo.Echo, cfg RouterConfig) {
 	api.DELETE("/workspaces/:id/integrations", wh.RemoveIntegrations, required)
 	api.POST("/workspaces/:id/transfer-ownership", wh.TransferOwnership, required)
 
+	// --- Service routes ---
+	// JWT required; the caller must hold Maintainer or Owner in the target workspace
+	// This can bypass the self-promotion guard that PATCH .../members/:user_id enforces.
+	api.PATCH("/service/workspaces/:id/members/:user_id", wh.UpdateMemberViaService, required)
+
 	// --- Permission ---
 	ph := handlers.NewPermissionHandler()
 	// OptionalAuth resolves a JWT/mock user (attaching it for APIKeyOrAuth and the

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -537,6 +537,45 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 	})
 }
 
+// UpdateUserMemberViaService sets a member's role without the self-promotion guard applied in UpdateUserMember
+func (i *Workspace) UpdateUserMemberViaService(ctx context.Context, id workspace.ID, u workspace.UserID, newRole role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
+	if operator.User == nil {
+		return nil, interfaces.ErrInvalidOperator
+	}
+
+	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		if ws.IsPersonal() {
+			return nil, workspace.ErrCannotModifyPersonalWorkspace
+		}
+
+		if !operator.IsMaintainingWorkspace(id) {
+			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionEditMember); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := ws.Members().UpdateUserRole(u, newRole); err != nil {
+			return nil, err
+		}
+
+		if err := i.updatePermittable(ctx, u, ws.ID(), newRole); err != nil {
+			return nil, err
+		}
+
+		if err := i.repos.Workspace.Save(ctx, ws); err != nil {
+			return nil, err
+		}
+
+		i.applyDefaultPolicy(ws, operator)
+		return ws, nil
+	})
+}
+
 func (i *Workspace) UpdateIntegration(ctx context.Context, wId workspace.ID, iId workspace.IntegrationID, role role.RoleType, operator *workspace.Operator) (_ *workspace.Workspace, err error) {
 	if operator.User == nil {
 		return nil, interfaces.ErrInvalidOperator

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -556,6 +556,11 @@ func (i *Workspace) UpdateUserMemberViaService(ctx context.Context, id workspace
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
+		// Prevent leaving the workspace without any owners.
+		if ws.Members().IsOnlyOwner(u) {
+			return nil, interfaces.ErrCannotChangeOwnerRole
+		}
+
 		if !operator.IsMaintainingWorkspace(id) {
 			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionEditMember); err != nil {
 				return nil, err

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -542,6 +542,9 @@ func (i *Workspace) UpdateUserMemberViaService(ctx context.Context, id workspace
 	if operator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
 	}
+	if newRole == role.RoleOwner {
+		return nil, workspace.ErrCannotChangeRoleToOwner
+	}
 
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {
 		ws, err := i.repos.Workspace.FindByID(ctx, id)

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -2600,6 +2600,24 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		assert.ErrorIs(t, err, workspace.ErrCannotChangeRoleToOwner)
 	})
 
+	t.Run("UpdateUserMemberViaService: cannot demote the sole owner, leaving the workspace ownerless", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		ownerID := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{ownerID: {Role: role.RoleOwner}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		// The owner is also maintaining (owner implies maintaining), so the
+		// permission gate alone wouldn't have blocked this without the guard.
+		op := &workspace.Operator{User: lo.ToPtr(ownerID), OwningWorkspaces: []workspace.ID{wid}}
+
+		workspaceUC := NewWorkspace(db, nil, nil)
+		_, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, ownerID, role.RoleMaintainer, op)
+		assert.ErrorIs(t, err, interfaces.ErrCannotChangeOwnerRole)
+	})
+
 	t.Run("UpdateUserMemberViaService: also allowed for a non-self target", func(t *testing.T) {
 		db := memory.New()
 		seedRoles(db)

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -2540,6 +2540,102 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		assert.Equal(t, role.RoleWriter, got.Members().UserRole(targetUser))
 	})
 
+	t.Run("UpdateUserMember: self-promotion is blocked even for a real workspace-local maintainer", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		operatorID := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{operatorID: {Role: role.RoleMaintainer}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		op := &workspace.Operator{
+			User:                   lo.ToPtr(operatorID),
+			WritableWorkspaces:     []workspace.ID{wid},
+			MaintainableWorkspaces: []workspace.ID{wid},
+		}
+
+		// A real maintainer already has edit_member, so nothing (Cerbos included)
+		// should let them grant themselves Owner through UpdateUserMember; that
+		// privilege escalation path only exists via UpdateUserMemberViaService,
+		// which every real Maintainer/Owner can reach — see the tests below.
+		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
+		_, err := workspaceUC.UpdateUserMember(ctx, wid, operatorID, role.RoleOwner, op)
+		assert.ErrorIs(t, err, interfaces.ErrCannotSelfPromote)
+	})
+
+	t.Run("UpdateUserMemberViaService: a Maintainer can set their own role, bypassing the self-promotion guard", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		operatorID := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{operatorID: {Role: role.RoleMaintainer}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		op := &workspace.Operator{User: lo.ToPtr(operatorID), MaintainableWorkspaces: []workspace.ID{wid}}
+
+		workspaceUC := NewWorkspace(db, nil, nil)
+		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, operatorID, role.RoleOwner, op)
+		assert.NoError(t, err)
+		assert.Equal(t, role.RoleOwner, got.Members().UserRole(operatorID))
+	})
+
+	t.Run("UpdateUserMemberViaService: also allowed for a non-self target", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		operatorID := id.NewUserID()
+		targetUser := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{
+				operatorID: {Role: role.RoleMaintainer},
+				targetUser: {Role: role.RoleReader},
+			}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		op := &workspace.Operator{User: lo.ToPtr(operatorID), MaintainableWorkspaces: []workspace.ID{wid}}
+
+		workspaceUC := NewWorkspace(db, nil, nil)
+		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, targetUser, role.RoleMaintainer, op)
+		assert.NoError(t, err)
+		assert.Equal(t, role.RoleMaintainer, got.Members().UserRole(targetUser))
+	})
+
+	t.Run("UpdateUserMemberViaService: a Writer is denied (Maintainer/Owner only)", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		operatorID := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{operatorID: {Role: role.RoleWriter}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		// Writer counts as writable but not maintaining, so this must still be denied.
+		op := &workspace.Operator{User: lo.ToPtr(operatorID), WritableWorkspaces: []workspace.ID{wid}}
+
+		workspaceUC := NewWorkspace(db, nil, nil)
+		_, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, operatorID, role.RoleMaintainer, op)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("UpdateUserMemberViaService: Cerbos global role allows a non-member (e.g. LINKS-Veda's admin account)", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		targetUser := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{targetUser: {Role: role.RoleReader}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		op := &workspace.Operator{User: lo.ToPtr(id.NewUserID())} // not a member at all
+
+		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
+		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, targetUser, role.RoleOwner, op)
+		assert.NoError(t, err)
+		assert.Equal(t, role.RoleOwner, got.Members().UserRole(targetUser))
+	})
+
 	t.Run("RemoveMultipleUserMembers: Cerbos global role allows removal by a non-member", func(t *testing.T) {
 		db := memory.New()
 		targetUser := id.NewUserID()

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -2556,15 +2556,33 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		}
 
 		// A real maintainer already has edit_member, so nothing (Cerbos included)
-		// should let them grant themselves Owner through UpdateUserMember; that
-		// privilege escalation path only exists via UpdateUserMemberViaService,
-		// which every real Maintainer/Owner can reach — see the tests below.
+		// should let them grant themselves Owner through UpdateUserMember.
 		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
 		_, err := workspaceUC.UpdateUserMember(ctx, wid, operatorID, role.RoleOwner, op)
 		assert.ErrorIs(t, err, interfaces.ErrCannotSelfPromote)
 	})
 
-	t.Run("UpdateUserMemberViaService: a Maintainer can set their own role, bypassing the self-promotion guard", func(t *testing.T) {
+	t.Run("UpdateUserMemberViaService: a Maintainer can set their own role (below Owner), bypassing the self-promotion guard", func(t *testing.T) {
+		db := memory.New()
+		seedRoles(db)
+		wid := id.NewWorkspaceID()
+		operatorID := id.NewUserID()
+		ws := workspace.New().ID(wid).Name("Test").Alias("test-alias").
+			Members(map[user.ID]workspace.Member{operatorID: {Role: role.RoleWriter}}).
+			Personal(false).MustBuild()
+		assert.NoError(t, db.Workspace.Save(ctx, ws))
+		// MaintainableWorkspaces reflects a real Maintainer elsewhere but Writer
+		// here is enough to exercise the bypass; IsMaintainingWorkspace is what
+		// actually gates this call (see the Writer-denied test below).
+		op := &workspace.Operator{User: lo.ToPtr(operatorID), MaintainableWorkspaces: []workspace.ID{wid}}
+
+		workspaceUC := NewWorkspace(db, nil, nil)
+		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, operatorID, role.RoleMaintainer, op)
+		assert.NoError(t, err)
+		assert.Equal(t, role.RoleMaintainer, got.Members().UserRole(operatorID))
+	})
+
+	t.Run("UpdateUserMemberViaService: never grants Owner, even to a real Maintainer changing their own role", func(t *testing.T) {
 		db := memory.New()
 		seedRoles(db)
 		wid := id.NewWorkspaceID()
@@ -2575,10 +2593,11 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		assert.NoError(t, db.Workspace.Save(ctx, ws))
 		op := &workspace.Operator{User: lo.ToPtr(operatorID), MaintainableWorkspaces: []workspace.ID{wid}}
 
-		workspaceUC := NewWorkspace(db, nil, nil)
-		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, operatorID, role.RoleOwner, op)
-		assert.NoError(t, err)
-		assert.Equal(t, role.RoleOwner, got.Members().UserRole(operatorID))
+		// Cerbos would even allow it (global role), but Owner is blocked
+		// unconditionally — TransferOwnership is the only path to Owner.
+		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
+		_, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, operatorID, role.RoleOwner, op)
+		assert.ErrorIs(t, err, workspace.ErrCannotChangeRoleToOwner)
 	})
 
 	t.Run("UpdateUserMemberViaService: also allowed for a non-self target", func(t *testing.T) {
@@ -2631,9 +2650,9 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		op := &workspace.Operator{User: lo.ToPtr(id.NewUserID())} // not a member at all
 
 		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
-		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, targetUser, role.RoleOwner, op)
+		got, err := workspaceUC.UpdateUserMemberViaService(ctx, wid, targetUser, role.RoleMaintainer, op)
 		assert.NoError(t, err)
-		assert.Equal(t, role.RoleOwner, got.Members().UserRole(targetUser))
+		assert.Equal(t, role.RoleMaintainer, got.Members().UserRole(targetUser))
 	})
 
 	t.Run("RemoveMultipleUserMembers: Cerbos global role allows removal by a non-member", func(t *testing.T) {

--- a/server/internal/usecase/interfaces/workspace.go
+++ b/server/internal/usecase/interfaces/workspace.go
@@ -70,6 +70,8 @@ type Workspace interface {
 	AddUserMember(context.Context, workspace.ID, map[user.ID]role.RoleType, *workspace.Operator) (*workspace.Workspace, error)
 	AddIntegrationMember(context.Context, workspace.ID, workspace.IntegrationID, role.RoleType, *workspace.Operator) (*workspace.Workspace, error)
 	UpdateUserMember(context.Context, workspace.ID, user.ID, role.RoleType, *workspace.Operator) (*workspace.Workspace, error)
+	// UpdateUserMemberViaService sets a member's role without the self-promotion guard in UpdateUserMember
+	UpdateUserMemberViaService(context.Context, workspace.ID, user.ID, role.RoleType, *workspace.Operator) (*workspace.Workspace, error)
 	UpdateIntegration(context.Context, workspace.ID, workspace.IntegrationID, role.RoleType, *workspace.Operator) (*workspace.Workspace, error)
 	RemoveUserMember(context.Context, workspace.ID, user.ID, *workspace.Operator) (*workspace.Workspace, error)
 	RemoveMultipleUserMembers(context.Context, workspace.ID, user.IDList, *workspace.Operator) (*workspace.Workspace, error)

--- a/server/internal/usecase/proxy/workspace.go
+++ b/server/internal/usecase/proxy/workspace.go
@@ -148,6 +148,10 @@ func (w *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, userI
 	return ToWorkspace(res.UpdateUserOfWorkspace.Workspace.FragmentWorkspace)
 }
 
+func (w *Workspace) UpdateUserMemberViaService(ctx context.Context, id workspace.ID, userID accountid.UserID, role role.RoleType, op *workspace.Operator) (*workspace.Workspace, error) {
+	return nil, interfaces.ErrOperationDenied
+}
+
 func (w *Workspace) UpdateIntegration(ctx context.Context, id workspace.ID, integrationID workspace.IntegrationID, role role.RoleType, op *workspace.Operator) (*workspace.Workspace, error) {
 	res, err := UpdateIntegrationOfWorkspace(ctx, w.gql, UpdateIntegrationOfWorkspaceInput{WorkspaceId: id.String(), IntegrationId: integrationID.String(), Role: Role(string(role))})
 	if err != nil {


### PR DESCRIPTION
### Why

In Veda, `GET /api/users/{id}` is called from exactly one place: `accountsRepository.getUser()` in `web/app/actions/UserAction.ts:63`, as part of `userAuthAction` (the login flow). After a successful Firebase auth, the login flow calls `getMe()` for basic profile info, then calls `getUser(idToken, accountsMe.id)` with the user's own ID specifically to read `is_deleted` and `platform_roles` (used to determine `isAdmin` via the owner role).

However, `Get` (backing `GET /api/users/{id}`) only returned the bare user fields via `httpmodel.NewUserResponse(res[0])` — it never enriched the response with `Permittable` data, so `platform_roles` (and `workspaces`) were missing. `ListAll` already had this enrichment logic inline, but it wasn't shared with `Get`.

This PR extracts the enrichment logic into a shared `applyPermittablesToResponses` helper (batch-fetches `Permittable` records, resolves role/workspace names) and applies it to both `ListAll` and `Get`, so the login flow's owner/admin check now receives the `platform_roles` it depends on. While wiring this up, a few related issues surfaced and are fixed in the same PR:

Separately, `Workspace.UpdateUserMember` unconditionally blocked an operator from changing their own workspace role (self-promote / stepping down from owner), even for a Maintainer/Owner who would otherwise have full `edit_member` rights over every other member. This broke a real Veda workflow (a per-workspace Maintainer account managing its own role). Rather than weakening `UpdateUserMember`'s guard — which every existing caller (GraphQL resolver, REST, in-repo tests) relies on — this PR adds a new endpoint:



# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo