### PR TITLE
fix(server): apply alias sync updates in decision order

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias.go
+++ b/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -92,6 +93,13 @@ func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 				if doc.Workspace == "" || doc.Alias == "" {
 					continue
 				}
+				// A personal workspace should have exactly one owner. If the
+				// data disagrees, keep the lowest user ID rather than whoever
+				// happened to be scanned last: Find has no sort, so scan order
+				// is not guaranteed.
+				if prev, exists := owners[doc.Workspace]; exists && prev.userID <= doc.ID {
+					continue
+				}
 				owners[doc.Workspace] = aliasSyncOwner{userID: doc.ID, alias: doc.Alias}
 			}
 			return nil
@@ -115,7 +123,14 @@ func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 					return err
 				}
 				if doc.Alias != "" {
-					taken[strings.ToLower(doc.Alias)] = doc.ID
+					key := strings.ToLower(doc.Alias)
+					// alias_case_insensitive_unique makes this key unique
+					// wherever the index exists. Where it does not yet,
+					// duplicates are possible, so keep the lowest workspace ID
+					// to keep the reported conflict stable across runs.
+					if prev, exists := taken[key]; !exists || doc.ID < prev {
+						taken[key] = doc.ID
+					}
 				}
 				if doc.Personal {
 					candidates = append(candidates, aliasSyncCandidate{workspaceID: doc.ID, alias: doc.Alias})
@@ -127,10 +142,18 @@ func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 		return fmt.Errorf("failed to scan workspaces: %w", err)
 	}
 
-	// Decide everything up front, before any write, so the outcome does not
-	// depend on a cursor running concurrently with updates to the same
-	// collection. candidates is a slice, so the order — and therefore which
-	// workspace wins a contested alias — is deterministic.
+	// Sort by workspace ID before deciding anything. The decision loop below
+	// mutates taken as it goes, releasing and claiming aliases, so the order it
+	// visits candidates in determines which workspace wins a contested alias.
+	// Find is issued without a sort and Mongo guarantees no particular order,
+	// so an explicit sort is what makes the outcome reproducible.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].workspaceID < candidates[j].workspaceID
+	})
+
+	// Decide everything up front, before any write, so the outcome also does
+	// not depend on a cursor running concurrently with updates to the same
+	// collection.
 	updates := map[string]string{}
 	updateOrder := make([]string, 0)
 	skips := make([]AliasSyncSkipRecord, 0)
@@ -163,9 +186,10 @@ func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 			continue
 		}
 
-		// Releasing the old alias is safe because decisions are applied in the
-		// order they are made, so a workspace claiming this alias later is
-		// always written after this one.
+		// Releasing the old alias lets a later candidate claim it. That is only
+		// safe because applyAliasSyncUpdates replays updateOrder in order, so
+		// the write that frees the alias is always queued ahead of the write
+		// that takes it.
 		if cand.alias != "" {
 			delete(taken, strings.ToLower(cand.alias))
 		}
@@ -189,9 +213,15 @@ func SyncPersonalWorkspaceAlias(ctx context.Context, c DBClient) error {
 	return nil
 }
 
