### PR TITLE
fix(server): case-insensitive FindByAlias and workspace alias uniqueness in UpdateMe

### DIFF
--- a/server/internal/infrastructure/mongo/user.go
+++ b/server/internal/infrastructure/mongo/user.go
@@ -130,7 +130,12 @@ func (r *User) FindByNameOrEmail(ctx context.Context, nameOrEmail string) (*user
 }
 
 func (r *User) FindByAlias(ctx context.Context, alias string) (*user.User, error) {
-	return r.findOne(ctx, bson.M{"alias": alias})
+	c := mongodoc.NewUserConsumer(r.host)
+	opt := options.FindOne().SetCollation(&options.Collation{Locale: "en", Strength: 2})
+	if err := r.client.FindOne(ctx, bson.M{"alias": alias}, c, opt); err != nil {
+		return nil, err
+	}
+	return c.Result[0], nil
 }
 
 func (r *User) SearchByKeyword(ctx context.Context, keyword string) (user.List, error) {

--- a/server/internal/infrastructure/mongo/user_test.go
+++ b/server/internal/infrastructure/mongo/user_test.go
@@ -268,6 +268,13 @@ func TestUserRepo_FindByAlias(t *testing.T) {
 		Email("foo@bar.com").
 		Workspace(wsid).
 		MustBuild()
+	userMixed := user.New().
+		NewID().
+		Name("bar").
+		Alias("MixedCase").
+		Email("bar@bar.com").
+		Workspace(wsid).
+		MustBuild()
 	tests := []struct {
 		Name               string
 		Input              string
@@ -285,6 +292,18 @@ func TestUserRepo_FindByAlias(t *testing.T) {
 			Input:    "xxx",
 			RepoData: user1,
 			WantErr:  true,
+		},
+		{
+			Name:     "must find user by alias case-insensitively",
+			Input:    "mixedcase",
+			RepoData: userMixed,
+			Expected: userMixed,
+		},
+		{
+			Name:     "must find user by alias with uppercase query",
+			Input:    "MIXEDCASE",
+			RepoData: userMixed,
+			Expected: userMixed,
 		},
 	}
 
@@ -650,4 +669,39 @@ func TestUserRepo_Remove(t *testing.T) {
 
 	err = repo.Remove(ctx, user1.ID())
 	assert.NoError(t, err)
+}
+
+func TestUserRepo_FindByAlias_CaseInsensitive(t *testing.T) {
+	db := Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	repo := NewUser(client)
+	ctx := context.Background()
+
+	wsid := user.NewWorkspaceID()
+	u := user.New().
+		NewID().
+		Name("casei").
+		Alias("MixedAlias").
+		Email("casei@bar.com").
+		Workspace(wsid).
+		MustBuild()
+	assert.NoError(t, repo.Save(ctx, u))
+
+	t.Run("lowercase query finds mixed-case stored alias", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "mixedalias")
+		assert.NoError(t, err)
+		assert.Equal(t, u.ID(), got.ID())
+	})
+
+	t.Run("uppercase query finds mixed-case stored alias", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "MIXEDALIAS")
+		assert.NoError(t, err)
+		assert.Equal(t, u.ID(), got.ID())
+	})
+
+	t.Run("exact match still works", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "MixedAlias")
+		assert.NoError(t, err)
+		assert.Equal(t, u.ID(), got.ID())
+	})
 }

