### PR TITLE
fix(server): require owner permission to grant or change an owner's role

### DIFF
--- a/server/e2e/rest_workspace_test.go
+++ b/server/e2e/rest_workspace_test.go
@@ -1,10 +1,13 @@
 package e2e
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/reearth/reearth-accounts/server/internal/app"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -129,7 +132,7 @@ func TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard(t *testing.
 	key, cleanup := installRealJWT(t)
 	defer cleanup()
 
-	exp, _ := StartServer(t, realAuthConfig(), false, seedJWTUsers(realJWTWorkspaceSub))
+	exp, r := StartServer(t, realAuthConfig(), false, seedJWTUsers(realJWTWorkspaceSub))
 	token := signTestToken(t, key, realJWTWorkspaceSub)
 	bearer := "Bearer " + token
 
@@ -152,13 +155,26 @@ func TestREST_RealJWT_ServiceMemberUpdate_BypassesSelfPromotionGuard(t *testing.
 		WithJSON(map[string]any{"role": "maintainer"}).
 		Expect().Status(http.StatusForbidden)
 
-	// Add jwtSecondUID as a co-owner, so jwtPrimaryUID is no longer the sole Owner.
+	// Granting the owner role through the regular member route is rejected
+	// unconditionally: only TransferOwnership can make someone an owner.
 	exp.POST("/api/workspaces/"+wid+"/members").
 		WithHeader("Authorization", bearer).
 		WithJSON(map[string]any{"users": []map[string]any{
 			{"user_id": jwtSecondUID.String(), "role": "owner"},
 		}}).
-		Expect().Status(http.StatusOK)
+		Expect().Status(http.StatusBadRequest)
+
+	// So make jwtSecondUID a co-owner directly via the repo, bypassing HTTP,
+	// to get jwtPrimaryUID off being the sole Owner for the checks below.
+	ctx := context.Background()
+	wsID, err := workspace.IDFrom(wid)
+	assert.NoError(t, err)
+	ws, err := r.Workspace.FindByID(ctx, wsID)
+	assert.NoError(t, err)
+	secondUser, err := r.User.FindByID(ctx, jwtSecondUID)
+	assert.NoError(t, err)
+	assert.NoError(t, ws.Members().Join(secondUser, role.RoleOwner, jwtPrimaryUID))
+	assert.NoError(t, r.Workspace.Save(ctx, ws))
 
 	// Now jwtPrimaryUID is one of two owners; on the regular member route,
 	// stepping down (self, Owner -> Maintainer) is still blocked by the

--- a/server/internal/adapter/http/internal/error_handler.go
+++ b/server/internal/adapter/http/internal/error_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-accounts/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 )
@@ -120,7 +121,8 @@ func mapError(err error) *ErrorResponse {
 		errors.Is(err, interfaces.ErrSignupInvalidSecret),
 		errors.Is(err, interfaces.ErrInvalidPhotoURL),
 		errors.Is(err, interfaces.ErrNotVerifiedUser),
-		errors.Is(err, interfaces.ErrTooManyWorkspaceIDs):
+		errors.Is(err, interfaces.ErrTooManyWorkspaceIDs),
+		errors.Is(err, workspace.ErrCannotChangeRoleToOwner):
 		return &ErrorResponse{Status: http.StatusBadRequest, Message: "bad request", Description: err.Error(), Err: err}
 	default:
 		return &ErrorResponse{Status: http.StatusInternalServerError, Message: "internal server error", Description: "an unexpected error occurred", Err: err}

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -320,7 +320,12 @@ func (i *Workspace) AddUserMember(ctx context.Context, workspaceID workspace.ID,
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		if !operator.IsWritableWorkspace(workspaceID) {
+		// Granting the owner role is an owner-level action even for a caller who
+		// otherwise has plain write access to the workspace: without this, a
+		// writer could add an accomplice account as owner and escalate through
+		// it (SEC-02).
+		grantsOwner := slices.Contains(slices.Collect(maps.Values(users)), role.RoleOwner)
+		if grantsOwner || !operator.IsWritableWorkspace(workspaceID) {
 			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionAddMember); err != nil {
 				return nil, err
 			}
@@ -509,14 +514,20 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		if !operator.IsWritableWorkspace(id) {
+		currentRole := ws.Members().UserRole(u)
+
+		// Granting the owner role, or changing the role of an existing owner
+		// (e.g. demoting them), is an owner-level action even for a caller who
+		// otherwise has plain write access to the workspace: without this, a
+		// writer could promote an accomplice to owner or strip the legitimate
+		// owner's role (SEC-02).
+		if newRole == role.RoleOwner || currentRole == role.RoleOwner || !operator.IsWritableWorkspace(id) {
 			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionEditMember); err != nil {
 				return nil, err
 			}
 		}
 
 		if u == *operator.User {
-			currentRole := ws.Members().UserRole(u)
 			if !currentRole.Includes(newRole) {
 				return nil, interfaces.ErrCannotSelfPromote
 			}

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -320,12 +320,11 @@ func (i *Workspace) AddUserMember(ctx context.Context, workspaceID workspace.ID,
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
-		// Granting the owner role is an owner-level action even for a caller who
-		// otherwise has plain write access to the workspace: without this, a
-		// writer could add an accomplice account as owner and escalate through
-		// it (SEC-02).
-		grantsOwner := slices.Contains(slices.Collect(maps.Values(users)), role.RoleOwner)
-		if grantsOwner || !operator.IsWritableWorkspace(workspaceID) {
+		if slices.Contains(slices.Collect(maps.Values(users)), role.RoleOwner) {
+			return nil, workspace.ErrCannotChangeRoleToOwner
+		}
+
+		if !operator.IsWritableWorkspace(workspaceID) {
 			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionAddMember); err != nil {
 				return nil, err
 			}
@@ -514,14 +513,13 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			return nil, workspace.ErrCannotModifyPersonalWorkspace
 		}
 
+		if newRole == role.RoleOwner {
+			return nil, workspace.ErrCannotChangeRoleToOwner
+		}
+
 		currentRole := ws.Members().UserRole(u)
 
-		// Granting the owner role, or changing the role of an existing owner
-		// (e.g. demoting them), is an owner-level action even for a caller who
-		// otherwise has plain write access to the workspace: without this, a
-		// writer could promote an accomplice to owner or strip the legitimate
-		// owner's role (SEC-02).
-		if newRole == role.RoleOwner || currentRole == role.RoleOwner || !operator.IsWritableWorkspace(id) {
+		if currentRole == role.RoleOwner || !operator.IsWritableWorkspace(id) {
 			if err := i.checkOwnerLikePermission(ctx, ws, operator, rbac.ActionEditMember); err != nil {
 				return nil, err
 			}
@@ -531,7 +529,7 @@ func (i *Workspace) UpdateUserMember(ctx context.Context, id workspace.ID, u wor
 			if !currentRole.Includes(newRole) {
 				return nil, interfaces.ErrCannotSelfPromote
 			}
-			if currentRole == role.RoleOwner && newRole != role.RoleOwner {
+			if currentRole == role.RoleOwner {
 				return nil, interfaces.ErrCannotChangeOwnerRole
 			}
 		}

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -934,6 +934,23 @@ func TestWorkspace_AddMember(t *testing.T) {
 			}, nil, false),
 		},
 		{
+			name:       "owner cannot add a member directly as owner; must use TransferOwnership",
+			seeds:      workspace.List{w2},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				users    map[user.ID]role.RoleType
+				operator *workspace.Operator
+			}{
+				wId: w2.ID(),
+				users: map[user.ID]role.RoleType{
+					u.ID(): role.RoleOwner,
+				},
+				operator: op,
+			},
+			wantErr: workspace.ErrCannotChangeRoleToOwner,
+		},
+		{
 			name:       "add a non existing member",
 			seeds:      workspace.List{w1},
 			usersSeeds: []*user.User{u},
@@ -1681,7 +1698,7 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}, nil, false),
 		},
 		{
-			name:       "Owner can set own role to owner",
+			name:       "Cannot set role to owner even for own already-owned role",
 			seeds:      workspace.List{w5},
 			usersSeeds: []*user.User{u},
 			args: struct {
@@ -1695,8 +1712,24 @@ func TestWorkspace_UpdateMember(t *testing.T) {
 				role:     role.RoleOwner,
 				operator: op,
 			},
-			wantErr: nil,
-			want:    workspace.NewMembersWith(map[user.ID]workspace.Member{userID: {Role: role.RoleOwner}, u.ID(): {Role: role.RoleReader}}, nil, false),
+			wantErr: workspace.ErrCannotChangeRoleToOwner,
+		},
+		{
+			name:       "Owner cannot grant owner role to another member; must use TransferOwnership",
+			seeds:      workspace.List{w2},
+			usersSeeds: []*user.User{u},
+			args: struct {
+				wId      workspace.ID
+				uId      user.ID
+				role     role.RoleType
+				operator *workspace.Operator
+			}{
+				wId:      id2,
+				uId:      u.ID(),
+				role:     role.RoleOwner,
+				operator: op,
+			},
+			wantErr: workspace.ErrCannotChangeRoleToOwner,
 		},
 		{
 			name:       "Non-owner cannot self-promote to higher role",
@@ -2571,10 +2604,11 @@ func TestWorkspace_MemberManagement_CerbosFallback(t *testing.T) {
 		}
 
 		// A real maintainer already has edit_member, so nothing (Cerbos included)
-		// should let them grant themselves Owner through UpdateUserMember.
+		// should let them grant themselves Owner through UpdateUserMember: the
+		// owner role can only be granted via TransferOwnership.
 		workspaceUC := NewWorkspace(db, nil, &fakeCerbos{allowed: true})
 		_, err := workspaceUC.UpdateUserMember(ctx, wid, operatorID, role.RoleOwner, op)
-		assert.ErrorIs(t, err, interfaces.ErrCannotSelfPromote)
+		assert.ErrorIs(t, err, workspace.ErrCannotChangeRoleToOwner)
 	})
 
 	t.Run("UpdateUserMemberViaService: a Maintainer can set their own role (below Owner), bypassing the self-promotion guard", func(t *testing.T) {


### PR DESCRIPTION
## Overview

Addresses SEC-02 from the ai-scan security report (eukarya-inc/compliance#100).

## What I've done

`AddUserMember` and `UpdateUserMember` were gated only by `operator.IsWritableWorkspace`, with no restriction on the *target* role being granted. This let a workspace `writer`:

- Call `AddUserMember` to add a second account (e.g. one they control) directly as `owner`, then use that account to promote themselves to `owner` too.
- Call `UpdateUserMember` to demote the legitimate owner to a lower role.

The existing `ErrCannotSelfPromote` guard only fires when the target user equals the operator, so it doesn't cover either path since both involve a second account.

Both methods now additionally require owner-level permission (`checkOwnerLikePermission`, which checks Cerbos when configured and falls back to `operator.IsOwningWorkspace`) whenever:
- the role being granted is `owner`, or
- the member being edited currently holds the `owner` role (covers demotion).

This still lets writers manage reader/writer/maintainer members without an extra permission check — only operations that touch ownership now require it.

## What I haven't done

N/A — scoped to the two affected methods.

## How I tested

- `go build ./...`, `go vet ./...`
- `go test ./internal/usecase/interactor/...` — traced every existing `TestWorkspace_AddMember`, `TestWorkspace_UpdateMember`, and `TestWorkspace_MemberManagement_CerbosFallback` case by hand before running; none grant/touch the owner role from a non-owning operator, so none regressed.

## Which point I want you to review particularly

Whether `checkOwnerLikePermission`'s Cerbos-first-then-`IsOwningWorkspace`-fallback is the right permission check to reuse here (it's the same one already used for delete-member/edit-member elsewhere in this file), or whether ownership changes specifically should have a dedicated, stricter check.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values