### PR TITLE
fix(server): skip conflicting aliases in personal workspace alias sync

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias.go
+++ b/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias.go
@@ -2,73 +2,270 @@ package migration
 
 import (
 	"context"
-	"log"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/reearth/reearth-accounts/server/internal/infrastructure/mongo/mongodoc"
 	"github.com/reearth/reearthx/mongox"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+const (
+	// syncPersonalWorkspaceAliasKey is this migration's key in migrations.go.
+	// It is recorded on every skip record so the records stay attributable
+	// if the migration is re-timestamped again.
+	syncPersonalWorkspaceAliasKey int64 = 260422140204
+
+	// aliasSyncSkipMarker prefixes every skipped-workspace log line so the
+	// records can be pulled out of Cloud Logging with a single text filter:
+	//   gcloud logging read 'textPayload:"ALIAS_SYNC_SKIPPED"'
+	aliasSyncSkipMarker = "ALIAS_SYNC_SKIPPED"
+
+	// aliasSyncUpdateMarker does the same for workspaces that were updated.
+	aliasSyncUpdateMarker = "ALIAS_SYNC_UPDATED"
+
+	// aliasSyncSkipCollection persists the skip records. Logs expire with the
+	// Cloud Logging retention window, so the same records are stored here to
+	// stay queryable when the conflicts are resolved manually later. Keyed by
+	// workspace ID, so re-running the migration refreshes rather than
+	// duplicates each record.
+	aliasSyncSkipCollection = "migration_alias_sync_skipped"
+
+	// aliasSyncSkipReason is the only reason a workspace is skipped today.
+	// Kept as a field so the records stay filterable if more reasons appear.
+	aliasSyncSkipReason = "desired_alias_taken_by_another_workspace"
+
+	aliasSyncReadBatchSize  = 1000
+	aliasSyncWriteChunkSize = 500
+)
+
+// AliasSyncSkipRecord describes one personal workspace whose alias could not be
+// synced to its owner's alias.
+type AliasSyncSkipRecord struct {
+	ID                     string    `bson:"id" json:"id"`
+	MigrationKey           int64     `bson:"migrationkey" json:"migrationKey"`
+	WorkspaceID            string    `bson:"workspaceid" json:"workspaceId"`
+	WorkspaceAlias         string    `bson:"workspacealias" json:"workspaceAlias"`
+	UserID                 string    `bson:"userid" json:"userId"`
+	UserAlias              string    `bson:"useralias" json:"userAlias"`
+	ConflictingWorkspaceID string    `bson:"conflictingworkspaceid" json:"conflictingWorkspaceId"`
+	Reason                 string    `bson:"reason" json:"reason"`
+	RecordedAt             time.Time `bson:"recordedat" json:"recordedAt"`
+}
+
+type aliasSyncOwner struct {
+	userID string
+	alias  string
+}
+
+type aliasSyncCandidate struct {
+	workspaceID string
+	alias       string
+}
+
+// SyncPersonalWorkspaceAlias copies each user's alias onto their personal
+// workspace so the two stay in sync.
+//
+// The workspace collection carries a unique case-insensitive index on alias
+// (alias_case_insensitive_unique, added by AddCaseInsensitiveWorkspaceAliasIndex),
+// and user aliases live in a separate namespace from workspace aliases, so a
+// user's alias can already be held by an unrelated workspace. Writing it
+// anyway aborts the whole migration with E11000, so conflicting workspaces are
+// left untouched and reported instead: one JSON line per workspace on stdout,
+// plus a durable record in aliasSyncSkipCollection.
 func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 	userCol := c.Collection("user")
 	workspaceCol := c.Collection("workspace")
 
-	// Build a map of workspace ID to user alias
-	userAliasMap := make(map[string]string)
-
-	// First, get all users and map their workspace to alias
-	err := userCol.Find(ctx, bson.D{}, &mongox.BatchConsumer{
-		Size: 1000,
+	// personal workspace ID -> its owner
+	owners := map[string]aliasSyncOwner{}
+	if err := userCol.Find(ctx, bson.D{}, &mongox.BatchConsumer{
+		Size: aliasSyncReadBatchSize,
 		Callback: func(rows []bson.Raw) error {
 			for _, row := range rows {
-				var userDoc mongodoc.UserDocument
-				if err := bson.Unmarshal(row, &userDoc); err != nil {
+				var doc mongodoc.UserDocument
+				if err := bson.Unmarshal(row, &doc); err != nil {
 					return err
 				}
-				// Map workspace ID to user alias
-				if userDoc.Workspace != "" && userDoc.Alias != "" {
-					userAliasMap[userDoc.Workspace] = userDoc.Alias
+				if doc.Workspace == "" || doc.Alias == "" {
+					continue
+				}
+				owners[doc.Workspace] = aliasSyncOwner{userID: doc.ID, alias: doc.Alias}
+			}
+			return nil
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to scan users: %w", err)
+	}
+
+	// lower(alias) -> workspace ID for *every* workspace, mirroring what
+	// alias_case_insensitive_unique enforces, so a desired alias can be checked
+	// before it is written. Soft-deleted workspaces are included on purpose:
+	// the index covers them too.
+	taken := map[string]string{}
+	candidates := make([]aliasSyncCandidate, 0)
+	if err := workspaceCol.Find(ctx, bson.D{}, &mongox.BatchConsumer{
+		Size: aliasSyncReadBatchSize,
+		Callback: func(rows []bson.Raw) error {
+			for _, row := range rows {
+				var doc mongodoc.WorkspaceDocument
+				if err := bson.Unmarshal(row, &doc); err != nil {
+					return err
+				}
+				if doc.Alias != "" {
+					taken[strings.ToLower(doc.Alias)] = doc.ID
+				}
+				if doc.Personal {
+					candidates = append(candidates, aliasSyncCandidate{workspaceID: doc.ID, alias: doc.Alias})
 				}
 			}
 			return nil
 		},
-	})
-	if err != nil {
+	}); err != nil {
+		return fmt.Errorf("failed to scan workspaces: %w", err)
+	}
+
+	// Decide everything up front, before any write, so the outcome does not
+	// depend on a cursor running concurrently with updates to the same
+	// collection. candidates is a slice, so the order — and therefore which
+	// workspace wins a contested alias — is deterministic.
+	updates := map[string]string{}
+	updateOrder := make([]string, 0)
+	skips := make([]AliasSyncSkipRecord, 0)
+	now := time.Now().UTC()
+
+	for _, cand := range candidates {
+		owner, ok := owners[cand.workspaceID]
+		if !ok {
+			continue
+		}
+		if cand.alias == owner.alias {
+			continue
+		}
+
+		desired := strings.ToLower(owner.alias)
+		// A holder equal to this workspace means the alias only differs by
+		// case, which the index treats as the same value: safe to normalize.
+		if holder, exists := taken[desired]; exists && holder != cand.workspaceID {
+			skips = append(skips, AliasSyncSkipRecord{
+				ID:                     cand.workspaceID,
+				MigrationKey:           syncPersonalWorkspaceAliasKey,
+				WorkspaceID:            cand.workspaceID,
+				WorkspaceAlias:         cand.alias,
+				UserID:                 owner.userID,
+				UserAlias:              owner.alias,
+				ConflictingWorkspaceID: holder,
+				Reason:                 aliasSyncSkipReason,
+				RecordedAt:             now,
+			})
+			continue
+		}
+
+		// Releasing the old alias is safe because decisions are applied in the
+		// order they are made, so a workspace claiming this alias later is
+		// always written after this one.
+		if cand.alias != "" {
+			delete(taken, strings.ToLower(cand.alias))
+		}
+		taken[desired] = cand.workspaceID
+		updates[cand.workspaceID] = owner.alias
+		updateOrder = append(updateOrder, cand.workspaceID)
+	}
+
+	if err := applyAliasSyncUpdates(ctx, workspaceCol, updateOrder, updates); err != nil {
 		return err
 	}
 
-	// Now update workspaces where personal=true and alias differs from user's alias
-	return workspaceCol.Find(ctx, bson.M{"personal": true}, &mongox.BatchConsumer{
-		Size: 1000,
-		Callback: func(rows []bson.Raw) error {
-			ids := make([]string, 0, len(rows))
-			newRows := make([]interface{}, 0, len(rows))
+	if err := recordAliasSyncSkips(ctx, c, skips); err != nil {
+		return err
+	}
 
-			for _, row := range rows {
-				var wsDoc mongodoc.WorkspaceDocument
-				if err := bson.Unmarshal(row, &wsDoc); err != nil {
-					return err
-				}
+	fmt.Printf(
+		"SyncPersonalWorkspaceAlias: %d personal workspace(s) updated, %d skipped (skip records: %s, log marker: %s)\n",
+		len(updateOrder), len(skips), aliasSyncSkipCollection, aliasSyncSkipMarker,
+	)
+	return nil
+}
 
-				// Check if we have a user alias for this workspace
-				if userAlias, ok := userAliasMap[wsDoc.ID]; ok {
-					// Only update if aliases differ
-					if wsDoc.Alias != userAlias {
-						log.Println("updating workspace alias: ", wsDoc.ID, "from", wsDoc.Alias, "to", userAlias)
-						wsDoc.Alias = userAlias
-						ids = append(ids, wsDoc.ID)
-						newRows = append(newRows, wsDoc)
+// applyAliasSyncUpdates writes the new aliases in chunks. Each chunk is read
+// fully into memory before it is written, so no cursor is open on the
+// workspace collection while it is being modified.
+func applyAliasSyncUpdates(ctx context.Context, col *mongox.Collection, order []string, updates map[string]string) error {
+	for start := 0; start < len(order); start += aliasSyncWriteChunkSize {
+		end := start + aliasSyncWriteChunkSize
+		if end > len(order) {
+			end = len(order)
+		}
+		chunk := order[start:end]
+
+		ids := make([]string, 0, len(chunk))
+		newRows := make([]interface{}, 0, len(chunk))
+		if err := col.Find(ctx, bson.M{"id": bson.M{"$in": chunk}}, &mongox.BatchConsumer{
+			Size: aliasSyncWriteChunkSize,
+			Callback: func(rows []bson.Raw) error {
+				for _, row := range rows {
+					var doc mongodoc.WorkspaceDocument
+					if err := bson.Unmarshal(row, &doc); err != nil {
+						return err
 					}
+					newAlias, ok := updates[doc.ID]
+					if !ok {
+						continue
+					}
+					b, err := json.Marshal(map[string]string{
+						"workspaceId": doc.ID,
+						"fromAlias":   doc.Alias,
+						"toAlias":     newAlias,
+					})
+					if err != nil {
+						return err
+					}
+					fmt.Printf("%s %s\n", aliasSyncUpdateMarker, b)
+
+					doc.Alias = newAlias
+					ids = append(ids, doc.ID)
+					newRows = append(newRows, doc)
 				}
-			}
+				return nil
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to load workspaces for alias sync: %w", err)
+		}
 
-			log.Println("count of ids: ", len(ids))
+		if len(ids) == 0 {
+			continue
+		}
+		if err := col.SaveAll(ctx, ids, newRows); err != nil {
+			return fmt.Errorf("failed to update personal workspace aliases: %w", err)
+		}
+	}
+	return nil
+}
 
-			// Only save if there are records to update
-			if len(ids) > 0 {
-				return workspaceCol.SaveAll(ctx, ids, newRows)
-			}
-			return nil
-		},
-	})
+// recordAliasSyncSkips prints every skipped workspace as a single JSON line and
+// upserts the same records into aliasSyncSkipCollection.
+func recordAliasSyncSkips(ctx context.Context, c DBClient, skips []AliasSyncSkipRecord) error {
+	if len(skips) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(skips))
+	rows := make([]interface{}, 0, len(skips))
+	for _, s := range skips {
+		b, err := json.Marshal(s)
+		if err != nil {
+			return fmt.Errorf("failed to marshal alias sync skip record for workspace %s: %w", s.WorkspaceID, err)
+		}
+		fmt.Printf("%s %s\n", aliasSyncSkipMarker, b)
+
+		ids = append(ids, s.ID)
+		rows = append(rows, s)
+	}
+
+	if err := c.Collection(aliasSyncSkipCollection).SaveAll(ctx, ids, rows); err != nil {
+		return fmt.Errorf("failed to persist alias sync skip records: %w", err)
+	}
+	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias_test.go
+++ b/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias_test.go
@@ -8,11 +8,50 @@ import (
 	"github.com/reearth/reearthx/mongox"
 	"github.com/reearth/reearthx/mongox/mongotest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	mongodriver "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func init() {
 	mongotest.Env = "REEARTH_DB"
+}
+
+// createWorkspaceAliasUniqueIndex mirrors the index that
+// AddCaseInsensitiveWorkspaceAliasIndex puts on the workspace collection in
+// production. Without it a regression in the conflict handling would write the
+// duplicate alias and the test would still pass.
+func createWorkspaceAliasUniqueIndex(t *testing.T, ctx context.Context, db *mongodriver.Database) {
+	t.Helper()
+
+	_, err := db.Collection("workspace").Indexes().CreateOne(ctx, mongodriver.IndexModel{
+		Keys: bson.D{{Key: "alias", Value: 1}},
+		Options: options.Index().SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2,
+		}).SetUnique(true).SetName("alias_case_insensitive_unique"),
+	})
+	require.NoError(t, err)
+}
+
+func fetchAliasSyncSkips(t *testing.T, ctx context.Context, db *mongodriver.Database) []AliasSyncSkipRecord {
+	t.Helper()
+
+	cursor, err := db.Collection(aliasSyncSkipCollection).Find(ctx, bson.M{})
+	require.NoError(t, err)
+
+	var records []AliasSyncSkipRecord
+	require.NoError(t, cursor.All(ctx, &records))
+	return records
+}
+
+func workspaceAlias(t *testing.T, ctx context.Context, db *mongodriver.Database, id string) string {
+	t.Helper()
+
+	var ws mongodoc.WorkspaceDocument
+	require.NoError(t, db.Collection("workspace").FindOne(ctx, bson.M{"id": id}).Decode(&ws))
+	return ws.Alias
 }
 
 func TestSyncPersonalWorkspaceAlias(t *testing.T) {
@@ -50,10 +89,8 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify workspace alias was updated to match user alias
-		var result mongodoc.WorkspaceDocument
-		err = workspaceCol.Client().FindOne(ctx, bson.M{"id": "workspace1"}).Decode(&result)
-		assert.NoError(t, err)
-		assert.Equal(t, "userone", result.Alias)
+		assert.Equal(t, "userone", workspaceAlias(t, ctx, db, "workspace1"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
 	})
 
 	t.Run("PersonalWorkspaceWithMatchingAlias", func(t *testing.T) {
@@ -90,10 +127,8 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify workspace alias remains unchanged
-		var result mongodoc.WorkspaceDocument
-		err = workspaceCol.Client().FindOne(ctx, bson.M{"id": "workspace2"}).Decode(&result)
-		assert.NoError(t, err)
-		assert.Equal(t, "usertwo", result.Alias)
+		assert.Equal(t, "usertwo", workspaceAlias(t, ctx, db, "workspace2"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
 	})
 
 	t.Run("NonPersonalWorkspace", func(t *testing.T) {
@@ -130,10 +165,8 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify workspace alias remains unchanged (not personal)
-		var result mongodoc.WorkspaceDocument
-		err = workspaceCol.Client().FindOne(ctx, bson.M{"id": "workspace3"}).Decode(&result)
-		assert.NoError(t, err)
-		assert.Equal(t, "teamworkspace", result.Alias)
+		assert.Equal(t, "teamworkspace", workspaceAlias(t, ctx, db, "workspace3"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
 	})
 
 	t.Run("PersonalWorkspaceWithoutUser", func(t *testing.T) {
@@ -159,10 +192,8 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify workspace alias remains unchanged (no matching user)
-		var result mongodoc.WorkspaceDocument
-		err = workspaceCol.Client().FindOne(ctx, bson.M{"id": "workspace4"}).Decode(&result)
-		assert.NoError(t, err)
-		assert.Equal(t, "orphanworkspace", result.Alias)
+		assert.Equal(t, "orphanworkspace", workspaceAlias(t, ctx, db, "workspace4"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
 	})
 
 	t.Run("EmptyDatabase", func(t *testing.T) {
@@ -174,5 +205,179 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		// Run migration on empty database - should not error
 		err := SyncPersonalWorkspaceAlias(ctx, client)
 		assert.NoError(t, err)
+	})
+
+	t.Run("SkipsWhenDesiredAliasIsHeldByAnotherWorkspace", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		// A team workspace already holds the alias the user wants, differing
+		// only by case - which alias_case_insensitive_unique treats as equal.
+		_, err := workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:       "teamws",
+			Name:     "Team Workspace",
+			Alias:    "SharedAlias",
+			Personal: false,
+		})
+		assert.NoError(t, err)
+
+		_, err = userCol.Client().InsertOne(ctx, mongodoc.UserDocument{
+			ID:        "user5",
+			Name:      "User Five",
+			Email:     "user5@example.com",
+			Alias:     "sharedalias",
+			Workspace: "personalws",
+		})
+		assert.NoError(t, err)
+
+		_, err = workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:       "personalws",
+			Name:     "Personal Workspace",
+			Alias:    "oldpersonalalias",
+			Personal: true,
+		})
+		assert.NoError(t, err)
+
+		// The migration must complete instead of aborting on E11000.
+		err = SyncPersonalWorkspaceAlias(ctx, client)
+		require.NoError(t, err)
+
+		// Neither workspace is touched.
+		assert.Equal(t, "oldpersonalalias", workspaceAlias(t, ctx, db, "personalws"))
+		assert.Equal(t, "SharedAlias", workspaceAlias(t, ctx, db, "teamws"))
+
+		// The skip is recorded so it can be followed up on later.
+		records := fetchAliasSyncSkips(t, ctx, db)
+		require.Len(t, records, 1)
+		assert.Equal(t, "personalws", records[0].ID)
+		assert.Equal(t, "personalws", records[0].WorkspaceID)
+		assert.Equal(t, "oldpersonalalias", records[0].WorkspaceAlias)
+		assert.Equal(t, "user5", records[0].UserID)
+		assert.Equal(t, "sharedalias", records[0].UserAlias)
+		assert.Equal(t, "teamws", records[0].ConflictingWorkspaceID)
+		assert.Equal(t, aliasSyncSkipReason, records[0].Reason)
+		assert.Equal(t, syncPersonalWorkspaceAliasKey, records[0].MigrationKey)
+		assert.False(t, records[0].RecordedAt.IsZero())
+	})
+
+	t.Run("SyncsNonConflictingWorkspacesEvenWhenOthersAreSkipped", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		_, err := workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:    "teamws",
+			Name:  "Team Workspace",
+			Alias: "takenalias",
+		})
+		assert.NoError(t, err)
+
+		users := []mongodoc.UserDocument{
+			{ID: "blocked", Name: "Blocked", Email: "b@example.com", Alias: "takenalias", Workspace: "blockedws"},
+			{ID: "ok", Name: "Ok", Email: "o@example.com", Alias: "freealias", Workspace: "okws"},
+		}
+		for _, u := range users {
+			_, err = userCol.Client().InsertOne(ctx, u)
+			assert.NoError(t, err)
+		}
+
+		workspaces := []mongodoc.WorkspaceDocument{
+			{ID: "blockedws", Name: "Blocked WS", Alias: "oldblocked", Personal: true},
+			{ID: "okws", Name: "Ok WS", Alias: "oldok", Personal: true},
+		}
+		for _, ws := range workspaces {
+			_, err = workspaceCol.Client().InsertOne(ctx, ws)
+			assert.NoError(t, err)
+		}
+
+		err = SyncPersonalWorkspaceAlias(ctx, client)
+		require.NoError(t, err)
+
+		assert.Equal(t, "oldblocked", workspaceAlias(t, ctx, db, "blockedws"))
+		assert.Equal(t, "freealias", workspaceAlias(t, ctx, db, "okws"))
+
+		records := fetchAliasSyncSkips(t, ctx, db)
+		require.Len(t, records, 1)
+		assert.Equal(t, "blockedws", records[0].WorkspaceID)
+	})
+
+	t.Run("NormalizesAliasDifferingOnlyByCase", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		_, err := userCol.Client().InsertOne(ctx, mongodoc.UserDocument{
+			ID:        "user6",
+			Name:      "User Six",
+			Email:     "user6@example.com",
+			Alias:     "myalias",
+			Workspace: "casews",
+		})
+		assert.NoError(t, err)
+
+		_, err = workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:       "casews",
+			Name:     "Case Workspace",
+			Alias:    "MyAlias",
+			Personal: true,
+		})
+		assert.NoError(t, err)
+
+		// The workspace holds the index entry itself, so this is not a conflict.
+		err = SyncPersonalWorkspaceAlias(ctx, client)
+		require.NoError(t, err)
+
+		assert.Equal(t, "myalias", workspaceAlias(t, ctx, db, "casews"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
+	})
+
+	t.Run("SkipRecordsDoNotDuplicateOnRerun", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		_, err := workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:    "teamws",
+			Name:  "Team Workspace",
+			Alias: "conflict",
+		})
+		assert.NoError(t, err)
+		_, err = userCol.Client().InsertOne(ctx, mongodoc.UserDocument{
+			ID:        "user7",
+			Name:      "User Seven",
+			Email:     "user7@example.com",
+			Alias:     "conflict",
+			Workspace: "personalws",
+		})
+		assert.NoError(t, err)
+		_, err = workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:       "personalws",
+			Name:     "Personal Workspace",
+			Alias:    "oldalias",
+			Personal: true,
+		})
+		assert.NoError(t, err)
+
+		require.NoError(t, SyncPersonalWorkspaceAlias(ctx, client))
+		require.NoError(t, SyncPersonalWorkspaceAlias(ctx, client))
+
+		assert.Len(t, fetchAliasSyncSkips(t, ctx, db), 1)
 	})
 }


