### PR TITLE
fix(server): bulk-insert PostgreSQL workspace members and integrations

### DIFF
--- a/server/internal/infrastructure/postgres/pgdoc/workspace.go
+++ b/server/internal/infrastructure/postgres/pgdoc/workspace.go
@@ -19,20 +19,25 @@ type WorkspaceMetadataJSON struct {
 	PhotoURL     string `json:"photourl"`
 }
 
+// json tags match the column names in the WorkspaceMembersInsertBulk sqlc
+// query's jsonb_to_recordset(...) AS t(...) clause, which are matched
+// case-sensitively against these keys.
 type WorkspaceMemberRow struct {
-	WorkspaceID string
-	UserID      string
-	Role        string
-	InvitedBy   string
-	Disabled    bool
+	WorkspaceID string `json:"workspace_id"`
+	UserID      string `json:"user_id"`
+	Role        string `json:"role"`
+	InvitedBy   string `json:"invited_by"`
+	Disabled    bool   `json:"disabled"`
 }
 
+// json tags match WorkspaceIntegrationsInsertBulk's jsonb_to_recordset(...)
+// AS t(...) clause; see WorkspaceMemberRow.
 type WorkspaceIntegrationRow struct {
-	WorkspaceID   string
-	IntegrationID string
-	Role          string
-	InvitedBy     string
-	Disabled      bool
+	WorkspaceID   string `json:"workspace_id"`
+	IntegrationID string `json:"integration_id"`
+	Role          string `json:"role"`
+	InvitedBy     string `json:"invited_by"`
+	Disabled      bool   `json:"disabled"`
 }
 
 type WorkspaceRow struct {

--- a/server/internal/infrastructure/postgres/sqlc/gen/querier.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/querier.go
@@ -64,9 +64,18 @@ type Querier interface {
 	WorkspaceIntegrationInsert(ctx context.Context, arg WorkspaceIntegrationInsertParams) error
 	WorkspaceIntegrationsByWorkspaceIDs(ctx context.Context, dollar_1 []string) ([]WorkspaceIntegration, error)
 	WorkspaceIntegrationsDeleteByWorkspace(ctx context.Context, workspaceID string) error
+	// One round-trip for any number of integration members, instead of one
+	// WorkspaceIntegrationInsert per integration. See WorkspaceMembersInsertBulk
+	// for why jsonb_to_recordset is used over a multi-arg unnest.
+	WorkspaceIntegrationsInsertBulk(ctx context.Context, dollar_1 []byte) error
 	WorkspaceMemberInsert(ctx context.Context, arg WorkspaceMemberInsertParams) error
 	WorkspaceMembersByWorkspaceIDs(ctx context.Context, dollar_1 []string) ([]WorkspaceMember, error)
 	WorkspaceMembersDeleteByWorkspace(ctx context.Context, workspaceID string) error
+	// One round-trip for any number of members, instead of one
+	// WorkspaceMemberInsert per member. jsonb_to_recordset takes a single
+	// parameter (rather than one array per column, as a multi-arg unnest would),
+	// which sqlc's static catalog can type-check without a live database.
+	WorkspaceMembersInsertBulk(ctx context.Context, dollar_1 []byte) error
 	WorkspaceUpsert(ctx context.Context, arg WorkspaceUpsertParams) error
 }
 

--- a/server/internal/infrastructure/postgres/sqlc/gen/workspace.sql.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/workspace.sql.go
@@ -337,6 +337,21 @@ func (q *Queries) WorkspaceIntegrationsDeleteByWorkspace(ctx context.Context, wo
 	return err
 }
 
+const workspaceIntegrationsInsertBulk = `-- name: WorkspaceIntegrationsInsertBulk :exec
+INSERT INTO workspace_integrations (workspace_id, integration_id, role, invited_by, disabled)
+SELECT workspace_id, integration_id, role, invited_by, disabled
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(workspace_id text, integration_id text, role text, invited_by text, disabled bool)
+`
+
+// One round-trip for any number of integration members, instead of one
+// WorkspaceIntegrationInsert per integration. See WorkspaceMembersInsertBulk
+// for why jsonb_to_recordset is used over a multi-arg unnest.
+func (q *Queries) WorkspaceIntegrationsInsertBulk(ctx context.Context, dollar_1 []byte) error {
+	_, err := q.db.Exec(ctx, workspaceIntegrationsInsertBulk, dollar_1)
+	return err
+}
+
 const workspaceMemberInsert = `-- name: WorkspaceMemberInsert :exec
 INSERT INTO workspace_members (workspace_id, user_id, role, invited_by, disabled) VALUES ($1,$2,$3,$4,$5)
 `
@@ -396,6 +411,22 @@ DELETE FROM workspace_members WHERE workspace_id = $1
 
 func (q *Queries) WorkspaceMembersDeleteByWorkspace(ctx context.Context, workspaceID string) error {
 	_, err := q.db.Exec(ctx, workspaceMembersDeleteByWorkspace, workspaceID)
+	return err
+}
+
+const workspaceMembersInsertBulk = `-- name: WorkspaceMembersInsertBulk :exec
+INSERT INTO workspace_members (workspace_id, user_id, role, invited_by, disabled)
+SELECT workspace_id, user_id, role, invited_by, disabled
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(workspace_id text, user_id text, role text, invited_by text, disabled bool)
+`
+
+// One round-trip for any number of members, instead of one
+// WorkspaceMemberInsert per member. jsonb_to_recordset takes a single
+// parameter (rather than one array per column, as a multi-arg unnest would),
+// which sqlc's static catalog can type-check without a live database.
+func (q *Queries) WorkspaceMembersInsertBulk(ctx context.Context, dollar_1 []byte) error {
+	_, err := q.db.Exec(ctx, workspaceMembersInsertBulk, dollar_1)
 	return err
 }
 

--- a/server/internal/infrastructure/postgres/sqlc/queries/workspace.sql
+++ b/server/internal/infrastructure/postgres/sqlc/queries/workspace.sql
@@ -41,6 +41,16 @@ DELETE FROM workspace_members WHERE workspace_id = $1;
 -- name: WorkspaceMemberInsert :exec
 INSERT INTO workspace_members (workspace_id, user_id, role, invited_by, disabled) VALUES ($1,$2,$3,$4,$5);
 
+-- name: WorkspaceMembersInsertBulk :exec
+-- One round-trip for any number of members, instead of one
+-- WorkspaceMemberInsert per member. jsonb_to_recordset takes a single
+-- parameter (rather than one array per column, as a multi-arg unnest would),
+-- which sqlc's static catalog can type-check without a live database.
+INSERT INTO workspace_members (workspace_id, user_id, role, invited_by, disabled)
+SELECT workspace_id, user_id, role, invited_by, disabled
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(workspace_id text, user_id text, role text, invited_by text, disabled bool);
+
 -- name: WorkspaceMembersByWorkspaceIDs :many
 SELECT * FROM workspace_members WHERE workspace_id = ANY($1::text[]);
 
@@ -49,6 +59,15 @@ DELETE FROM workspace_integrations WHERE workspace_id = $1;
 
 -- name: WorkspaceIntegrationInsert :exec
 INSERT INTO workspace_integrations (workspace_id, integration_id, role, invited_by, disabled) VALUES ($1,$2,$3,$4,$5);
+
+-- name: WorkspaceIntegrationsInsertBulk :exec
+-- One round-trip for any number of integration members, instead of one
+-- WorkspaceIntegrationInsert per integration. See WorkspaceMembersInsertBulk
+-- for why jsonb_to_recordset is used over a multi-arg unnest.
+INSERT INTO workspace_integrations (workspace_id, integration_id, role, invited_by, disabled)
+SELECT workspace_id, integration_id, role, invited_by, disabled
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(workspace_id text, integration_id text, role text, invited_by text, disabled bool);
 
 -- name: WorkspaceIntegrationsByWorkspaceIDs :many
 SELECT * FROM workspace_integrations WHERE workspace_id = ANY($1::text[]);

--- a/server/internal/infrastructure/postgres/workspace.go
+++ b/server/internal/infrastructure/postgres/workspace.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
@@ -249,20 +250,24 @@ func (r *Workspace) save(ctx context.Context, ws *workspace.Workspace) error {
 		if err := q.WorkspaceMembersDeleteByWorkspace(ctx, row.ID); err != nil {
 			return rerror.ErrInternalByWithContext(ctx, err)
 		}
-		for _, m := range members {
-			if err := q.WorkspaceMemberInsert(ctx, gen.WorkspaceMemberInsertParams{
-				WorkspaceID: m.WorkspaceID, UserID: m.UserID, Role: m.Role, InvitedBy: m.InvitedBy, Disabled: m.Disabled,
-			}); err != nil {
+		if len(members) > 0 {
+			payload, err := json.Marshal(members)
+			if err != nil {
+				return rerror.ErrInternalByWithContext(ctx, err)
+			}
+			if err := q.WorkspaceMembersInsertBulk(ctx, payload); err != nil {
 				return rerror.ErrInternalByWithContext(ctx, err)
 			}
 		}
 		if err := q.WorkspaceIntegrationsDeleteByWorkspace(ctx, row.ID); err != nil {
 			return rerror.ErrInternalByWithContext(ctx, err)
 		}
-		for _, m := range integrations {
-			if err := q.WorkspaceIntegrationInsert(ctx, gen.WorkspaceIntegrationInsertParams{
-				WorkspaceID: m.WorkspaceID, IntegrationID: m.IntegrationID, Role: m.Role, InvitedBy: m.InvitedBy, Disabled: m.Disabled,
-			}); err != nil {
+		if len(integrations) > 0 {
+			payload, err := json.Marshal(integrations)
+			if err != nil {
+				return rerror.ErrInternalByWithContext(ctx, err)
+			}
+			if err := q.WorkspaceIntegrationsInsertBulk(ctx, payload); err != nil {
 				return rerror.ErrInternalByWithContext(ctx, err)
 			}
 		}

--- a/server/internal/infrastructure/postgres/workspace_save_members_test.go
+++ b/server/internal/infrastructure/postgres/workspace_save_members_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	"github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkspace_Save_MembersBulkInsert exercises the WorkspaceMembersInsertBulk
+// / WorkspaceIntegrationsInsertBulk path (SCA-03): saving a workspace with
+// several members and integrations, then round-tripping it through a real
+// Postgres to catch anything a static sqlc type-check can't (jsonb key casing,
+// jsonb_to_recordset column matching, etc).
+func TestWorkspace_Save_MembersBulkInsert(t *testing.T) {
+	pool, cleanup := pgPool(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewWorkspace(NewClient(pool))
+
+	ownerID := id.NewUserID()
+	writerID := id.NewUserID()
+	readerID := id.NewUserID()
+	iid := id.NewIntegrationID()
+
+	ws := workspace.New().NewID().Name("bulk-insert-corp").Alias("bulk-insert-corp").
+		Members(map[user.ID]workspace.Member{
+			ownerID:  {Role: role.RoleOwner, InvitedBy: ownerID},
+			writerID: {Role: role.RoleWriter, InvitedBy: ownerID},
+			readerID: {Role: role.RoleReader, InvitedBy: ownerID, Disabled: true},
+		}).
+		Integrations(map[id.IntegrationID]workspace.Member{
+			iid: {Role: role.RoleMaintainer, InvitedBy: ownerID},
+		}).
+		MustBuild()
+
+	require.NoError(t, r.Create(ctx, ws))
+
+	got, err := r.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, role.RoleOwner, got.Members().UserRole(ownerID))
+	assert.Equal(t, role.RoleWriter, got.Members().UserRole(writerID))
+	assert.Equal(t, role.RoleReader, got.Members().UserRole(readerID))
+	if m := got.Members().User(readerID); assert.NotNil(t, m) {
+		assert.True(t, m.Disabled)
+	}
+	assert.Equal(t, role.RoleMaintainer, got.Members().IntegrationRole(iid))
+
+	// Save again with a changed member set: exercises the delete-then-bulk-
+	// insert path with a different row count than the original insert.
+	require.NoError(t, got.Members().Leave(readerID))
+	require.NoError(t, r.Save(ctx, got))
+
+	reloaded, err := r.FindByID(ctx, ws.ID())
+	require.NoError(t, err)
+	assert.Equal(t, role.RoleOwner, reloaded.Members().UserRole(ownerID))
+	assert.Equal(t, role.RoleWriter, reloaded.Members().UserRole(writerID))
+	assert.False(t, reloaded.Members().HasUser(readerID))
+	assert.Equal(t, role.RoleMaintainer, reloaded.Members().IntegrationRole(iid))
+}


### PR DESCRIPTION
## Overview

Addresses SCA-03 from the ai-scan scalability report (eukarya-inc/compliance#100).

## What I've done

`Workspace.save` deleted all `workspace_members`/`workspace_integrations` rows for a workspace and re-inserted them with a separate `WorkspaceMemberInsert`/`WorkspaceIntegrationInsert` statement per row, inside one transaction. Cost was O(current member count) per write regardless of how small the change was -- renaming a workspace or adding one member to a 1,000-member workspace issued 1,000+ sequential round-trips while holding the workspace row lock for the whole transaction. `SaveAll` multiplies this by the number of workspaces (e.g. `DeleteMe` saves every workspace the user belonged to), so a single request could hold a write transaction across tens of thousands of statements.

Added `WorkspaceMembersInsertBulk` / `WorkspaceIntegrationsInsertBulk` sqlc queries that insert any number of rows in one round-trip:

```sql
INSERT INTO workspace_members (workspace_id, user_id, role, invited_by, disabled)
SELECT workspace_id, user_id, role, invited_by, disabled
  FROM jsonb_to_recordset($1::jsonb)
  AS t(workspace_id text, user_id text, role text, invited_by text, disabled bool);
```

I initially tried the more common `unnest($1::text[], $2::text[], ...)` multi-array pattern, but sqlc's static catalog (this repo's `sqlc.yaml` type-checks against a schema file, not a live database) doesn't have that overload of `unnest` registered and fails to generate. `jsonb_to_recordset` takes a single `jsonb` parameter and sqlc resolves it fine without a live DB. One footgun found along the way: writing the query as `SELECT * FROM jsonb_to_recordset(...) AS t(...)` gets normalized by sqlc into `SELECT t FROM ...`, which would insert the whole composite value as a single column instead of expanding it -- fixed by listing the columns explicitly instead of `*`.

`Workspace.save` now marshals the member/integration rows to JSON and calls the bulk query once instead of looping. `WorkspaceMemberRow`/`WorkspaceIntegrationRow` gained explicit `json` tags matching the `jsonb_to_recordset` column list, since that function matches JSON object keys case-sensitively and the untagged struct fields would otherwise serialize as PascalCase (`WorkspaceID`, not `workspace_id`), which wouldn't match the column names and would silently insert NULLs.

## What I haven't done

Did not touch `SCA-04` (the `Permittable.SaveMany` per-item loop) -- separate PR incoming for that.

## How I tested

- `go build ./...`, `go build -tags integration ./...`, `go vet ./...`
- `go test ./internal/infrastructure/postgres/...` (unit-level, no DB) passes.
- Added `TestWorkspace_Save_MembersBulkInsert` (build-tag `integration`, runs against a real Postgres via testcontainers in CI's `ci-server-integration` job): creates a workspace with 3 members (owner/writer/disabled-reader) and 1 integration member, round-trips it through `FindByID` to confirm the bulk insert lands correctly with the right roles/disabled flags, then saves again with a member removed to exercise the delete-then-bulk-insert path with a different row count.
- I don't have a working local Docker/testcontainers setup in this environment, so I could not run the integration test myself -- deferring to CI's `ci-server-integration` job, which runs `go test -tags integration` against real Postgres and Mongo containers, to validate the actual SQL against a live database. Flagging this explicitly since it's new SQL that a static sqlc type-check alone doesn't fully validate (e.g. the JSON key casing issue above was only caught by reasoning through `jsonb_to_recordset`'s matching semantics, not by a compiler).

## Which point I want you to review particularly

Please have CI's integration job confirm `TestWorkspace_Save_MembersBulkInsert` actually passes against real Postgres before merging -- I'm fairly confident in the `jsonb_to_recordset` semantics but this is exactly the kind of thing that's worth a real DB checking rather than my reasoning alone.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values