### PR TITLE
fix(server): bulk-insert PostgreSQL permittable workspace roles

### DIFF
--- a/server/internal/infrastructure/postgres/permittable.go
+++ b/server/internal/infrastructure/postgres/permittable.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/jackc/pgx/v5"
@@ -110,10 +111,17 @@ func (r *Permittable) Save(ctx context.Context, p permittable.Permittable) error
 		if err := q.PermittableWorkspaceRolesDeleteByPermittable(ctx, pid); err != nil {
 			return rerror.ErrInternalByWithContext(ctx, err)
 		}
-		for _, wr := range wrs {
-			if err := q.PermittableWorkspaceRoleInsert(ctx, gen.PermittableWorkspaceRoleInsertParams{
-				PermittableID: pid, WorkspaceID: wr.WorkspaceID, RoleID: wr.RoleID,
-			}); err != nil {
+		if len(wrs) > 0 {
+			// pid is the row's actual DB id, which ON CONFLICT may have kept as
+			// the pre-existing id rather than p.ID(); every role must use it.
+			for i := range wrs {
+				wrs[i].PermittableID = pid
+			}
+			payload, err := json.Marshal(wrs)
+			if err != nil {
+				return rerror.ErrInternalByWithContext(ctx, err)
+			}
+			if err := q.PermittableWorkspaceRolesInsertBulk(ctx, payload); err != nil {
 				return rerror.ErrInternalByWithContext(ctx, err)
 			}
 		}

--- a/server/internal/infrastructure/postgres/permittable_save_test.go
+++ b/server/internal/infrastructure/postgres/permittable_save_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/permittable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPermittable_Save_WorkspaceRolesBulkInsert exercises the
+// PermittableWorkspaceRolesInsertBulk path (SCA-04): saving a permittable
+// with several workspace roles, then round-tripping it through a real
+// Postgres to catch anything a static sqlc type-check can't (jsonb key
+// casing, jsonb_to_recordset column matching, etc).
+func TestPermittable_Save_WorkspaceRolesBulkInsert(t *testing.T) {
+	pool, cleanup := pgPool(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewPermittable(NewClient(pool))
+
+	uid := id.NewUserID()
+	rid := id.NewRoleID()
+	wid1 := id.NewWorkspaceID()
+	wid2 := id.NewWorkspaceID()
+	wid3 := id.NewWorkspaceID()
+
+	p := permittable.New().NewID().UserID(uid).RoleIDs([]id.RoleID{rid}).
+		WorkspaceRoles([]permittable.WorkspaceRole{
+			permittable.NewWorkspaceRole(wid1, rid),
+			permittable.NewWorkspaceRole(wid2, rid),
+			permittable.NewWorkspaceRole(wid3, rid),
+		}).MustBuild()
+
+	require.NoError(t, r.Save(ctx, *p))
+
+	got, err := r.FindByUserID(ctx, uid)
+	require.NoError(t, err)
+
+	gotWorkspaceIDs := make(map[id.WorkspaceID]struct{}, len(got.WorkspaceRoles()))
+	for _, wr := range got.WorkspaceRoles() {
+		gotWorkspaceIDs[wr.ID()] = struct{}{}
+	}
+	assert.Len(t, got.WorkspaceRoles(), 3)
+	assert.Contains(t, gotWorkspaceIDs, wid1)
+	assert.Contains(t, gotWorkspaceIDs, wid2)
+	assert.Contains(t, gotWorkspaceIDs, wid3)
+
+	// Save again with a changed role set (same user, same permittable id kept
+	// by ON CONFLICT): exercises the delete-then-bulk-insert path with a
+	// different row count than the original insert.
+	p2 := permittable.New().NewID().UserID(uid).RoleIDs([]id.RoleID{rid}).
+		WorkspaceRoles([]permittable.WorkspaceRole{
+			permittable.NewWorkspaceRole(wid1, rid),
+		}).MustBuild()
+	require.NoError(t, r.Save(ctx, *p2))
+
+	reloaded, err := r.FindByUserID(ctx, uid)
+	require.NoError(t, err)
+	assert.Len(t, reloaded.WorkspaceRoles(), 1)
+	assert.Equal(t, wid1, reloaded.WorkspaceRoles()[0].ID())
+}
+
+// TestPermittable_SaveMany_WorkspaceRolesBulkInsert covers the same path via
+// SaveMany, batching several permittables in one transaction.
+func TestPermittable_SaveMany_WorkspaceRolesBulkInsert(t *testing.T) {
+	pool, cleanup := pgPool(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewPermittable(NewClient(pool))
+
+	rid := id.NewRoleID()
+	uid1, uid2 := id.NewUserID(), id.NewUserID()
+	wid1, wid2 := id.NewWorkspaceID(), id.NewWorkspaceID()
+
+	p1 := permittable.New().NewID().UserID(uid1).RoleIDs([]id.RoleID{rid}).
+		WorkspaceRoles([]permittable.WorkspaceRole{permittable.NewWorkspaceRole(wid1, rid)}).MustBuild()
+	p2 := permittable.New().NewID().UserID(uid2).RoleIDs([]id.RoleID{rid}).
+		WorkspaceRoles([]permittable.WorkspaceRole{
+			permittable.NewWorkspaceRole(wid1, rid),
+			permittable.NewWorkspaceRole(wid2, rid),
+		}).MustBuild()
+
+	require.NoError(t, r.SaveMany(ctx, permittable.List{p1, p2}))
+
+	got1, err := r.FindByUserID(ctx, uid1)
+	require.NoError(t, err)
+	assert.Len(t, got1.WorkspaceRoles(), 1)
+
+	got2, err := r.FindByUserID(ctx, uid2)
+	require.NoError(t, err)
+	assert.Len(t, got2.WorkspaceRoles(), 2)
+}

--- a/server/internal/infrastructure/postgres/pgdoc/permittable.go
+++ b/server/internal/infrastructure/postgres/pgdoc/permittable.go
@@ -7,10 +7,13 @@ import (
 	"github.com/reearth/reearth-accounts/server/pkg/permittable"
 )
 
+// json tags match the column names in the PermittableWorkspaceRolesInsertBulk
+// sqlc query's jsonb_to_recordset(...) AS t(...) clause, which are matched
+// case-sensitively against these keys.
 type PermittableWorkspaceRoleRow struct {
-	PermittableID string
-	WorkspaceID   string
-	RoleID        string
+	PermittableID string `json:"permittable_id"`
+	WorkspaceID   string `json:"workspace_id"`
+	RoleID        string `json:"role_id"`
 }
 
 type PermittableRow struct {

--- a/server/internal/infrastructure/postgres/sqlc/gen/permittable.sql.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/permittable.sql.go
@@ -157,3 +157,19 @@ func (q *Queries) PermittableWorkspaceRolesDeleteByPermittable(ctx context.Conte
 	_, err := q.db.Exec(ctx, permittableWorkspaceRolesDeleteByPermittable, permittableID)
 	return err
 }
+
+const permittableWorkspaceRolesInsertBulk = `-- name: PermittableWorkspaceRolesInsertBulk :exec
+INSERT INTO permittable_workspace_roles (permittable_id, workspace_id, role_id)
+SELECT permittable_id, workspace_id, role_id
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(permittable_id text, workspace_id text, role_id text)
+`
+
+// One round-trip for any number of workspace roles, instead of one
+// PermittableWorkspaceRoleInsert per role. See
+// WorkspaceMembersInsertBulk (workspace.sql) for why jsonb_to_recordset is
+// used over a multi-arg unnest.
+func (q *Queries) PermittableWorkspaceRolesInsertBulk(ctx context.Context, dollar_1 []byte) error {
+	_, err := q.db.Exec(ctx, permittableWorkspaceRolesInsertBulk, dollar_1)
+	return err
+}

--- a/server/internal/infrastructure/postgres/sqlc/gen/querier.go
+++ b/server/internal/infrastructure/postgres/sqlc/gen/querier.go
@@ -23,6 +23,11 @@ type Querier interface {
 	PermittableWorkspaceRoleInsert(ctx context.Context, arg PermittableWorkspaceRoleInsertParams) error
 	PermittableWorkspaceRolesByPermittableIDs(ctx context.Context, dollar_1 []string) ([]PermittableWorkspaceRole, error)
 	PermittableWorkspaceRolesDeleteByPermittable(ctx context.Context, permittableID string) error
+	// One round-trip for any number of workspace roles, instead of one
+	// PermittableWorkspaceRoleInsert per role. See
+	// WorkspaceMembersInsertBulk (workspace.sql) for why jsonb_to_recordset is
+	// used over a multi-arg unnest.
+	PermittableWorkspaceRolesInsertBulk(ctx context.Context, dollar_1 []byte) error
 	RoleDelete(ctx context.Context, id string) error
 	RoleFindAll(ctx context.Context) ([]Role, error)
 	RoleFindByID(ctx context.Context, id string) (Role, error)

--- a/server/internal/infrastructure/postgres/sqlc/queries/permittable.sql
+++ b/server/internal/infrastructure/postgres/sqlc/queries/permittable.sql
@@ -19,5 +19,15 @@ DELETE FROM permittable_workspace_roles WHERE permittable_id = $1;
 -- name: PermittableWorkspaceRoleInsert :exec
 INSERT INTO permittable_workspace_roles (permittable_id, workspace_id, role_id) VALUES ($1,$2,$3);
 
+-- name: PermittableWorkspaceRolesInsertBulk :exec
+-- One round-trip for any number of workspace roles, instead of one
+-- PermittableWorkspaceRoleInsert per role. See
+-- WorkspaceMembersInsertBulk (workspace.sql) for why jsonb_to_recordset is
+-- used over a multi-arg unnest.
+INSERT INTO permittable_workspace_roles (permittable_id, workspace_id, role_id)
+SELECT permittable_id, workspace_id, role_id
+  FROM jsonb_to_recordset($1::jsonb)
+  AS t(permittable_id text, workspace_id text, role_id text);
+
 -- name: PermittableWorkspaceRolesByPermittableIDs :many
 SELECT * FROM permittable_workspace_roles WHERE permittable_id = ANY($1::text[]);


### PR DESCRIPTION
## Overview

Addresses SCA-04 from the ai-scan scalability report (eukarya-inc/compliance#100). Builds on the same technique as #320 (SCA-03).

## What I've done

`Permittable.Save` deletes all of a permittable's `permittable_workspace_roles` rows and re-inserts them with one `PermittableWorkspaceRoleInsert` statement per role. `SaveMany` calls `Save` once per permittable inside the same transaction (`WithinTransaction` correctly reuses the outer tx rather than nesting). The interactor deliberately batches these calls -- `bulkUpdatePermittable`/`bulkRemovePermittable` fetch in one round-trip and call `SaveMany` once -- but the Postgres repository unrolled that batch back into per-role statements: adding 100 members who each belong to 20 workspaces became 100 × (2 + 20) ≈ 2,200 sequential statements in one transaction, turning a bounded bulk operation into a multi-second lock-holding transaction as membership counts grow. The Mongo implementation instead does a single bulk `SaveAll`.

Added `PermittableWorkspaceRolesInsertBulk`, using the same `jsonb_to_recordset` technique as `WorkspaceMembersInsertBulk` from #320 (sqlc's static catalog can't resolve a multi-arg `unnest`), and use it in `Save` in place of the per-role loop. This cuts the same example case to 100 × (2 + 1) = 300 statements.

One detail carried over from the existing code: `PermittableUpsert`'s `ON CONFLICT (user_id)` can keep a pre-existing row's id rather than the new `p.ID()`, so `Save` already used the upsert's *returned* id (`pid`) for every role insert rather than trusting `NewPermittableRow`'s pre-computed `PermittableID`. The bulk path preserves this by overwriting `PermittableID` on every row right before marshaling.

`PermittableWorkspaceRoleRow` gained explicit `json` tags matching the `jsonb_to_recordset` column list, for the same case-sensitive-key-match reason as `WorkspaceMemberRow`/`WorkspaceIntegrationRow` in #320 (untagged struct fields serialize as PascalCase, which wouldn't match the lowercase/snake_case column names and would silently insert NULLs).

## What I haven't done

Did not unify all N permittables in a `SaveMany` batch into a single upsert + single delete + single bulk-role-insert (i.e., full parity with Mongo's one-call `SaveAll`) -- that's a larger change to `PermittableUpsert` (bulk upsert with per-row id resolution) that felt like scope creep beyond what the report specifically flagged (the per-role loop). Happy to take it further if you'd rather have full parity in one pass.

## How I tested

- `go build ./...`, `go build -tags integration ./...`, `go vet ./...`
- `go test ./internal/infrastructure/postgres/...` (unit-level, no DB) passes.
- Added `TestPermittable_Save_WorkspaceRolesBulkInsert` and `TestPermittable_SaveMany_WorkspaceRolesBulkInsert` (build-tag `integration`, run against real Postgres via testcontainers in CI's `ci-server-integration` job): save/reload round-trips with 3 and 1 workspace roles (exercising the delete-then-bulk-insert path with a shrinking row count), and a `SaveMany` batch across two permittables with different role counts.
- As with #320, I don't have a working local Docker/testcontainers setup in this environment, so I'm relying on CI's `ci-server-integration` job to validate the actual SQL against a live database -- flagging this explicitly per the same caveat as that PR.

## Which point I want you to review particularly

Same as #320: please confirm the new integration tests pass in CI before merging. Also open to feedback on the "haven't done" scope call above -- whether the report expects the fuller Mongo-parity fix or this narrower one is sufficient.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values