### PR TITLE
fix(server): apply user/workspace schema validators with correct collection names

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260727000001_apply_user_and_workspace_schemas.go
+++ b/server/internal/infrastructure/mongo/migration/260727000001_apply_user_and_workspace_schemas.go
@@ -1,7 +1,0 @@
-package migration
-
-import "context"
-
-func ApplyUserAndWorkspaceSchemas(ctx context.Context, c DBClient) error {
-	return ApplyCollectionSchemas(ctx, []string{"users", "workspaces"}, c)
-}

--- a/server/internal/infrastructure/mongo/migration/260819120000_apply_user_and_workspace_schemas.go
+++ b/server/internal/infrastructure/mongo/migration/260819120000_apply_user_and_workspace_schemas.go
@@ -1,0 +1,11 @@
+package migration
+
+import "context"
+
+// ApplyUserAndWorkspaceSchemas re-applies the JSON schema validators for the
+// user and workspace collections, which gained createdat/createdby/deletedat.
+// Collection names must match both the embedded schema file names in
+// internal/infrastructure/mongo/schema and the names the repositories use.
+func ApplyUserAndWorkspaceSchemas(ctx context.Context, c DBClient) error {
+	return ApplyCollectionSchemas(ctx, []string{"user", "workspace"}, c)
+}

--- a/server/internal/infrastructure/mongo/migration/apply_schema_names_test.go
+++ b/server/internal/infrastructure/mongo/migration/apply_schema_names_test.go
@@ -1,0 +1,65 @@
+package migration
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/internal/infrastructure/mongo/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every collection name passed to ApplyCollectionSchemas must resolve to an
+// embedded schema file (<name>.json). A name that does not resolve - such as the
+// plural "workspaces" instead of "workspace" - makes the migration fail at
+// runtime with "failed to read schema file", which leaves the collection
+// validator stale while newly deployed code writes fields the old validator
+// rejects. Nothing else in the build catches that, so check the call sites here.
+func TestApplyCollectionSchemasUsesEmbeddedSchemaNames(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+
+	names := 0
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				fn, ok := call.Fun.(*ast.Ident)
+				if !ok || fn.Name != "ApplyCollectionSchemas" || len(call.Args) < 2 {
+					return true
+				}
+				lit, ok := call.Args[1].(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				for _, elt := range lit.Elts {
+					bl, ok := elt.(*ast.BasicLit)
+					if !ok || bl.Kind != token.STRING {
+						continue
+					}
+					name, err := strconv.Unquote(bl.Value)
+					require.NoError(t, err)
+					names++
+					_, err = schema.SchemaFS.ReadFile(name + ".json")
+					assert.NoErrorf(t, err, "%s: collection %q has no embedded schema file %s.json",
+						filepath.Base(path), name, name)
+				}
+				return true
+			})
+		}
+	}
+
+	assert.NotZero(t, names, "no ApplyCollectionSchemas call sites found")
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -45,5 +45,5 @@ var migrations = migration.Migrations[DBClient]{
 	260701120002: AddAdminUserStatusCreatedAtIndex,
 	260708123739: BackfillAdminUserRole,
 	260803120000: AddWorkspaceMembersWildcardIndex,
-	260804000001: ApplyUserAndWorkspaceSchemas,
+	260819120000: ApplyUserAndWorkspaceSchemas,
 }


### PR DESCRIPTION
# Overview

Creating a workspace fails in dev and prod with a MongoDB document validation error. The migration meant to update the workspace validator can never succeed, because it passes collection names that do not exist.

## What I've done

`ApplyUserAndWorkspaceSchemas` passed the plural names `users` and `workspaces`. `ApplyCollectionSchemas` resolves each name to an embedded schema file, and only `user.json` and `workspace.json` exist, so it fails with "failed to read schema file for users". The repositories also use the singular names.

So the workspace collection still has the validator from `260126150000`, with `additionalProperties: false` and no `createdat` or `createdby`. Once the code writing those fields shipped, every insert was rejected. Only creation broke, since both fields are `omitempty` and existing workspaces leave them unset.

- Corrected the names to `user` and `workspace`.
- Re-keyed `260804000001` to `260819120000` and renamed the file to match, so it sorts above `260803120000`, which some environments have already applied.
- Added a test that walks the migration package syntax tree and asserts every collection name passed to `ApplyCollectionSchemas` resolves to an embedded schema file.

## What I haven't done

No change to the schema JSON or the document structs. `workspace.json` was already correct.

This does not fix a deployed environment by itself. The `reearth-accounts-migration` job has to run after deploy. Dev last ran it on 2026-08-03 and prod on 2026-04-09, so prod will replay a backlog including the admin user role backfill and a wildcard index build on the live workspace collection. Worth planning rather than triggering right away.

## How I tested

Against a local MongoDB in a scratch database: installed the old validator, confirmed an old shaped document inserts, confirmed a document with `createdat` and `createdby` is rejected with the same error seen in dev and prod, ran the fixed migration, then confirmed the same document inserts.

Also ran `make run-migration` against a local database. `260819120000` applied last and the validators were updated, and the collection now accepts workspace documents with the new fields.

Reverting the names makes the new test fail with "collection \"users\" has no embedded schema file users.json".

`go build ./...`, `go vet` and `go test -short ./internal/infrastructure/mongo/...` pass.

## Which point I want you to review particularly

How to handle the migration key. I picked a new key above `260803120000` so it runs everywhere, since the original was never applied anywhere. If there is a convention you would rather follow here, or a reason to keep the original key, happy to change it.

## Memo

Worth deciding whether the migration job should run automatically on deploy.
