### PR TITLE
docs(server): note known reauth gap in RegenerateMFARecoveryCode (SEC-04)

### DIFF
--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -400,6 +400,18 @@ func (i *User) GetMFAStatus(ctx context.Context, operator *workspace.Operator) (
 	})
 }
 
+// SEC-04: regenerating the MFA recovery code here only requires a valid
+// operator/session, with no password confirmation, current-MFA challenge, or
+// recent-auth check. This is worse than the SEC-03 gap on UpdateMe/DisableMFA
+// above: those merely lower protection, whereas this mints and returns a
+// long-lived credential that bypasses MFA on future logins, so a hijacked
+// session/access token alone is enough to walk away with persistent
+// second-factor bypass. A password-based re-auth check was tried (#322) and
+// rejected: it can only gate accounts with a "reearth" (password) auth
+// record, and password-based auth is being phased out and is no longer
+// present on most accounts, so it wouldn't meaningfully close this gap going
+// forward. The real fix needs a step-up mechanism through the identity
+// provider (Auth0), which is planned separately and not covered here.
 func (i *User) RegenerateMFARecoveryCode(ctx context.Context, operator *workspace.Operator) (string, error) {
 	if operator == nil || operator.User == nil {
 		return "", interfaces.ErrInvalidOperator


### PR DESCRIPTION
## Overview

Documents SEC-04 from the ai-scan security report (eukarya-inc/compliance#100) as a known, accepted gap, matching how SEC-03's equivalent gap on `UpdateMe`/`DisableMFA` was already documented in `3bb068a` (#294).

## What I've done

`RegenerateMFARecoveryCode` still has no re-authentication check: any valid session can mint and receive a fresh MFA recovery code, which is a persistent second-factor bypass credential if a session/access token is ever hijacked. A password-based re-auth fix was attempted in #322 and closed instead of merged: it could only gate accounts with a `"reearth"` (password) auth record, and password-based auth is being phased out and is no longer present on most accounts, so it wouldn't meaningfully close the gap going forward.

Added a code comment on `RegenerateMFARecoveryCode`, in the same style and location pattern as the existing `SEC-03` comments on `UpdateMe`/`DisableMFA`, recording:
- why this is worse than the SEC-03 gap (mints a durable bypass credential vs. merely lowering protection)
- that a password check was tried and rejected, and why
- that the real fix needs a step-up mechanism through the identity provider (Auth0), tracked separately

This is a comment-only change -- no behavior change. The intent is for this to be citable the next time the ai-scan report (or a human reviewer) flags this finding, so it reads as "acknowledged, real, and tracked" rather than silently reopened each scan.

## What I haven't done

Did not implement any re-authentication mechanism here -- see above for why the previously attempted approach (#322) was rejected, and that the real fix is separate, larger work.

## How I tested

- `go build ./...`, `go vet ./...` -- comment-only change, no test impact.

## Which point I want you to review particularly

Whether this comment accurately reflects the team's current direction on phasing out password auth, since that's the stated reason the #322 approach doesn't work going forward.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no PII is included in displayed values