### PR DESCRIPTION
# Overview

The nightly [`run-migration` job failed](https://github.com/reearth/reearth-accounts/actions/runs/32317118977/job/96271662940) with:

```
internal: bulk write exception: write errors: [E11000 duplicate key error
collection: reearth-account.workspace index: alias_case_insensitive_unique
collation: { locale: "en", ..., strength: 2, ... } dup key: { alias: CollationKey(...) }]
```

`SyncPersonalWorkspaceAlias` (key `260422140204`) copies each user's alias onto their personal workspace **unconditionally**. The workspace collection carries a unique case-insensitive index on `alias` (`alias_case_insensitive_unique`, added by `AddCaseInsensitiveWorkspaceAliasIndex` / key `260122110000`), and user aliases live in a **separate namespace** from workspace aliases — so a user's alias can already be held by an unrelated workspace (e.g. a team workspace named `Foo` vs. a user whose alias is `foo`). The bulk write then fails with E11000 and aborts the entire migration.

Why it surfaced only now:

| When | What |
| --- | --- |
| original key `251107102200` | migration ran once — **before** the case-insensitive unique index existed |
| 2026-01-22 (`260122110000`) | `alias_case_insensitive_unique` added to `workspace` |
| 2026-04-09 | last successful migration run; config reached `260330120000` |
| 2026-04-22 (#231) | migration re-timestamped `251107102200` → **`260422140204`**, re-queueing it |
| 2026-08-20 | it re-ran **with the index in place** → E11000 |

Since the migration is wrapped in `usecasex.DoTransaction` over a `NopTransaction` (`mongox.NewClient` in `internal/app/server.go`), nothing rolls back, and `SaveAll` is an *ordered* `BulkWrite` — so the batch was partially applied and the config key never advanced.

This is the first pending migration for that environment, so it blocks everything after it — including `ApplyUserAndWorkspaceSchemas`, which #325 has already fixed and re-keyed to `260819120000`.

## What I've done

**1. Conflict-aware alias sync.** `SyncPersonalWorkspaceAlias` is restructured into read → decide → write:

- scan `user` → `personal workspace ID -> {userID, alias}`
- scan `workspace` → `lower(alias) -> workspace ID` (the same key space the unique index enforces; soft-deleted workspaces included on purpose, since the index covers them too) plus the personal-workspace candidate list
- decide: if the desired alias is held by **another** workspace, skip it. If this workspace is the holder, the alias only differs by case, so it is safely normalized.
- write in chunks of 500

Conflicting workspaces are left completely untouched — no third-party workspace gets renamed.

**2. Skipped rows are traceable two ways.** Cloud Logging expires, so the records are also persisted.

One JSON line per skip on stdout, greppable with `textPayload:"ALIAS_SYNC_SKIPPED"`:

```
ALIAS_SYNC_SKIPPED {"id":"personalws","migrationKey":260422140204,"workspaceId":"personalws",
"workspaceAlias":"oldalias","userId":"user5","userAlias":"sharedalias",
"conflictingWorkspaceId":"teamws","reason":"desired_alias_taken_by_another_workspace",
"recordedAt":"2026-08-20T02:01:46.077008Z"}
```

Plus a durable record in the `migration_alias_sync_skipped` collection, keyed by workspace ID so a re-run refreshes rather than duplicates:

```js
db.migration_alias_sync_skipped.find().sort({ recordedAt: -1 })
```

Updates get an `ALIAS_SYNC_UPDATED` line too, and the run ends with a summary:

```
SyncPersonalWorkspaceAlias: 12 personal workspace(s) updated, 3 skipped (skip records: migration_alias_sync_skipped, log marker: ALIAS_SYNC_SKIPPED)
```

**3. Deciding before writing** also removes the pre-existing hazard of holding a cursor open on `workspace` while writing to it.

## What I haven't done

Two related pre-existing bugs found while investigating, left for a follow-up — happy to fold them in if preferred:

- **`FindByAlias` is case-sensitive.** `internal/infrastructure/mongo/user.go:133` queries `bson.M{"alias": alias}` with no collation, while the index is case-insensitive unique. reearth-dashboard's `ValidateAlias` queries with `strings.ToLower(input.Alias)`, so an existing `Foo` is not found, the alias is reported as available, and the subsequent write hits E11000.
- **`UpdateMe` does not check workspace alias uniqueness.** `internal/usecase/interactor/user.go:198-207` calls both `u.UpdateAlias()` and `ws.UpdateAlias()` but only validates against `repos.User.FindByAlias`, so it can hit the same E11000 at runtime. This means the desync this migration repairs can keep being created.

Also not done: resolving the conflicts themselves. Skipped personal workspaces keep their current alias and need a manual decision — which is why the records are persisted.

## How I tested

`go test ./internal/infrastructure/mongo/...` (needs MongoDB on `localhost:27017`; `internal/infrastructure/mongo/test_utils.go:19` hardcodes the URI):

```
ok  .../internal/infrastructure/mongo             0.998s
ok  .../internal/infrastructure/mongo/migration   2.209s
ok  .../internal/infrastructure/mongo/mongodoc    0.363s
```

`go vet ./...`, `golangci-lint`, and `gofmt` are clean.

**The new tests were verified to actually catch the bug.** They create the real `alias_case_insensitive_unique` index, so with the conflict guard temporarily disabled the suite reproduces the production error exactly:

```
E11000 duplicate key error collection: test_....workspace index: alias_case_insensitive_unique
collation: { locale: "en", ..., strength: 2, ... }
--- FAIL: TestSyncPersonalWorkspaceAlias/SkipsWhenDesiredAliasIsHeldByAnotherWorkspace
```

The pre-existing tests never created that index, which is why this shipped unnoticed.

New cases: skip on conflict (asserting both workspaces are untouched and the record contents) / non-conflicting workspaces still sync while others are skipped / case-only difference is normalized / skip records do not duplicate on re-run.

## Which point I want you to review particularly

- **Skip vs. resolve.** Skipping means a skipped personal workspace keeps an alias that disagrees with its owner's. The alternative considered was copying the *workspace* alias onto the *user* instead — which would actually restore the invariant without breaking URLs, since dashboard routes resolve on `workspace.alias` (`/$workspaceAlias/...`) and Cerbos resolves workspace roles via `workspaceRepo.FindByAlias`, so neither is affected by a user alias change. It was rejected for now as too invasive to do unattended. Worth revisiting as a follow-up.
- **Releasing the old alias** during the decision pass (`delete(taken, lower(cand.alias))`). This is safe because decisions are applied in the order they are made, so a workspace claiming a released alias is always written after the one releasing it. Please sanity-check that reasoning.
- **`migration_alias_sync_skipped` is deliberately not registered** in `tools/cmd/mongoschemagen/registry.go`. It is an operational record, not domain data, so it gets no validator. It can be dropped once the conflicts are resolved.

## Memo

- Backward compatibility: no schema or API change. The alias-sync migration becomes strictly less destructive — it now writes a subset of what it used to attempt.
- Migration compatibility: `260422140204` had partially applied before it aborted, and its config key never advanced. Re-running is safe — already-synced workspaces are no-ops.
- No PII is added to any output. The skip records and log lines contain only IDs and aliases, which are user-chosen public handles — no emails or names.
- Rebased onto `bd8e3b6` (#325). An earlier revision of this PR also carried a duplicate fix for the pluralized collection names in `ApplyUserAndWorkspaceSchemas`; #325 landed the same fix first, with a better AST-based test over every `ApplyCollectionSchemas` call site and a key re-roll to `260819120000`, so that part has been dropped here.
- To preview the blast radius before running, this lists every user whose alias is held by a different workspace:

```js
db.user.aggregate([
  { $match: { alias: { $nin: [null, ""] } } },
  { $lookup: {
      from: "workspace",
      let: { ua: { $toLower: "$alias" }, pws: "$workspace" },
      pipeline: [
        { $match: { $expr: { $and: [
          { $eq: [ { $toLower: "$alias" }, "$$ua" ] },
          { $ne: [ "$id", "$$pws" ] }
        ] } } },
        { $project: { _id: 0, id: 1, alias: 1, name: 1, personal: 1 } }
      ],
      as: "blockedBy"
  }},
  { $match: { "blockedBy.0": { $exists: true } } },
  { $project: { _id: 0, userId: "$id", userAlias: "$alias", personalWorkspaceId: "$workspace", blockedBy: 1 } }
])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
