### PR TITLE
fix(server): allow retry after transient GCS client init failure

### DIFF
--- a/server/internal/infrastructure/storage/storage.go
+++ b/server/internal/infrastructure/storage/storage.go
@@ -39,9 +39,8 @@ type Config struct {
 
 type Storage struct {
 	cfg       *Config
-	once      sync.Once
+	mu        sync.Mutex
 	gcsClient *storage.Client
-	initErr   error
 	cache     *lruexpirable.LRU[string, string]
 }
 
@@ -114,27 +113,36 @@ func (s *Storage) GetSignedURL(ctx context.Context, name string) (string, error)
 }
 
 func (s *Storage) bucket(ctx context.Context) (*storage.BucketHandle, error) {
-	s.once.Do(func() {
-		_, span := otel.Tracer("reearth-accounts").Start(ctx, "storage.initGCSClient")
-		defer span.End()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-		var opts []option.ClientOption
-		if s.cfg.EmulatorEnabled {
-			_ = os.Setenv("STORAGE_EMULATOR_HOST", s.cfg.EmulatorEndpoint)
-		}
-		if s.cfg.IsLocal {
-			opts = append(opts, option.WithoutAuthentication())
-		}
-		// Use a non-cancelable context so a canceled caller doesn't permanently latch initErr.
-		s.gcsClient, s.initErr = storage.NewClient(context.WithoutCancel(ctx), opts...)
-		if s.initErr != nil {
-			span.RecordError(s.initErr)
-			span.SetStatus(codes.Error, "GCS client initialization failed")
-		}
-	})
-	if s.initErr != nil {
-		return nil, s.initErr
+	if s.gcsClient != nil {
+		return s.gcsClient.Bucket(s.cfg.BucketName), nil
 	}
+
+	_, span := otel.Tracer("reearth-accounts").Start(ctx, "storage.initGCSClient")
+	defer span.End()
+
+	var opts []option.ClientOption
+	if s.cfg.EmulatorEnabled {
+		_ = os.Setenv("STORAGE_EMULATOR_HOST", s.cfg.EmulatorEndpoint)
+	}
+	if s.cfg.IsLocal {
+		opts = append(opts, option.WithoutAuthentication())
+	}
+	// Use a non-cancelable context so a canceled caller doesn't abort init on
+	// behalf of other callers waiting on s.mu.
+	client, err := storage.NewClient(context.WithoutCancel(ctx), opts...)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "GCS client initialization failed")
+		// Deliberately not cached: an unset s.gcsClient makes the next call
+		// retry init instead of failing forever on a transient error (e.g. a
+		// metadata-server blip during ADC lookup).
+		return nil, err
+	}
+
+	s.gcsClient = client
 	return s.gcsClient.Bucket(s.cfg.BucketName), nil
 }
 

--- a/server/internal/infrastructure/storage/storage_test.go
+++ b/server/internal/infrastructure/storage/storage_test.go
@@ -3,8 +3,14 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -460,9 +466,61 @@ func TestStorage_bucket(t *testing.T) {
 		assert.NoError(t, err2)
 		assert.NotNil(t, bucket2)
 
-		// The GCS client should be reused (sync.Once guarantees single initialization)
+		// The GCS client should be reused once initialization succeeds.
 		assert.Same(t, firstClient, s.gcsClient)
 	})
+
+	t.Run("should retry initialization after a transient failure instead of latching it", func(t *testing.T) {
+		// An earlier subtest sets STORAGE_EMULATOR_HOST via os.Setenv without
+		// clearing it, which would otherwise let the client construct
+		// successfully against the emulator regardless of credentials.
+		t.Setenv("STORAGE_EMULATOR_HOST", "")
+
+		credPath := filepath.Join(t.TempDir(), "adc.json")
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credPath)
+
+		cfg := &Config{BucketName: "test-bucket"}
+		s := &Storage{cfg: cfg}
+
+		// First call: no credentials file yet, so client init fails.
+		bucket, err := s.bucket(context.Background())
+		assert.Error(t, err)
+		assert.Nil(t, bucket)
+		assert.Nil(t, s.gcsClient)
+
+		// Second call: the transient condition has cleared, so init must be
+		// retried (not fail forever because of the earlier attempt).
+		require.NoError(t, os.WriteFile(credPath, fakeServiceAccountJSON(t), 0o600))
+		bucket, err = s.bucket(context.Background())
+		assert.NoError(t, err)
+		assert.NotNil(t, bucket)
+		assert.NotNil(t, s.gcsClient)
+	})
+}
+
+// fakeServiceAccountJSON returns a syntactically valid GCP service-account
+// key so storage.NewClient can parse credentials locally without any network
+// access.
+func fakeServiceAccountJSON(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pemKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	b, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "test-project",
+		"private_key":  string(pemKey),
+		"client_email": "test@test-project.iam.gserviceaccount.com",
+		"token_uri":    "https://oauth2.googleapis.com/token",
+	})
+	require.NoError(t, err)
+	return b
 }
 
 func newTestStorage(cfg *Config) *Storage {


### PR DESCRIPTION
## Overview

Addresses REL-03 from the ai-scan reliability report (eukarya-inc/compliance#100).

## What I've done

`Storage.bucket()` initialized the GCS client inside a `sync.Once`, caching both the client and any init error (`s.initErr`) for the lifetime of the process. A prior fix guarded against a canceled caller context permanently latching that error (`context.WithoutCancel`), but any *other* transient failure during `storage.NewClient` — a metadata-server 5xx or DNS blip while resolving ADC — still latched forever, since `sync.Once.Do` only runs its function once regardless of outcome.

User-visible impact matched the report: the `Me` GraphQL query hard-fails for every user with an avatar once this happens (`resolver_query.go` propagates the signed-URL error instead of degrading), and it stays broken for the rest of that pod's life.

Replaced `sync.Once` + `initErr` with a `sync.Mutex` guarding a cached `*storage.Client`:
- On success, the client is cached and reused by all future calls (same behavior as before).
- On failure, nothing is cached — the next call to `bucket()` retries initialization from scratch, holding the mutex for the duration of the attempt (so concurrent callers still serialize instead of firing duplicate `NewClient` calls).

## What I haven't done

Did not add backoff/jitter between retries — a failed call now simply lets the *next* caller retry immediately, which is bounded by natural request rate rather than a timer. Happy to add explicit backoff if repeated hammering during a real outage is a concern.

## How I tested

- `go build ./...`, `go vet ./...`
- `go test ./internal/infrastructure/storage/...` (existing suite requires `GOOGLE_APPLICATION_CREDENTIALS` pointing at valid-looking credentials to exercise the success path locally; same requirement as before this change)
- Added a new subtest, `should retry initialization after a transient failure instead of latching it`: points `GOOGLE_APPLICATION_CREDENTIALS` at a not-yet-existing file (forcing the first `bucket()` call to fail and confirming `s.gcsClient` stays nil), then writes a valid fake service-account key and confirms the *second* call succeeds — which would have failed forever under the old `sync.Once` behavior.

## Which point I want you to review particularly

Whether holding the mutex for the full `storage.NewClient` duration (a blocking call) is acceptable here, versus a narrower critical section — I chose the simple version since it mirrors the original `sync.Once` semantics (concurrent callers block on the single in-flight init) and this path is already the cold/rare one.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values