### PR TITLE
fix(server): require current password before regenerating MFA recovery code

### DIFF
--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -117,7 +117,7 @@ type ComplexityRoot struct {
 		FindOrCreate                     func(childComplexity int, input gqlmodel.FindOrCreateInput) int
 		Logout                           func(childComplexity int) int
 		PasswordReset                    func(childComplexity int, input gqlmodel.PasswordResetInput) int
-		RegenerateMFARecoveryCode        func(childComplexity int) int
+		RegenerateMFARecoveryCode        func(childComplexity int, currentPassword *string) int
 		RemoveIntegrationFromWorkspace   func(childComplexity int, input gqlmodel.RemoveIntegrationFromWorkspaceInput) int
 		RemoveIntegrationsFromWorkspace  func(childComplexity int, input gqlmodel.RemoveIntegrationsFromWorkspaceInput) int
 		RemoveMultipleUsersFromWorkspace func(childComplexity int, input gqlmodel.RemoveMultipleUsersFromWorkspaceInput) int
@@ -264,7 +264,7 @@ type MutationResolver interface {
 	FindOrCreate(ctx context.Context, input gqlmodel.FindOrCreateInput) (*gqlmodel.UserPayload, error)
 	Logout(ctx context.Context) (*gqlmodel.Me, error)
 	PasswordReset(ctx context.Context, input gqlmodel.PasswordResetInput) (*bool, error)
-	RegenerateMFARecoveryCode(ctx context.Context) (*gqlmodel.MFARecoveryCodeResult, error)
+	RegenerateMFARecoveryCode(ctx context.Context, currentPassword *string) (*gqlmodel.MFARecoveryCodeResult, error)
 	RemoveMyAuth(ctx context.Context, input gqlmodel.RemoveMyAuthInput) (*gqlmodel.UpdateMePayload, error)
 	Signup(ctx context.Context, input gqlmodel.SignupInput) (*gqlmodel.UserPayload, error)
 	SignupOidc(ctx context.Context, input gqlmodel.SignupOIDCInput) (*gqlmodel.UserPayload, error)
@@ -605,7 +605,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		return e.complexity.Mutation.RegenerateMFARecoveryCode(childComplexity), true
+		args, err := ec.field_Mutation_regenerateMFARecoveryCode_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RegenerateMFARecoveryCode(childComplexity, args["currentPassword"].(*string)), true
 	case "Mutation.removeIntegrationFromWorkspace":
 		if e.complexity.Mutation.RemoveIntegrationFromWorkspace == nil {
 			break
@@ -1630,7 +1635,10 @@ extend type Mutation {
   findOrCreate(input: FindOrCreateInput!): UserPayload
   logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
-  regenerateMFARecoveryCode: MFARecoveryCodeResult!
+  # currentPassword is required and verified when the account has a "reearth"
+  # (password) auth record; omitted/ignored for SSO-only accounts, which have
+  # no local password to check.
+  regenerateMFARecoveryCode(currentPassword: String): MFARecoveryCodeResult!
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload
@@ -1916,6 +1924,17 @@ func (ec *executionContext) field_Mutation_passwordReset_args(ctx context.Contex
 		return nil, err
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_regenerateMFARecoveryCode_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "currentPassword", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["currentPassword"] = arg0
 	return args, nil
 }
 
@@ -3437,7 +3456,8 @@ func (ec *executionContext) _Mutation_regenerateMFARecoveryCode(ctx context.Cont
 		field,
 		ec.fieldContext_Mutation_regenerateMFARecoveryCode,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Mutation().RegenerateMFARecoveryCode(ctx)
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().RegenerateMFARecoveryCode(ctx, fc.Args["currentPassword"].(*string))
 		},
 		nil,
 		ec.marshalNMFARecoveryCodeResult2ᚖgithubᚗcomᚋreearthᚋreearthᚑaccountsᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐMFARecoveryCodeResult,
@@ -3446,7 +3466,7 @@ func (ec *executionContext) _Mutation_regenerateMFARecoveryCode(ctx context.Cont
 	)
 }
 
-func (ec *executionContext) fieldContext_Mutation_regenerateMFARecoveryCode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_regenerateMFARecoveryCode(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -3459,6 +3479,17 @@ func (ec *executionContext) fieldContext_Mutation_regenerateMFARecoveryCode(_ co
 			}
 			return nil, fmt.Errorf("no field named %q was found under type MFARecoveryCodeResult", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_regenerateMFARecoveryCode_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }

--- a/server/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/internal/adapter/gql/resolver_mutation_user.go
@@ -185,8 +185,8 @@ func (r *mutationResolver) EnableMfa(ctx context.Context) (*gqlmodel.MFAEnrollRe
 	return &gqlmodel.MFAEnrollResult{EnrollmentURL: enrollmentURL}, nil
 }
 
-func (r *mutationResolver) RegenerateMFARecoveryCode(ctx context.Context) (*gqlmodel.MFARecoveryCodeResult, error) {
-	recoveryCode, err := usecases(ctx).User.RegenerateMFARecoveryCode(ctx, getOperator(ctx))
+func (r *mutationResolver) RegenerateMFARecoveryCode(ctx context.Context, currentPassword *string) (*gqlmodel.MFARecoveryCodeResult, error) {
+	recoveryCode, err := usecases(ctx).User.RegenerateMFARecoveryCode(ctx, getOperator(ctx), lo.FromPtr(currentPassword))
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -400,7 +400,7 @@ func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (
 	})
 }
 
-func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspace.Operator) (string, error) {
+func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspace.Operator, currentPassword string) (string, error) {
 	if operator == nil || operator.User == nil {
 		return "", interfaces.ErrInvalidOperator
 	}
@@ -409,6 +409,17 @@ func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspac
 		if err != nil {
 			return "", err
 		}
+
+		// This mints a credential that can bypass MFA on future logins, so
+		// require and verify the current password first for accounts that have
+		// one; SSO-only accounts have no local password to check.
+		if u.HasAuthProvider("reearth") {
+			matched, mErr := u.MatchPassword(currentPassword)
+			if mErr != nil || !matched {
+				return "", interfaces.ErrInvalidCurrentPassword
+			}
+		}
+
 		a := u.Auths().GetByProvider(user.ProviderAuth0)
 		if a == nil {
 			return "", rerror.NewE(i18n.T("no authenticator found"))

--- a/server/internal/usecase/interactor/user_test.go
+++ b/server/internal/usecase/interactor/user_test.go
@@ -1311,14 +1311,14 @@ func TestUser_RegenerateMFARecoveryCode(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		uc, operator := newUC()
-		code, err := uc.RegenerateMFARecoveryCode(ctx, operator)
+		code, err := uc.RegenerateMFARecoveryCode(ctx, operator, "")
 		assert.NoError(t, err)
 		assert.Equal(t, "new-recovery-code", code)
 	})
 
 	t.Run("nil operator", func(t *testing.T) {
 		uc, _ := newUC()
-		code, err := uc.RegenerateMFARecoveryCode(ctx, nil)
+		code, err := uc.RegenerateMFARecoveryCode(ctx, nil, "")
 		assert.ErrorIs(t, err, interfaces.ErrInvalidOperator)
 		assert.Empty(t, code)
 	})
@@ -1344,9 +1344,60 @@ func TestUser_RegenerateMFARecoveryCode(t *testing.T) {
 		g := &gateway.Container{Authenticators: map[gateway.Provider]gateway.Authenticator{}}
 		uc := NewUser(r, g, nil, "", "")
 
-		code, err := uc.RegenerateMFARecoveryCode(ctx, &workspace.Operator{User: &noAuthUID})
+		code, err := uc.RegenerateMFARecoveryCode(ctx, &workspace.Operator{User: &noAuthUID}, "")
 		assert.Error(t, err)
 		assert.Empty(t, code)
+	})
+
+	newPasswordUC := func() (interfaces.User, *workspace.Operator, id.UserID) {
+		pwUID := id.NewUserID()
+		pwWID := id.NewWorkspaceID()
+		pwUser := user.New().
+			ID(pwUID).
+			Workspace(pwWID).
+			Name("Password User").
+			Email("password-user@example.com").
+			PasswordPlainText("CurrentPass123!").
+			Auths([]user.Auth{
+				{Provider: user.ProviderReearth, Sub: "reearth|" + pwUID.String()},
+				{Provider: "auth0", Sub: "auth0|password-user"},
+			}).
+			MustBuild()
+		pwWs := workspace.New().
+			ID(pwWID).
+			Name("Password User").
+			Personal(true).
+			MustBuild()
+
+		r := memory.New()
+		assert.NoError(t, r.User.Save(ctx, pwUser))
+		assert.NoError(t, r.Workspace.Save(ctx, pwWs))
+
+		mockAuth := &mockAuthenticatorWithError{}
+		g := &gateway.Container{Authenticators: map[gateway.Provider]gateway.Authenticator{gateway.ProviderAuth0: mockAuth}}
+
+		return NewUser(r, g, nil, "", ""), &workspace.Operator{User: &pwUID}, pwUID
+	}
+
+	t.Run("password account requires current password", func(t *testing.T) {
+		uc, operator, _ := newPasswordUC()
+		code, err := uc.RegenerateMFARecoveryCode(ctx, operator, "")
+		assert.ErrorIs(t, err, interfaces.ErrInvalidCurrentPassword)
+		assert.Empty(t, code)
+	})
+
+	t.Run("password account rejects wrong current password", func(t *testing.T) {
+		uc, operator, _ := newPasswordUC()
+		code, err := uc.RegenerateMFARecoveryCode(ctx, operator, "WrongPass123!")
+		assert.ErrorIs(t, err, interfaces.ErrInvalidCurrentPassword)
+		assert.Empty(t, code)
+	})
+
+	t.Run("password account succeeds with correct current password", func(t *testing.T) {
+		uc, operator, _ := newPasswordUC()
+		code, err := uc.RegenerateMFARecoveryCode(ctx, operator, "CurrentPass123!")
+		assert.NoError(t, err)
+		assert.Equal(t, "new-recovery-code", code)
 	})
 }
 

--- a/server/internal/usecase/interfaces/user.go
+++ b/server/internal/usecase/interfaces/user.go
@@ -19,6 +19,7 @@ var (
 	ErrInvalidUserEmail                = rerror.NewE(i18n.T("invalid email"))
 	ErrNotVerifiedUser                 = rerror.NewE(i18n.T("not verified user"))
 	ErrInvalidEmailOrPassword          = rerror.NewE(i18n.T("invalid email or password"))
+	ErrInvalidCurrentPassword          = rerror.NewE(i18n.T("current password is required or incorrect"))
 	ErrUserAlreadyExists               = rerror.NewE(i18n.T("user already exists"))
 	ErrUserAliasAlreadyExists          = rerror.NewE(i18n.T("user alias already exists"))
 	ErrWorkspaceAliasAlreadyExists     = rerror.NewE(i18n.T("workspace alias already exists"))
@@ -163,5 +164,9 @@ type User interface {
 	DisableMFA(context.Context, *workspace.Operator) error
 	EnableMFA(context.Context, *workspace.Operator) (enrollmentURL string, err error)
 	GetMFAStatus(context.Context, *workspace.Operator) (gateway.MFAStatus, error)
-	RegenerateMFARecoveryCode(context.Context, *workspace.Operator) (recoveryCode string, err error)
+	// RegenerateMFARecoveryCode mints a fresh MFA recovery code, invalidating
+	// the previous one. currentPassword is required and verified when the
+	// account has a "reearth" (password) auth record, since this credential
+	// can bypass MFA on future logins; ignored for SSO-only accounts.
+	RegenerateMFARecoveryCode(ctx context.Context, operator *workspace.Operator, currentPassword string) (recoveryCode string, err error)
 }

--- a/server/internal/usecase/proxy/user.go
+++ b/server/internal/usecase/proxy/user.go
@@ -229,7 +229,7 @@ func (u *User) GetMFAStatus(_ context.Context, _ *workspace.Operator) (gateway.M
 	return gateway.MFAStatus{}, errors.New("GetMFAStatus is not supported in proxy mode")
 }
 
-func (u *User) RegenerateMFARecoveryCode(_ context.Context, _ *workspace.Operator) (string, error) {
+func (u *User) RegenerateMFARecoveryCode(_ context.Context, _ *workspace.Operator, _ string) (string, error) {
 	return "", errors.New("RegenerateMFARecoveryCode is not supported in proxy mode")
 }
 

--- a/server/schemas/user.graphql
+++ b/server/schemas/user.graphql
@@ -153,7 +153,10 @@ extend type Mutation {
   findOrCreate(input: FindOrCreateInput!): UserPayload
   logout: Me
   passwordReset(input: PasswordResetInput!): Boolean
-  regenerateMFARecoveryCode: MFARecoveryCodeResult!
+  # currentPassword is required and verified when the account has a "reearth"
+  # (password) auth record; omitted/ignored for SSO-only accounts, which have
+  # no local password to check.
+  regenerateMFARecoveryCode(currentPassword: String): MFARecoveryCodeResult!
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   signup(input: SignupInput!): UserPayload
   signupOIDC(input: SignupOIDCInput!): UserPayload


### PR DESCRIPTION
## Overview

Addresses SEC-04 from the ai-scan security report (eukarya-inc/compliance#100).

## What I've done

`regenerateMFARecoveryCode` only checked that `operator.User != nil`, then called Auth0's `recovery-code-regeneration` endpoint and returned the plaintext recovery code -- no password confirmation, no MFA challenge, no recent-auth check. That code satisfies the MFA challenge on future interactive logins and survives session revocation and password rotation, so an attacker holding only a hijacked session/access token (stolen cookie, XSS, leaked bearer token) could call this mutation and walk away with a persistent second-factor bypass, silently invalidating the victim's real recovery code in the process.

This is a step above the already-documented re-auth gap on `updateMe`/`disableMFA` (SEC-03, #294 -- see the comments at `user.go:246` and `user.go:335`): those merely *lower* protection (password change, MFA disable), whereas this *exfiltrates* a long-lived bypass credential, and the report is explicit that this endpoint isn't covered by that documented exception.

Changes:
- `regenerateMFARecoveryCode` now takes an optional `currentPassword: String` GraphQL argument.
- `RegenerateMFARecoveryCode` requires and verifies it (via `user.MatchPassword`) whenever the account has a `"reearth"` (password) auth record -- returning the new `interfaces.ErrInvalidCurrentPassword` if it's missing or wrong -- before doing anything with Auth0.
- SSO-only accounts (no `"reearth"` auth record) skip the check, same as before, since there's no local password to verify.

This closes the highest-value exploit path described in the report -- a bare stolen token, no other access -- for password-based accounts, which I'd expect to be the majority of MFA-enabled accounts here. It does **not** close the gap for SSO-only accounts; a real fix there would need a step-up mechanism through each external IdP (Auth0 enterprise connections, etc.), which felt like a separate, larger piece of work best scoped on its own rather than folded into this fix.

## What I haven't done

- Did not add step-up re-auth for SSO-only accounts (see above).
- Did not update `pkg/gqlclient/user` (this repo's own generated-style GraphQL client, presumably used by other services to call this API) to expose the new `currentPassword` argument -- it's optional server-side, so existing callers keep working for SSO accounts and get a clear `ErrInvalidCurrentPassword` for password accounts until updated. Flagging in case another service needs to pass this through.

## How I tested

- `go generate ./internal/adapter/gql` to regenerate gqlgen code from the schema change; `go build ./...`, `go build -tags integration ./...`, `go vet ./...`.
- Updated `TestUser_RegenerateMFARecoveryCode`'s existing call sites for the new parameter, and added three new subtests: password account with no `currentPassword` (rejected), with a wrong one (rejected), and with the correct one (succeeds) -- all against a `"reearth"`-provider test user built with `PasswordPlainText(...)`.
- `go test ./internal/usecase/... ./internal/adapter/gql/... ./pkg/gqlclient/...` all pass.

## Which point I want you to review particularly

Whether an optional (rather than required) GraphQL argument is the right shape here -- I went optional to stay backward-compatible for SSO-only callers, but it means a password-account caller that doesn't know about the new requirement gets a runtime error instead of a schema-level nudge. Also open to feedback on whether SSO-only accounts should be blocked from this mutation entirely until a step-up mechanism exists, rather than left with the pre-existing gap.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values