--- a/server/internal/infrastructure/mongo/workspace.go
+++ b/server/internal/infrastructure/mongo/workspace.go
@@ -18,6 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type Workspace struct {
@@ -180,11 +181,12 @@ func (r *Workspace) FindByAlias(ctx context.Context, alias string) (*workspace.W
 		return nil, rerror.ErrNotFound
 	}
 
-	w, err := r.findOne(ctx, bson.M{"alias": alias})
-	if err != nil {
+	c := mongodoc.NewWorkspaceConsumer()
+	opt := options.FindOne().SetCollation(&options.Collation{Locale: "en", Strength: 2})
+	if err := r.client.FindOne(ctx, bson.M{"alias": alias}, c, opt); err != nil {
 		return nil, err
 	}
-	return w, nil
+	return c.Result[0], nil
 }
 
 func (r *Workspace) FindByAliases(ctx context.Context, aliases []string) (workspace.List, error) {

--- a/server/internal/infrastructure/mongo/workspace_test.go
+++ b/server/internal/infrastructure/mongo/workspace_test.go
@@ -174,6 +174,7 @@ func TestWorkspace_FindByAlias(t *testing.T) {
 	ws1 := workspace.New().NewID().Name("hoge").Alias("alias").MustBuild()
 	ws2 := workspace.New().NewID().Name("foo").Alias("alias2").MustBuild()
 	ws3 := workspace.New().NewID().Name("xxx").Alias("alias3").MustBuild()
+	wsMixed := workspace.New().NewID().Name("mixed").Alias("MixedCase").MustBuild()
 
 	tests := []struct {
 		Name          string
@@ -195,6 +196,20 @@ func TestWorkspace_FindByAlias(t *testing.T) {
 			Input:         "notfound",
 			Expected:      nil,
 			ExpectedError: rerror.ErrNotFoundRaw,
+		},
+		{
+			Name:          "must find workspace by alias case-insensitively (lowercase query)",
+			RepoData:      workspace.List{wsMixed},
+			Input:         "mixedcase",
+			Expected:      wsMixed,
+			ExpectedError: nil,
+		},
+		{
+			Name:          "must find workspace by alias case-insensitively (uppercase query)",
+			RepoData:      workspace.List{wsMixed},
+			Input:         "MIXEDCASE",
+			Expected:      wsMixed,
+			ExpectedError: nil,
 		},
 	}
 
@@ -470,4 +485,32 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestWorkspace_FindByAlias_CaseInsensitive(t *testing.T) {
+	db := Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	repo := NewWorkspace(client)
+	ctx := context.Background()
+
+	ws := workspace.New().NewID().Name("casei").Alias("MixedAlias").MustBuild()
+	assert.NoError(t, repo.SaveAll(ctx, workspace.List{ws}))
+
+	t.Run("lowercase query finds mixed-case stored alias", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "mixedalias")
+		assert.NoError(t, err)
+		assert.Equal(t, ws.ID(), got.ID())
+	})
+
+	t.Run("uppercase query finds mixed-case stored alias", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "MIXEDALIAS")
+		assert.NoError(t, err)
+		assert.Equal(t, ws.ID(), got.ID())
+	})
+
+	t.Run("exact match still works", func(t *testing.T) {
+		got, err := repo.FindByAlias(ctx, "MixedAlias")
+		assert.NoError(t, err)
+		assert.Equal(t, ws.ID(), got.ID())
+	})
 }

--- a/server/internal/usecase/interactor/user.go
+++ b/server/internal/usecase/interactor/user.go
@@ -203,6 +203,13 @@ func (i *User) UpdateMe(ctx context.Context, p interfaces.UpdateMeParam, operato
 			if existingUser != nil && existingUser.ID() != u.ID() {
 				return nil, interfaces.ErrUserAliasAlreadyExists
 			}
+			existingWs, err := i.repos.Workspace.FindByAlias(ctx, *p.Alias)
+			if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+				return nil, err
+			}
+			if existingWs != nil && existingWs.ID() != u.Workspace() {
+				return nil, interfaces.ErrWorkspaceAliasAlreadyExists
+			}
 			u.UpdateAlias(*p.Alias)
 			ws.UpdateAlias(*p.Alias)
 		}

