### PR TITLE
fix(server): warn loudly when Mongo transactions are unavailable

### DIFF
--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/reearth/reearth-accounts/server/internal/infrastructure/auth0"
@@ -70,7 +71,10 @@ func initPostgresReposAndGateways(ctx context.Context, pool *pgxpool.Pool, conf 
 }
 
 func initReposAndGateways(ctx context.Context, client *mongo.Client, conf *Config) (*repo.Container, *gateway.Container) {
-	txAvailable := mongox.IsTransactionAvailable(conf.DB)
+	txAvailable := mongoTransactionsAvailable(conf.DB)
+	if !txAvailable {
+		log.Warnf("mongo: multi-document transactions are unavailable for %s; multi-step writes such as signup will not be rolled back atomically on a mid-sequence failure", redactMongoURI(conf.DB))
+	}
 
 	repos, err := mongorepo.New(ctx, client.Database(conf.DBName), txAvailable, false, []user.Repo{})
 	if err != nil {
@@ -78,4 +82,36 @@ func initReposAndGateways(ctx context.Context, client *mongo.Client, conf *Confi
 	}
 
 	return repos, initGateways(ctx, conf)
+}
+
+// mongoTransactionsAvailable reports whether the driver can start real
+// multi-document transactions against dbURI. mongox.IsTransactionAvailable
+// only recognizes mongodb+srv:// or a mongodb:// URI with a comma-separated
+// host list, so it misclassifies a single-host mongodb:// URI that carries a
+// replicaSet query parameter -- a legitimate transaction-capable topology,
+// since the driver discovers the other replica set members on connect. We OR
+// that case in here rather than changing the vendored predicate.
+func mongoTransactionsAvailable(dbURI string) bool {
+	// Parse first and bail out on failure: mongox.IsTransactionAvailable
+	// ignores its own url.Parse error and dereferences the nil *url.URL,
+	// panicking on unparseable input.
+	u, err := url.Parse(dbURI)
+	if err != nil {
+		return false
+	}
+	if mongox.IsTransactionAvailable(dbURI) {
+		return true
+	}
+	return u.Query().Get("replicaSet") != ""
+}
+
+// redactMongoURI strips userinfo (username/password) from a Mongo connection
+// string before it's put in a log line.
+func redactMongoURI(dbURI string) string {
+	u, err := url.Parse(dbURI)
+	if err != nil {
+		return "(unparseable)"
+	}
+	u.User = nil
+	return u.String()
 }

--- a/server/internal/app/repo_test.go
+++ b/server/internal/app/repo_test.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMongoTransactionsAvailable(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		{name: "srv scheme", uri: "mongodb+srv://cluster0.example.mongodb.net/db", want: true},
+		{name: "comma-separated hosts", uri: "mongodb://host1:27017,host2:27017/db", want: true},
+		{name: "single host with replicaSet param", uri: "mongodb://mongo:27017/db?replicaSet=rs0", want: true},
+		{name: "single host, no replicaSet param", uri: "mongodb://localhost:27017/db", want: false},
+		{name: "unparseable", uri: "://not a uri", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mongoTransactionsAvailable(tt.uri))
+		})
+	}
+}
+
+func TestRedactMongoURI(t *testing.T) {
+	got := redactMongoURI("mongodb://user:pass@localhost:27017/db?replicaSet=rs0")
+	assert.NotContains(t, got, "user")
+	assert.NotContains(t, got, "pass")
+	assert.Contains(t, got, "localhost:27017")
+
+	assert.Equal(t, "(unparseable)", redactMongoURI("://not a uri"))
+}


### PR DESCRIPTION
## Overview

Addresses REL-02 from the ai-scan reliability report (eukarya-inc/compliance#100).

## What I've done

`initReposAndGateways` decides whether to wire a real Mongo transaction with `mongox.IsTransactionAvailable(conf.DB)`, silently falling back to `usecasex.NopTransaction` (which `DoTransaction` treats as a successful commit) when it returns false. That predicate only recognizes `mongodb+srv://` or a `mongodb://` URI with a comma-separated host list.

Two problems:
1. **No diagnostic.** When it falls back, nothing is logged, so multi-step writes like `User.Signup`'s `Create -> Workspace.Save -> Permittable.Save` silently run non-atomically. A mid-sequence failure (duplicate alias, write-concern timeout, primary stepdown) leaves a committed user with no workspace/permittable, and re-signup is rejected as already-existing — requiring manual DB surgery, with no signal at startup that this was even possible.
2. **Misclassification.** A single-host `mongodb://mongo:27017/?replicaSet=rs0` URI — a legitimate transaction-capable topology, since the driver discovers the other replica set members on connect — is treated the same as a genuinely standalone instance.

Added `mongoTransactionsAvailable`, which:
- ORs in a check for a `replicaSet` query parameter, closing the misclassification.
- Parses the URI itself first and bails out on a parse failure *before* calling the vendored predicate — that predicate ignores its own `url.Parse` error and dereferences the resulting nil `*url.URL`, which panics on unparseable input.

`initReposAndGateways` now logs a `log.Warnf` when it ends up without real transactions, with credentials stripped from the URI via a new `redactMongoURI` helper.

## What I haven't done

Did not change the vendored `mongox.IsTransactionAvailable` predicate itself (external dependency in `reearthx`) — this ORs in the missing case locally instead. Also didn't change `usecasex.NopTransaction`'s "commit" semantics; that's a much larger behavioral change outside this repo.

## How I tested

- `go build ./...`, `go vet ./...`
- Added `TestMongoTransactionsAvailable` (srv scheme, comma hosts, single-host+replicaSet, single-host without it, and unparseable input) and `TestRedactMongoURI` (credentials stripped, unparseable input handled).
- `go test ./internal/app/...` passes; the unparseable-input case reproduces and then confirms the fix for the vendored-predicate panic.

## Which point I want you to review particularly

Whether logging at `Warn` (vs. `Error` or even refusing to start) is the right severity for a production deployment that's inadvertently running without transactional signup — happy to escalate if that's preferred.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values