### PR TITLE
fix(server): handle SIGTERM and drain in-flight requests on shutdown

### DIFF
--- a/server/internal/app/server.go
+++ b/server/internal/app/server.go
@@ -2,10 +2,13 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
@@ -216,13 +219,20 @@ func (w *WebServer) Run(ctx context.Context) {
 	log.Infof("server started%s at http://%s\n", debugLog, w.address)
 
 	go func() {
-		err := w.appServer.StartH2CServer(w.address, &http2.Server{})
-		log.Fatalc(ctx, err.Error())
+		if err := w.appServer.StartH2CServer(w.address, &http2.Server{}); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalc(ctx, err.Error())
+		}
 	}()
 
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 	<-quit
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := w.Shutdown(shutdownCtx); err != nil {
+		log.Errorf("server shutdown: %v", err)
+	}
 }
 
 func (w *WebServer) Serve(l net.Listener) error {


### PR DESCRIPTION
## Overview

Addresses REL-01 from the ai-scan reliability report (eukarya-inc/compliance#100).

## What I've done

`WebServer.Run` only registered `os.Interrupt` with `signal.Notify` and never called `Shutdown` (which already existed but was referenced only from `e2e/common_test.go`). Any rollout, pod eviction, or scale-down sends `SIGTERM`, not `SIGINT` — since `SIGTERM` wasn't in the `Notify` set, Go's default disposition terminated the process immediately, killing the goroutine serving HTTP mid-flight and severing every in-flight GraphQL/REST call with a TCP reset. That includes `checkPermission`, which every other Re:Earth service (dashboard, visualizer, CMS, flow) calls synchronously for authorization, and mutations like `signup`/`addUserMember` could be cut between the write and the response, leaving callers unable to tell whether they succeeded.

`Run` now:
- Traps `SIGTERM` in addition to `SIGINT`.
- On receiving either, calls `Shutdown` with a 10-second budget before returning, matching the existing pattern in the sibling admin server (`internal/admin/di/echohttp.go`).
- No longer treats the expected `http.ErrServerClosed` (returned once `Shutdown` closes the listener) as a fatal error in the launch goroutine — previously it would call `log.Fatalc` unconditionally on any return from `StartH2CServer`, including a graceful one, which would have short-circuited the drain this change adds.

## What I haven't done

Did not add an explicit readiness/liveness probe change or Cloud Run `terminationGracePeriodSeconds` tuning — this PR only fixes the in-process signal handling; deployment-level grace period should already default to something >= the 10s budget used here, but worth confirming separately.

## How I tested

- `go build ./...`, `go vet ./...`
- `go test ./internal/app/...`
- No existing unit test drives `WebServer.Run` directly (it's exercised via e2e's `Shutdown` call); this is a minimal, focused change mirroring the already-in-use admin server pattern.

## Which point I want you to review particularly

Whether 10s is the right shutdown budget for this service specifically (the admin server uses the same value) given typical request latencies here, and whether Cloud Run's configured termination grace period comfortably exceeds it.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values