--- a/server/internal/usecase/interactor/user_test.go
+++ b/server/internal/usecase/interactor/user_test.go
@@ -1209,6 +1209,88 @@ func TestUser_UpdateMe_FindByAliasError(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestUser_UpdateMe_WorkspaceAliasTaken(t *testing.T) {
+	user.DefaultPasswordEncoder = &user.NoopPasswordEncoder{}
+
+	ctx := context.Background()
+	r := memory.New()
+	uc := NewUser(r, nil, nil, "", "")
+
+	uid := id.NewUserID()
+	wid := id.NewWorkspaceID()
+	u := user.New().
+		ID(uid).
+		Workspace(wid).
+		Name("Alice").
+		Alias("alice").
+		Email("alice@example.com").
+		MustBuild()
+	personalWS := workspace.New().
+		ID(wid).
+		Name("Alice").
+		Alias("alice").
+		Personal(true).
+		MustBuild()
+
+	orgWID := id.NewWorkspaceID()
+	orgWS := workspace.New().
+		ID(orgWID).
+		Name("Org").
+		Alias("orgalias").
+		Personal(false).
+		MustBuild()
+
+	assert.NoError(t, r.User.Save(ctx, u))
+	assert.NoError(t, r.Workspace.Save(ctx, personalWS))
+	assert.NoError(t, r.Workspace.Save(ctx, orgWS))
+
+	operator := &workspace.Operator{User: &uid}
+	result, err := uc.UpdateMe(ctx, interfaces.UpdateMeParam{
+		Alias: strPtr("orgalias"),
+	}, operator)
+
+	assert.ErrorIs(t, err, interfaces.ErrWorkspaceAliasAlreadyExists)
+	assert.Nil(t, result)
+}
+
+func TestUser_UpdateMe_OwnPersonalWorkspaceAliasSameAsTarget(t *testing.T) {
+	user.DefaultPasswordEncoder = &user.NoopPasswordEncoder{}
+
+	ctx := context.Background()
+	r := memory.New()
+	uc := NewUser(r, nil, nil, "", "")
+
+	uid := id.NewUserID()
+	wid := id.NewWorkspaceID()
+	// User alias is empty, but personal workspace already has "wsalias".
+	// Updating the user alias to "wsalias" should succeed: the workspace that
+	// holds the alias is the user's own personal workspace.
+	u := user.New().
+		ID(uid).
+		Workspace(wid).
+		Name("Bob").
+		Email("bob@example.com").
+		MustBuild()
+	personalWS := workspace.New().
+		ID(wid).
+		Name("Bob").
+		Alias("wsalias").
+		Personal(true).
+		MustBuild()
+
+	assert.NoError(t, r.User.Save(ctx, u))
+	assert.NoError(t, r.Workspace.Save(ctx, personalWS))
+
+	operator := &workspace.Operator{User: &uid}
+	result, err := uc.UpdateMe(ctx, interfaces.UpdateMeParam{
+		Alias: strPtr("wsalias"),
+	}, operator)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "wsalias", result.Alias())
+}
+
 func TestUser_UpdateMe_SetPasswordError(t *testing.T) {
 	user.DefaultPasswordEncoder = &user.NoopPasswordEncoder{}
 


### PR DESCRIPTION
## Why

Follow-up to #327, which documented two pre-existing bugs as "What I haven't done":

**1. `FindByAlias` is case-sensitive** (`internal/infrastructure/mongo/user.go:133` and `workspace.go:183`)**

The `alias_case_insensitive_unique` index is created with `Collation{Locale:"en", Strength:2}`, but the `FindByAlias` queries had no collation — so a plain `{"alias": value}` filter does a byte-for-byte match. This means:
- A stored alias `Foo` is not found when querying `foo`
- `reearth-dashboard`'s `ValidateAlias` sends `strings.ToLower(alias)` to query availability, gets "not found", reports the alias as free, then the write hits E11000 on the index

Fix: pass `SetCollation(&options.Collation{Locale:"en", Strength:2})` directly on the `FindOne` call in both `FindByAlias` methods.

**2. `UpdateMe` does not check workspace alias uniqueness** (`internal/usecase/interactor/user.go:198-207`)**

`UpdateMe` validated the desired alias against `repos.User.FindByAlias` only. A non-personal workspace already holding that alias would pass the user check, then the `ws.UpdateAlias()` write would collide.

Fix: after the user check, also call `repos.Workspace.FindByAlias` and return `ErrWorkspaceAliasAlreadyExists` if a workspace other than the user's own personal workspace holds the alias.

## Checklist

- [x] Verified backward compatibility related to feature modifications (no API/schema change; behaviour becomes more correct)
- [x] Confirmed backward compatibility for migrations (no migration changes)
- [x] Verified that no PII is included in displayed values