### PR TITLE
fix(server): remove DB transaction wrapper from RegenerateMFARecoveryCode

### DIFF
--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -404,7 +404,7 @@ func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspac
 	if operator == nil || operator.User == nil {
 		return "", interfaces.ErrInvalidOperator
 	}
-	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (string, error) {
+	return Run1(ctx, operator, i.repos, Usecase(), func(ctx context.Context) (string, error) {
 		u, err := i.repos.User.FindByID(ctx, *operator.User)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Overview

Addresses SCA-05/REL-06 from the ai-scan security/scalability report (eukarya-inc/compliance#100).

## What I've done

`RegenerateMFARecoveryCode` wrapped `Usecase().Transaction()` around Auth0 Management API round-trips even though the callback performs only a `FindByID` read with no writes — the same anti-pattern already removed from `DisableMFA`/`EnableMFA`/`GetMFAStatus` in #298. This method landed in #305 before that fix and was missed.

Holding a pooled DB connection for the duration of an Auth0 call chain (up to ~2x the configured HTTP timeout when the cached management token needs refreshing) can drain the connection pool under degraded Auth0 latency and block unrelated requests, including the Cerbos permission-evaluation path shared by all Re:Earth microservices.

Removed `.Transaction()` from the `Run1` call, matching the existing pattern for the sibling MFA methods.

## What I haven't done

N/A — single-line, isolated fix.

## How I tested

- `go build ./...`
- `go test ./internal/usecase/interactor/...` (existing `TestUser_RegenerateMFARecoveryCode` cases pass unchanged)

## Which point I want you to review particularly

Confirm there isn't a reason (not visible in the code) that this specific mutation needs transactional semantics that the other MFA methods don't.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values