-// applyAliasSyncUpdates writes the new aliases in chunks. Each chunk is read
-// fully into memory before it is written, so no cursor is open on the
-// workspace collection while it is being modified.
+// applyAliasSyncUpdates writes the new aliases in chunks, following the order
+// the updates were decided in. That order matters: one workspace may claim an
+// alias another one is releasing, and SaveAll issues an ordered BulkWrite, so
+// the releasing write has to be queued first or the claim hits E11000. The
+// documents are therefore re-keyed by ID and replayed in `order` rather than in
+// the order the cursor returns them.
+//
+// Each chunk is also read fully into memory before it is written, so no cursor
+// is open on the workspace collection while it is being modified.
 func applyAliasSyncUpdates(ctx context.Context, col *mongox.Collection, order []string, updates map[string]string) error {
 	for start := 0; start < len(order); start += aliasSyncWriteChunkSize {
 		end := start + aliasSyncWriteChunkSize
@@ -200,8 +230,7 @@ func applyAliasSyncUpdates(ctx context.Context, col *mongox.Collection, order []
 		}
 		chunk := order[start:end]
 
-		ids := make([]string, 0, len(chunk))
-		newRows := make([]interface{}, 0, len(chunk))
+		docs := make(map[string]mongodoc.WorkspaceDocument, len(chunk))
 		if err := col.Find(ctx, bson.M{"id": bson.M{"$in": chunk}}, &mongox.BatchConsumer{
 			Size: aliasSyncWriteChunkSize,
 			Callback: func(rows []bson.Raw) error {
@@ -210,28 +239,40 @@ func applyAliasSyncUpdates(ctx context.Context, col *mongox.Collection, order []
 					if err := bson.Unmarshal(row, &doc); err != nil {
 						return err
 					}
-					newAlias, ok := updates[doc.ID]
-					if !ok {
-						continue
-					}
-					b, err := json.Marshal(map[string]string{
-						"workspaceId": doc.ID,
-						"fromAlias":   doc.Alias,
-						"toAlias":     newAlias,
-					})
-					if err != nil {
-						return err
-					}
-					fmt.Printf("%s %s\n", aliasSyncUpdateMarker, b)
-
-					doc.Alias = newAlias
-					ids = append(ids, doc.ID)
-					newRows = append(newRows, doc)
+					docs[doc.ID] = doc
 				}
 				return nil
 			},
 		}); err != nil {
 			return fmt.Errorf("failed to load workspaces for alias sync: %w", err)
+		}
+
+		ids := make([]string, 0, len(chunk))
+		newRows := make([]interface{}, 0, len(chunk))
+		for _, id := range chunk {
+			doc, ok := docs[id]
+			if !ok {
+				// Deleted between the scan and now; nothing to update.
+				continue
+			}
+			newAlias, ok := updates[id]
+			if !ok {
+				continue
+			}
+
+			b, err := json.Marshal(map[string]string{
+				"workspaceId": id,
+				"fromAlias":   doc.Alias,
+				"toAlias":     newAlias,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to marshal alias sync update for workspace %s: %w", id, err)
+			}
+			fmt.Printf("%s %s\n", aliasSyncUpdateMarker, b)
+
+			doc.Alias = newAlias
+			ids = append(ids, id)
+			newRows = append(newRows, doc)
 		}
 
 		if len(ids) == 0 {

--- a/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias_test.go
+++ b/server/internal/infrastructure/mongo/migration/260422140204_sync_personal_workspace_alias_test.go
@@ -344,6 +344,78 @@ func TestSyncPersonalWorkspaceAlias(t *testing.T) {
 		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
 	})
 
+	t.Run("ClaimsAnAliasReleasedByALowerNumberedWorkspace", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		// ws-a gives up "aliasone", which is exactly what ws-b wants. ws-a
+		// sorts first, so it is decided first and ws-b can take the released
+		// alias. Both rows are inserted in the opposite order on purpose: if
+		// the decision pass followed scan order instead of workspace ID, ws-b
+		// would be decided while ws-a still held "aliasone" and get skipped.
+		users := []mongodoc.UserDocument{
+			{ID: "user-b", Name: "B", Email: "b@example.com", Alias: "aliasone", Workspace: "ws-b"},
+			{ID: "user-a", Name: "A", Email: "a@example.com", Alias: "freshalias", Workspace: "ws-a"},
+		}
+		for _, u := range users {
+			_, err := userCol.Client().InsertOne(ctx, u)
+			assert.NoError(t, err)
+		}
+
+		workspaces := []mongodoc.WorkspaceDocument{
+			{ID: "ws-b", Name: "B WS", Alias: "aliastwo", Personal: true},
+			{ID: "ws-a", Name: "A WS", Alias: "aliasone", Personal: true},
+		}
+		for _, ws := range workspaces {
+			_, err := workspaceCol.Client().InsertOne(ctx, ws)
+			assert.NoError(t, err)
+		}
+
+		require.NoError(t, SyncPersonalWorkspaceAlias(ctx, client))
+
+		assert.Equal(t, "freshalias", workspaceAlias(t, ctx, db, "ws-a"))
+		assert.Equal(t, "aliasone", workspaceAlias(t, ctx, db, "ws-b"))
+		assert.Empty(t, fetchAliasSyncSkips(t, ctx, db))
+	})
+
+	t.Run("PicksTheLowestUserIDWhenAWorkspaceHasSeveralOwners", func(t *testing.T) {
+		ctx := context.Background()
+		db := mongotest.Connect(t)(t)
+		createWorkspaceAliasUniqueIndex(t, ctx, db)
+
+		client := mongox.NewClientWithDatabase(db)
+		userCol := client.WithCollection("user")
+		workspaceCol := client.WithCollection("workspace")
+
+		// Two users claim the same personal workspace. The higher ID is
+		// inserted first, so last-writer-wins would pick it.
+		users := []mongodoc.UserDocument{
+			{ID: "user-2", Name: "Two", Email: "two@example.com", Alias: "secondalias", Workspace: "sharedws"},
+			{ID: "user-1", Name: "One", Email: "one@example.com", Alias: "firstalias", Workspace: "sharedws"},
+		}
+		for _, u := range users {
+			_, err := userCol.Client().InsertOne(ctx, u)
+			assert.NoError(t, err)
+		}
+
+		_, err := workspaceCol.Client().InsertOne(ctx, mongodoc.WorkspaceDocument{
+			ID:       "sharedws",
+			Name:     "Shared WS",
+			Alias:    "oldshared",
+			Personal: true,
+		})
+		assert.NoError(t, err)
+
+		require.NoError(t, SyncPersonalWorkspaceAlias(ctx, client))
+
+		assert.Equal(t, "firstalias", workspaceAlias(t, ctx, db, "sharedws"))
+	})
+
 	t.Run("SkipRecordsDoNotDuplicateOnRerun", func(t *testing.T) {
 		ctx := context.Background()
 		db := mongotest.Connect(t)(t)


### PR DESCRIPTION
# Overview

Follow-up to #326, which merged while a Copilot review round was still in flight. Copilot submitted its review at 02:29:15Z, five minutes after the merge at 02:24:28Z, so these findings never made it onto that PR.

Both findings are real, and the first one **defeats part of what #326 set out to fix** — it can still abort the migration with the very E11000 that #326 was written to avoid.

## What I've done

**1. Write in decision order (the important one).**

`applyAliasSyncUpdates` re-fetches each chunk with `Find({id: {$in: chunk}})` and built `ids`/`newRows` in **cursor order**. `$in` results are unordered, and `SaveAll` issues an *ordered* `BulkWrite`, so a workspace claiming an alias could be queued ahead of the workspace releasing it:

```
ws-a: "aliasone" -> "freshalias"   (releases "aliasone")
ws-b: "aliastwo" -> "aliasone"     (claims what ws-a released)
```

If the cursor returned `ws-b` first, its write landed while `ws-a` still held `aliasone` → `E11000 ... index: alias_case_insensitive_unique` → migration aborts. The decision pass was correct; only the replay order was wrong, and the code comment asserting "decisions are applied in the order they are made" was not actually backed by anything.

Documents are now re-keyed by ID into a map and replayed in `updateOrder`, so the releasing write is always queued ahead of the claiming write. The comment now names `applyAliasSyncUpdates` as the thing that guarantees it.

**2. Sort candidates before deciding.**

The old comment claimed determinism because `candidates` is a slice — but a slice only preserves *insertion* order, and insertion order came from a `Find` with no sort, which MongoDB does not guarantee. Since the decision loop mutates `taken` as it goes, which workspace won a contested alias could vary between runs and environments. `candidates` is now sorted by workspace ID first, and the comment explains that the explicit sort is what makes it reproducible.

**3. Deterministic tie-breaks for the two remaining scan-order dependencies.**

- `owners` was last-writer-wins, so if more than one user claimed the same personal workspace, the winner depended on user scan order → now the lowest user ID wins.
- `taken` was last-writer-wins for duplicate case-insensitive aliases. That cannot happen where `alias_case_insensitive_unique` exists, but it can in an environment that has not applied `260122110000` yet, where it would make the reported `conflictingWorkspaceId` unstable → now the lowest workspace ID wins.

## What I haven't done

The two pre-existing bugs listed in #326 are still open and unchanged:

- **`FindByAlias` is case-sensitive** (`internal/infrastructure/mongo/user.go:133`) — no collation, while the index is case-insensitive unique. reearth-dashboard's `ValidateAlias` queries with `strings.ToLower(...)`, so an existing `Foo` is not found, the alias is reported available, and the write then hits E11000.
- **`UpdateMe` does not check workspace alias uniqueness** (`internal/usecase/interactor/user.go:198-207`) — updates both `u.UpdateAlias()` and `ws.UpdateAlias()` but only validates against `repos.User.FindByAlias`.

## How I tested

Two new cases, both of which **fail without the fixes**:

- `ClaimsAnAliasReleasedByALowerNumberedWorkspace` — the release/claim pair above, with the rows inserted in the *opposite* order to their IDs so scan order and sorted order disagree. Before the write-order fix it failed with `failed to update personal workspace aliases: internal` (the E11000). With the sort removed it fails differently — `ws-b` gets skipped instead of updated:
  ```
  expected: "aliasone"
  actual  : "aliastwo"
  Should be empty, but was [{ws-b ... conflictingWorkspaceId:ws-a desired_alias_taken_by_another_workspace}]
  ```
- `PicksTheLowestUserIDWhenAWorkspaceHasSeveralOwners` — inserts the higher user ID first, so last-writer-wins would pick the wrong owner.

Full gate on top of `main`:

```
gofmt          clean
golangci-lint  clean (v1.64.8, same minor as CI)
go build ./... ok
go test ./internal/infrastructure/mongo/... -race
  ok  .../internal/infrastructure/mongo
  ok  .../internal/infrastructure/mongo/migration   3.227s
  ok  .../internal/infrastructure/mongo/mongodoc
```

`go test ./... -race` also fails `e2e.TestCheckPermission` locally, but it fails identically on unmodified `origin/main` (verified in a separate worktree) with `cerbos check permission failed ... rpc error: code = DeadlineExceeded` — the Cerbos testcontainer not serving in this environment. Unrelated to this change.

## Which point I want you to review particularly

- **The ordering argument.** The release path is only safe because `updateOrder` is replayed verbatim and `BulkWrite` is ordered. Worth confirming that chain holds across chunk boundaries too: the releaser is always decided before the claimer, so its index in `updateOrder` is lower, so it lands in the same or an earlier chunk — and earlier chunks are written first.
- **Whether releasing aliases is worth keeping at all.** Dropping the `delete(taken, ...)` would make the migration strictly more conservative (a few extra skips, all recorded) and remove the ordering constraint entirely. Kept because it lets legitimate rotations through, but happy to simplify if reviewers prefer the weaker guarantee.

## Memo

- Backward compatibility: no schema or API change. Behaviour only becomes more correct and more reproducible.
- Migration compatibility: `260422140204` is unchanged in key and semantics. Environments that already ran the #326 version are unaffected; re-running is still a no-op for already-synced workspaces.
- No PII in any output; the skip records still carry only IDs and aliases.
- Credit: both findings came from Copilot's review on #326 ([review 4978524063](https://github.com/reearth/reearth-accounts/pull/326#pullrequestreview-4978524063)), which arrived after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
