### PR TITLE
fix(server): release in-process lock cache even when remote unlock fails

### DIFF
--- a/server/internal/infrastructure/mongo/lock.go
+++ b/server/internal/infrastructure/mongo/lock.go
@@ -58,11 +58,19 @@ func (r *Lock) Unlock(ctx context.Context, name string) error {
 		return repo.ErrNotLocked
 	}
 
-	if _, err := r.l.Unlock(ctx, lockID); err != nil {
+	// Always release the in-process guard, even if the remote unlock below
+	// fails, so a canceled caller context or a transient Mongo error doesn't
+	// leave this process permanently unable to (re)acquire name: the actual
+	// mutual-exclusion guarantee is the Mongo lock document and its TTL, not
+	// this local cache. Use a non-cancelable context for the remote call so
+	// an already-canceled ctx (e.g. an aborted HTTP request) doesn't turn a
+	// routine deferred unlock into a spurious failure.
+	defer r.deleteLockID(name)
+
+	if _, err := r.l.Unlock(context.WithoutCancel(ctx), lockID); err != nil {
 		return rerror.ErrInternalByWithContext(ctx, err)
 	}
 
-	r.deleteLockID(name)
 	log.Debugfc(ctx, "lock: unlocked: name=%s, id=%s, host=%s", name, lockID, r.hostid)
 	return nil
 }


### PR DESCRIPTION
## Overview

Addresses REL-05 from the ai-scan reliability report (eukarya-inc/compliance#100). This is a regression introduced by #297.

## What I've done

`Lock.Unlock` only cleared its in-process `locks` map entry after the Mongo unlock write succeeded. If that write failed — a canceled caller context from a client disconnect or gateway timeout, or a transient Mongo error — the lock name stayed marked as held in this process forever, since nothing else ever clears that cache.

The admin `system_admin` demotion guard (`SaveGuardingLastSystemAdmin`, added in #297) hits this directly: its deferred `Unlock` call uses the request context, so an aborted `SetRole` request permanently poisons the guard lock, and every subsequent demotion returns HTTP 500 until the pod is restarted.

`Lock.Unlock` now:
- Always releases the local cache via `defer`, regardless of the remote outcome — the real mutual-exclusion guarantee is the Mongo lock document and its TTL, not this local cache.
- Issues the remote unlock with `context.WithoutCancel(ctx)` so an already-canceled caller context doesn't turn a routine deferred unlock into a spurious failure.

Fixed at the shared `Lock` type rather than only at the admin-guard call site, since `mongo/config.go`'s `LockAndLoad` (REL-04) shares the same underlying risk.

## What I haven't done

Did not change `mongo/config.go`'s missing-unlock-on-error path (REL-04) — that's a separate finding (a lock never acquired-then-released vs. this one, a release that can silently no-op) and is being tracked separately.

## How I tested

- `go build ./...`, `go vet ./...`
- `go test ./internal/usecase/interactor/...`
- Full `mongo` package suite requires a live MongoDB (`localhost:27017`), which isn't available in this sandbox — no test in that package exercises `Lock.Unlock` directly, and the change is scoped to failure-path cleanup only.

## Which point I want you to review particularly

Whether returning the remote error while still clearing the local cache is the right tradeoff, vs. swallowing it — I kept the error surfaced for observability since existing callers already ignore it with `_ = ...Unlock(...)`.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values