### PR TITLE
fix(server): release migration lock on Mongo config load error path

### DIFF
--- a/server/internal/infrastructure/mongo/config.go
+++ b/server/internal/infrastructure/mongo/config.go
@@ -32,6 +32,10 @@ func (r *Config) LockAndLoad(ctx context.Context) (cfg *config.Config, err error
 	cfgd := &mongodoc.ConfigDocument{}
 	if err := r.client.FindOne(ctx, bson.M{}).Decode(cfgd); err != nil {
 		if !errors.Is(err, mongo.ErrNilDocument) && !errors.Is(err, mongo.ErrNoDocuments) {
+			// Release the lock on load failure so a transient read error (e.g. a
+			// primary stepdown) doesn't leave it held for its full TTL with no
+			// caller left to release it.
+			_ = r.lock.Unlock(ctx, configLockName)
 			return nil, rerror.ErrInternalByWithContext(ctx, err)
 		}
 	}


### PR DESCRIPTION
## Overview

Addresses REL-04 from the ai-scan reliability report (eukarya-inc/compliance#100).

## What I've done

`Config.LockAndLoad` acquires the `"config"` distributed lock, then on a genuine `FindOne` error (anything other than `ErrNilDocument`/`ErrNoDocuments`) returned immediately without releasing it. `migration.Config.Begin` forwards that error, and `usecasex/migration.Client.Migrate` returns before registering the `defer End()` that would normally unlock, so nothing ever releases the lock. Because the lock's TTL is one hour, a transient read error (primary stepdown, network blip) during a `RUN_MIGRATION=true` job blocks that job from being retried for up to an hour, mid-deploy.

Added an `Unlock` call on the error path, matching how the PostgreSQL sibling (`internal/infrastructure/postgres/config.go`) already releases its lock/connection on the same failure path.

## What I haven't done

N/A — single call-site fix.

## How I tested

- `go build ./...`
- No existing unit test covers `LockAndLoad`'s error path (it requires a live Mongo with an injectable read failure); the fix is a minimal, clearly-scoped addition mirroring the already-tested Postgres behavior.

## Which point I want you to review particularly

Whether this warrants a regression test using a fault-injecting Mongo double, given there's currently no test harness for that in this package.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values