### PR TITLE
fix(server): cap workspace fetch-by-IDs and fix quadratic FilterByID

### DIFF
--- a/server/internal/adapter/http/internal/error_handler.go
+++ b/server/internal/adapter/http/internal/error_handler.go
@@ -119,7 +119,8 @@ func mapError(err error) *ErrorResponse {
 		errors.Is(err, interfaces.ErrUserInvalidLang),
 		errors.Is(err, interfaces.ErrSignupInvalidSecret),
 		errors.Is(err, interfaces.ErrInvalidPhotoURL),
-		errors.Is(err, interfaces.ErrNotVerifiedUser):
+		errors.Is(err, interfaces.ErrNotVerifiedUser),
+		errors.Is(err, interfaces.ErrTooManyWorkspaceIDs):
 		return &ErrorResponse{Status: http.StatusBadRequest, Message: "bad request", Description: err.Error(), Err: err}
 	default:
 		return &ErrorResponse{Status: http.StatusInternalServerError, Message: "internal server error", Description: "an unexpected error occurred", Err: err}

--- a/server/internal/usecase/interactor/workspace.go
+++ b/server/internal/usecase/interactor/workspace.go
@@ -23,6 +23,10 @@ import (
 	"github.com/samber/lo"
 )
 
+// maxFetchWorkspaceIDs caps a single Fetch-by-IDs call, matching the admin
+// API's existing per-request ID limit (internal/admin/.../handler_list.go).
+const maxFetchWorkspaceIDs = 100
+
 type WorkspaceMemberCountEnforcer func(context.Context, *workspace.Workspace, user.List, *workspace.Operator) error
 
 type Workspace struct {
@@ -55,6 +59,9 @@ func NewWorkspace(r *repo.Container, enforceMemberCount WorkspaceMemberCountEnfo
 // layer must not require operator-based filtering. Any unauthenticated usage
 // must ensure that only the intended workspace fields are exposed by a higher layer.
 func (i *Workspace) Fetch(ctx context.Context, ids workspace.IDList, operator *workspace.Operator) (workspace.List, error) {
+	if len(ids) > maxFetchWorkspaceIDs {
+		return nil, interfaces.ErrTooManyWorkspaceIDs
+	}
 	return i.repos.Workspace.FindByIDs(ctx, ids)
 }
 

--- a/server/internal/usecase/interactor/workspace_test.go
+++ b/server/internal/usecase/interactor/workspace_test.go
@@ -635,6 +635,21 @@ func TestWorkspace_Fetch(t *testing.T) {
 	}
 }
 
+func TestWorkspace_Fetch_TooManyIDs(t *testing.T) {
+	ctx := context.Background()
+	db := memory.New()
+	workspaceUC := NewWorkspace(db, nil, nil)
+
+	ids := make([]workspace.ID, maxFetchWorkspaceIDs+1)
+	for i := range ids {
+		ids[i] = id.NewWorkspaceID()
+	}
+
+	got, err := workspaceUC.Fetch(ctx, ids, &workspace.Operator{})
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, interfaces.ErrTooManyWorkspaceIDs)
+}
+
 func TestWorkspace_FindByUser(t *testing.T) {
 	userID := id.NewUserID()
 	id1 := id.NewWorkspaceID()

--- a/server/internal/usecase/interfaces/workspace.go
+++ b/server/internal/usecase/interfaces/workspace.go
@@ -15,8 +15,9 @@ var (
 	ErrCannotDeleteWorkspace        = rerror.NewE(i18n.T("cannot delete workspace because at least one project is left"))
 	ErrCannotSelfPromote            = rerror.NewE(i18n.T("cannot promote own role to a higher level"))
 	ErrOwnerCannotLeaveTheWorkspace = rerror.NewE(i18n.T("owner user cannot leave from the workspace"))
-	ErrWorkspaceWithProjects        = rerror.NewE(i18n.T("target workspace still has some project"))
 	ErrPermissionDenied             = rerror.NewE(i18n.T("permission denied"))
+	ErrTooManyWorkspaceIDs          = rerror.NewE(i18n.T("too many workspace ids requested"))
+	ErrWorkspaceWithProjects        = rerror.NewE(i18n.T("target workspace still has some project"))
 )
 
 type FetchByUserWithPaginationParam struct {

--- a/server/pkg/workspace/workspace_list.go
+++ b/server/pkg/workspace/workspace_list.go
@@ -9,17 +9,15 @@ func (l List) FilterByID(ids ...ID) List {
 		return nil
 	}
 
-	res := make(List, 0, len(l))
+	byID := make(map[ID]*Workspace, len(l))
+	for _, t := range l {
+		byID[t.ID()] = t
+	}
+
+	res := make(List, 0, len(ids))
 	for _, id := range ids {
-		var t2 *Workspace
-		for _, t := range l {
-			if t.ID() == id {
-				t2 = t
-				break
-			}
-		}
-		if t2 != nil {
-			res = append(res, t2)
+		if t, ok := byID[id]; ok {
+			res = append(res, t)
 		}
 	}
 	return res

--- a/server/pkg/workspace/workspace_list_test.go
+++ b/server/pkg/workspace/workspace_list_test.go
@@ -18,6 +18,12 @@ func TestWorkspaceList_FilterByID(t *testing.T) {
 	assert.Equal(t, List{t1, t2}, List{t1, t2}.FilterByID(tid1, tid2))
 	assert.Equal(t, List{}, List{t1, t2}.FilterByID(NewID()))
 	assert.Equal(t, List(nil), List(nil).FilterByID(tid1))
+
+	// Result order follows the requested id order, not list order.
+	assert.Equal(t, List{t2, t1}, List{t1, t2}.FilterByID(tid2, tid1))
+
+	// A repeated id in the request repeats in the result.
+	assert.Equal(t, List{t1, t1}, List{t1, t2}.FilterByID(tid1, tid1))
 }
 
 func TestWorkspaceList_FilterByUserRole(t *testing.T) {


### PR DESCRIPTION
## Overview

Addresses SCA-02 from the ai-scan scalability report (eukarya-inc/compliance#100).

## What I've done

`workspace.List.FilterByID` was a nested loop (O(N×M): N = ids requested, M = rows already fetched), called by both `mongo.Workspace.FindByIDs` and `postgres.Workspace.FindByIDs`. Its callers -- the GraphQL `findByIds` resolver and the REST `GET /api/workspaces?ids=` endpoint, both routed through `interactor.Workspace.Fetch` -- applied no cap on the caller-supplied ID list, unlike the equivalent user-lookup path (`mongo/user.go`, a map lookup) and the admin API (`internal/admin/.../handler_list.go`, capped at 100 IDs). A single request with, say, 40k IDs costs ~1.6×10^9 pointer comparisons and burns seconds of CPU while holding a request slot -- amplified further downstream by `buildExistingUserSetFromWorkspaces`, which fetches every member of every returned workspace in one `$in` query.

Two changes:
1. `FilterByID` now builds a `map[ID]*Workspace` from the existing list once, then does O(M) map lookups for the requested ids -- O(N+M) instead of O(N×M). Result order still follows the *requested* id order (not list order), and requesting the same id twice still repeats it in the result -- both preserved exactly to avoid changing behavior for existing callers.
2. `Workspace.Fetch` (the single interactor method both the GraphQL resolver and the REST handler go through) now caps the incoming ID list at 100, matching the admin API's existing limit, returning a new `interfaces.ErrTooManyWorkspaceIDs` rather than accepting an unbounded list. Mapped to HTTP 400 on the REST error-handling path; on GraphQL it surfaces as a normal resolver error.

## What I haven't done

Did not add pagination or a "you have more than 100, use pagination instead" hint to the response -- just a flat cap with a clear error, matching the admin API's existing behavior for the same limit.

## How I tested

- `go build ./...`, `go vet ./...`
- Extended `TestWorkspaceList_FilterByID` with cases for requested-order-not-list-order and repeated-id-repeats-in-result, to lock in the exact behavior the rewrite must preserve.
- Added `TestWorkspace_Fetch_TooManyIDs`.
- `go test ./pkg/workspace/... ./internal/usecase/interactor/... ./internal/adapter/http/... ./internal/adapter/gql/...` all pass.

## Which point I want you to review particularly

Whether 100 is the right cap for this specific endpoint (vs. the admin API's use case) -- happy to make it configurable if 100 is too low for a legitimate bulk caller.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values