### PR TITLE
fix(server): restrict unauthenticated GraphQL bypass fields to safe subfields

### DIFF
--- a/server/internal/app/auth.go
+++ b/server/internal/app/auth.go
@@ -67,6 +67,75 @@ var bypassedFields = map[string]struct{}{
 	"startpasswordreset":           {},
 }
 
+// workspaceSafeFields and userSafeFields are the only fields an
+// unauthenticated (bypassed) caller may select on a Workspace/User returned
+// by findByID/findByAlias/findByIDs/findUsersByIDsWithPagination. These
+// bypasses exist so other Re:Earth services can resolve a workspace/user by
+// id/alias without a user token, but the resolvers behind them run without an
+// operator, so any field is otherwise reachable -- including workspace
+// members (with each member's email and, for password accounts, their live
+// email-verification code), the workspace billing email, and user email. All
+// of that is scalar-only on purpose: none of these fields have their own
+// selection set worth recursing into, so a request selecting anything with a
+// sub-selection here is also rejected.
+var (
+	workspaceSafeFields = map[string]struct{}{"id": {}, "name": {}, "alias": {}, "personal": {}, "__typename": {}}
+	userSafeFields      = map[string]struct{}{"id": {}, "name": {}, "alias": {}, "__typename": {}}
+)
+
+// bypassSubtreeAllowed reports whether every field selected under a bypassed
+// root field's selection set is safe for an unauthenticated caller. Root
+// fields not handled explicitly (signup, createVerification, authConfig, ...)
+// return payload types carrying no other-user PII, so their full selection
+// sets are inherently safe.
+func bypassSubtreeAllowed(rootField string, sel ast.SelectionSet) bool {
+	switch rootField {
+	case "findbyid", "findbyalias", "findbyids":
+		return allSelectionsIn(sel, workspaceSafeFields)
+	case "findusersbyidswithpagination":
+		for _, s := range sel {
+			f, ok := s.(*ast.Field)
+			if !ok {
+				return false
+			}
+			switch strings.ToLower(f.Name) {
+			case "totalcount", "__typename":
+				if len(f.SelectionSet) > 0 {
+					return false
+				}
+			case "users":
+				if !allSelectionsIn(f.SelectionSet, userSafeFields) {
+					return false
+				}
+			default:
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
+}
+
+// allSelectionsIn reports whether every selection in sel is a plain field
+// (no fragments) whose name is in allowed and which has no sub-selection of
+// its own.
+func allSelectionsIn(sel ast.SelectionSet, allowed map[string]struct{}) bool {
+	for _, s := range sel {
+		f, ok := s.(*ast.Field)
+		if !ok {
+			return false
+		}
+		if _, ok := allowed[strings.ToLower(f.Name)]; !ok {
+			return false
+		}
+		if len(f.SelectionSet) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func isBypassed(req *http.Request) bool {
 	if req.Method != http.MethodPost {
 		return false
@@ -142,7 +211,8 @@ func isBypassed(req *http.Request) bool {
 	}
 
 	// Require every top-level field in the selected operation to be in the
-	// bypass allowlist.
+	// bypass allowlist, and its own selection set to stay within the fields
+	// safe for an unauthenticated caller (see bypassSubtreeAllowed).
 	if len(targetOp.SelectionSet) == 0 {
 		return false
 	}
@@ -151,7 +221,11 @@ func isBypassed(req *http.Request) bool {
 		if !ok {
 			return false
 		}
-		if _, allowed := bypassedFields[strings.ToLower(field.Name)]; !allowed {
+		name := strings.ToLower(field.Name)
+		if _, allowed := bypassedFields[name]; !allowed {
+			return false
+		}
+		if !bypassSubtreeAllowed(name, field.SelectionSet) {
 			return false
 		}
 	}

--- a/server/internal/app/auth_signup_test.go
+++ b/server/internal/app/auth_signup_test.go
@@ -76,7 +76,7 @@ func TestIsBypassed(t *testing.T) {
 		})
 
 		t.Run("findUsersByIdsWithPagination query", func(t *testing.T) {
-			body := `{"query":"query { findUsersByIdsWithPagination(ids: [\"id1\"]) { nodes { id } } }"}`
+			body := `{"query":"query { findUsersByIdsWithPagination(ids: [\"id1\"]) { users { id name alias } totalCount } }"}`
 			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
 			assert.NoError(t, err)
 
@@ -91,6 +91,72 @@ func TestIsBypassed(t *testing.T) {
 
 			result := isBypassed(req)
 			assert.True(t, result)
+		})
+	})
+
+	t.Run("should reject sensitive sub-fields on bypassed lookups (SEC-01)", func(t *testing.T) {
+		t.Run("findByAlias selecting members is rejected", func(t *testing.T) {
+			body := `{"query":"{findByAlias(alias:\"acme\"){id name metadata{billingEmail} members{... on WorkspaceUserMember{userId role user{name email verification{code}}}}}}"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
+		})
+
+		t.Run("findByAlias selecting metadata is rejected", func(t *testing.T) {
+			body := `{"query":"query { findByAlias(alias: \"acme\") { id name metadata { billingEmail } } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
+		})
+
+		t.Run("findByAlias selecting only safe fields is allowed", func(t *testing.T) {
+			body := `{"query":"query { findByAlias(alias: \"acme\") { id name alias personal } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.True(t, isBypassed(req))
+		})
+
+		t.Run("findByID selecting members is rejected", func(t *testing.T) {
+			body := `{"query":"query { findByID(id: \"x\") { id members { userId } } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
+		})
+
+		t.Run("findByIDs selecting members is rejected", func(t *testing.T) {
+			body := `{"query":"query { findByIDs(ids: [\"x\"]) { id members { userId } } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
+		})
+
+		t.Run("findUsersByIDsWithPagination selecting email is rejected", func(t *testing.T) {
+			body := `{"query":"query { findUsersByIDsWithPagination(ids: [\"x\"], pagination: {}) { users { id name email verification { code } } totalCount } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
+		})
+
+		t.Run("findUsersByIDsWithPagination selecting only safe fields is allowed", func(t *testing.T) {
+			body := `{"query":"query { findUsersByIDsWithPagination(ids: [\"x\"], pagination: {}) { users { id name alias } totalCount } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.True(t, isBypassed(req))
+		})
+
+		t.Run("chaining findByAlias id harvest into findByIDs member selection is still rejected", func(t *testing.T) {
+			body := `{"query":"query { findByAlias(alias: \"acme\") { id } findByIDs(ids: [\"x\"]) { members { userId } } }"}`
+			req, err := http.NewRequest(http.MethodPost, "/api/graphql", io.NopCloser(bytes.NewBufferString(body)))
+			assert.NoError(t, err)
+
+			assert.False(t, isBypassed(req))
 		})
 	})
 


### PR DESCRIPTION
## Overview

Addresses SEC-01 from the ai-scan security report (eukarya-inc/compliance#100). Highest-severity item in that report (🟠 HIGH, and the only unauthenticated data-exposure finding).

## What I've done

`isBypassed` allowlisted `findByAlias`/`findByID`/`findByIDs`/`findUsersByIDsWithPagination` by top-level field name only. The resolvers behind them (`Workspace.FetchByID`/`FetchByAlias`, routed through `interactor.Workspace.Fetch`) run with no operator and no field-level restriction, and the interactor's own comment (`workspace.go:49-54`) explicitly delegates minimization to "a higher layer" that didn't exist. Since workspace aliases are human-chosen and enumerable, any anonymous POST to `/api/graphql` could do:

```graphql
{ findByAlias(alias: "acme") {
    id name
    metadata { billingEmail }
    members { ... on WorkspaceUserMember { userId role user { name email verification { code } } } }
} }
```

and harvest the full member roster, every member's email, the workspace billing email, and -- for password-signup accounts -- the *live* email-verification code, which `POST /api/users/verify` accepts unauthenticated. Chaining `findUsersByIDsWithPagination` with the harvested user IDs widens the dump further.

These fields are bypassed *at all* so other Re:Earth services can resolve a workspace/user by id/alias without a user token -- removing them from the bypass list outright would break that legitimate cross-service flow (confirmed by digging through the git history of why each was added: #175, #218/#220/#221). So instead of gating on the root field alone, `isBypassed` now also validates *what the request selects underneath it*:

- `findByID` / `findByAlias` / `findByIDs`: only `id`, `name`, `alias`, `personal` (plus `__typename`) may be selected on the returned `Workspace` -- all scalars, so anything carrying its own sub-selection (`members`, `metadata`) is rejected.
- `findUsersByIDsWithPagination`: only `totalCount` and a `users { }` selection restricted to `id`, `name`, `alias` on each `User` -- `email`, `verification`, `metadata`, `auths`, `workspace` are all rejected.
- Any selection that isn't a plain field (a fragment spread or inline fragment, e.g. `... on WorkspaceUserMember { ... }`) fails closed, since the existing per-selection type assertion (`sel.(*ast.Field)`) already requires a plain field.
- `signup`/`signupOIDC`/`signupSSO`/`createVerification`/`authConfig`/`startPasswordReset` are untouched -- their payload types carry no *other* user's PII (the caller's own just-created data, or static public config), so their full selection sets are already safe and don't need restriction.

A request that fails the new subtree check simply isn't bypassed -- it falls through to the normal auth middleware and gets a 401 unless it presents a valid token, exactly like any other protected field today.

## What I haven't done

- Did not change the underlying resolvers/interactor to add their own field-level minimization (the `workspace.go:49-54` comment's originally-intended "higher layer") -- this fix closes the gap at the transport/auth layer instead, which is where the existing bypass logic already lives and where the fix is smallest and most auditable. A defense-in-depth resolver-level fix could be a good follow-up but felt like separate scope.
- Did not touch `POST /api/users/verify`'s own auth posture (also unauthenticated by design, per the report) -- that's a distinct REST endpoint outside `isBypassed`'s scope; this PR only cuts off the GraphQL path that could harvest the verification code needed to use it.

## How I tested

- `go build ./...`, `go build -tags integration ./...`, `go vet ./...`
- Fixed one pre-existing test (`findUsersByIdsWithPagination query`) that asserted `true` using a `nodes { id }` selection -- `nodes` was never a real field on `UsersWithPagination` (the real field is `users`), so it only "passed" because there was no subtree validation before this change. Updated it to the real schema shape.
- Added a new subtest group reproducing the report's exact exploit query (verified it's now rejected), plus: `findByAlias`/`findByID`/`findByIDs` selecting `members` (rejected) vs. only safe fields (allowed), `findByAlias` selecting `metadata` (rejected), `findUsersByIDsWithPagination` selecting `email`/`verification` (rejected) vs. only safe fields (allowed), and a chained-query case combining a safe `findByAlias` with an unsafe `findByIDs { members }` in the same request (rejected).
- `go test ./internal/app/...` passes. Ran `go test ./...`: one unrelated pre-existing flake in `TestAdminUser_SaveGuardingLastSystemAdmin_ConcurrentDemote` (a Mongo-lock race fixed in #312, not yet merged, and this branch doesn't include that fix) -- confirmed unrelated by inspection, `auth.go`/`auth_signup_test.go` are the only files this branch touches.

## Which point I want you to review particularly

Whether the safe-field allowlists (`id`/`name`/`alias`/`personal` for Workspace, `id`/`name`/`alias` for User) match what the actual cross-service callers of these bypassed queries need -- if some service currently depends on a field I've now blocked (e.g. `workspace { alias }` combined with something else), it'll start getting a 401 and need to authenticate instead. I checked the one in-repo e2e caller (`e2e/gql_workspace_test.go`, `findByID(id) { id name }`) and it's unaffected, but I don't have visibility into other services' actual queries against this bypass path.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values