### PR TITLE
fix(server): mask Auth0 client secret, signup secret, sync-SSO API key in startup logs

### DIFF
--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -263,7 +263,12 @@ type GraphQLConfig struct {
 func (c Config) Print() string {
 	s := fmt.Sprintf("%+v", c)
 	// Mask credential-like values so the startup log line doesn't leak them.
-	for _, secret := range []string{c.DB, c.RestAPIKey, c.SwaggerBasicPass} {
+	// fmt's "%+v" ignores the `pp:",omitempty"` tags used elsewhere in this
+	// struct, so every secret field must be listed here explicitly.
+	for _, secret := range []string{
+		c.DB, c.RestAPIKey, c.SwaggerBasicPass,
+		c.Auth0.ClientSecret, c.SignupSecret, c.SyncSSOAPIKey,
+	} {
 		if secret == "" {
 			continue
 		}

--- a/server/internal/app/config_test.go
+++ b/server/internal/app/config_test.go
@@ -7,6 +7,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConfig_Print_MasksSecrets(t *testing.T) {
+	c := Config{
+		DB:               "mongodb://user:pass@localhost/db",
+		RestAPIKey:       "rest-api-key-value",
+		SwaggerBasicPass: "swagger-pass-value",
+		SignupSecret:     "signup-secret-value",
+		SyncSSOAPIKey:    "sync-sso-api-key-value",
+		Auth0: Auth0Config{
+			ClientSecret: "auth0-client-secret-value",
+		},
+	}
+
+	got := c.Print()
+
+	for _, secret := range []string{
+		"mongodb://user:pass@localhost/db",
+		"rest-api-key-value",
+		"swagger-pass-value",
+		"signup-secret-value",
+		"sync-sso-api-key-value",
+		"auth0-client-secret-value",
+	} {
+		assert.NotContains(t, got, secret)
+	}
+}
+
 func TestCIPConfig_AuthConfig(t *testing.T) {
 	// Unset project => nil (no provider added)
 	assert.Nil(t, CIPConfig{}.AuthConfig())


### PR DESCRIPTION
## Overview

Addresses SEC-03 from the ai-scan security report (eukarya-inc/compliance#100).

## What I've done

`Config.Print()` renders the whole struct with `fmt.Sprintf("%+v", c)` and only masked `DB`, `RestAPIKey` and `SwaggerBasicPass` from the result. The struct's `pp:",omitempty"` tags (used elsewhere for pretty-printing) are inert under `fmt`, so `Auth0.ClientSecret`, `SignupSecret`, and `SyncSSOAPIKey` were still emitted verbatim by the startup `log.Infof("config: %s", conf.Print())` call in `server.go`.

Anyone with log-viewer access (Cloud Logging) — a much wider set than secret-manager access, and a common target after a low-privilege compromise or a log-export misconfiguration — could read:
- the Auth0 M2M client secret, usable against the Auth0 Management API (reset any user's password/email)
- the sync-SSO API key, usable to provision arbitrary accounts via `POST /api/users/sync-sso`, which is gated solely by that key

Added all three to the masked-value list in `Print()`.

## What I haven't done

N/A — scoped to the log-masking function.

## How I tested

- `go build ./...`
- Added `TestConfig_Print_MasksSecrets`, asserting none of the six secret-like fields (including the three newly masked ones) appear in `Print()`'s output.
- `go test ./internal/app/...` passes.

## Which point I want you to review particularly

Whether any other config field should be treated as secret-like going forward — this is a substring-replace approach, so anything added later needs to be added to this list explicitly; happy to switch to an allowlist-based printer if preferred.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values